### PR TITLE
includes user/pass from .env in docker-compose config

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         restart: always
         environment:
             - PORT=${PORT}
+            - USERNAME=${USERNAME}
+            - PASSWORD=${PASSWORD}
         ports:
             - '${PORT}:${PORT}'
         volumes:


### PR DESCRIPTION
custom user/pass config in .env didn't work for me until I added this to docker_compose.yml 

not sure if there are any downsides to this, but changing the values in .env wasn't working for me without it (oddly it still required auth, it just "stuck" on the default example of user / 1234 -- perhaps cached in the docker workflow somehow?)