### PR TITLE
fix typo in description of recursive character text splitter

### DIFF
--- a/packages/components/nodes/textsplitters/RecursiveCharacterTextSplitter/RecursiveCharacterTextSplitter.ts
+++ b/packages/components/nodes/textsplitters/RecursiveCharacterTextSplitter/RecursiveCharacterTextSplitter.ts
@@ -18,7 +18,7 @@ class RecursiveCharacterTextSplitter_TextSplitters implements INode {
         this.type = 'RecursiveCharacterTextSplitter'
         this.icon = 'textsplitter.svg'
         this.category = 'Text Splitters'
-        this.description = `Split documents recursively by different characters - starting with "\n\n", then "\n", then " "`
+        this.description = `Split documents recursively by different characters - starting with "\\n\\n", then "\\n", then " "`
         this.baseClasses = [this.type, ...getBaseClasses(RecursiveCharacterTextSplitter)]
         this.inputs = [
             {


### PR DESCRIPTION
Result 
![image](https://user-images.githubusercontent.com/33013947/236598626-c67bbfeb-eede-47b4-8fd1-2fd639d529cf.png)
