### PR TITLE
Bugfix/Nodes Get Triggered Multiple Times

### DIFF
--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -95,6 +95,10 @@ export interface INodeQueue {
     depth: number
 }
 
+export interface IDepthQueue {
+    [key: string]: number
+}
+
 export interface IMessage {
     message: string
     type: MessageType


### PR DESCRIPTION
Bug: some nodes were triggered multiple times causing redundant calls
Expected: node should be triggered only once when traversing through the flow

Fix: use BFS to search for starting node ids, store the nodes with same depth levels and retrieve them when `buildLangchain` function is called (another BFS)
