### PR TITLE
style: improve AddNodes click

### DIFF
--- a/packages/ui/src/views/canvas/AddNodes.js
+++ b/packages/ui/src/views/canvas/AddNodes.js
@@ -218,6 +218,7 @@ const AddNodes = ({ nodesData, node }) => {
                                                             expanded={categoryExpanded[category] || false}
                                                             onChange={handleAccordionChange(category)}
                                                             key={category}
+                                                            disableGutters
                                                         >
                                                             <AccordionSummary
                                                                 expandIcon={<ExpandMoreIcon />}


### PR DESCRIPTION
When I click on a node, there is a gap that causes click on an empty space
like this : 
---
![bugfix](https://github.com/FlowiseAI/Flowise/assets/53885024/c3d655ff-8eec-4660-8627-b8b9b964b8db)
---
modified :
![bugfixDone](https://github.com/FlowiseAI/Flowise/assets/53885024/4bcf9dbc-76e2-4de9-98c4-b2a4683dfdd6)

