### PR TITLE
Bugfix/Add missing backslash for curl

### DIFF
--- a/packages/ui/src/ui-component/dialog/APICodeDialog.js
+++ b/packages/ui/src/ui-component/dialog/APICodeDialog.js
@@ -252,7 +252,7 @@ query({"question": "Hey, how are you?"}).then((response) => {
         } else if (codeLang === 'cURL') {
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
      -X POST \\
-     -d '{"question": "Hey, how are you?"}'
+     -d '{"question": "Hey, how are you?"}' \\
      -H "Authorization: Bearer ${selectedApiKey?.apiKey}"`
         } else if (codeLang === 'Embed') {
             return embedCode(dialogProps.chatflowid)


### PR DESCRIPTION
Fix - https://github.com/FlowiseAI/Flowise/issues/131

Before - missing a backslash after `how are you?"}'`
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/e10262da-089b-4a60-a926-c56dcfb2a1a0)

After:
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/d1452476-2bd3-4e02-84b2-265b1cb3256d)
