### PR TITLE
Add basePath configuration option to support OpenAI mirror 

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -96,6 +96,13 @@ class ChatOpenAI_ChatModels implements INode {
                 type: 'number',
                 optional: true,
                 additionalParams: true
+            },
+            {
+                label: 'BasePath',
+                name: 'basepath',
+                type: 'string',
+                optional: true,
+                additionalParams: true
             }
         ]
     }
@@ -110,6 +117,7 @@ class ChatOpenAI_ChatModels implements INode {
         const presencePenalty = nodeData.inputs?.presencePenalty as string
         const timeout = nodeData.inputs?.timeout as string
         const streaming = nodeData.inputs?.streaming as boolean
+        const basePath = nodeData.inputs?.basepath as string
 
         const obj: Partial<OpenAIChatInput> & { openAIApiKey?: string } = {
             temperature: parseInt(temperature, 10),
@@ -124,7 +132,9 @@ class ChatOpenAI_ChatModels implements INode {
         if (presencePenalty) obj.presencePenalty = parseInt(presencePenalty, 10)
         if (timeout) obj.timeout = parseInt(timeout, 10)
 
-        const model = new ChatOpenAI(obj)
+        const model = new ChatOpenAI(obj, {
+            basePath
+        })
         return model
     }
 }

--- a/packages/components/nodes/embeddings/OpenAIEmbedding/OpenAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/OpenAIEmbedding/OpenAIEmbedding.ts
@@ -46,6 +46,13 @@ class OpenAIEmbedding_Embeddings implements INode {
                 type: 'number',
                 optional: true,
                 additionalParams: true
+            },
+            {
+                label: 'BasePath',
+                name: 'basepath',
+                type: 'string',
+                optional: true,
+                additionalParams: true
             }
         ]
     }
@@ -55,6 +62,7 @@ class OpenAIEmbedding_Embeddings implements INode {
         const stripNewLines = nodeData.inputs?.stripNewLines as boolean
         const batchSize = nodeData.inputs?.batchSize as string
         const timeout = nodeData.inputs?.timeout as string
+        const basePath = nodeData.inputs?.basepath as string
 
         const obj: Partial<OpenAIEmbeddingsParams> & { openAIApiKey?: string } = {
             openAIApiKey
@@ -64,7 +72,7 @@ class OpenAIEmbedding_Embeddings implements INode {
         if (batchSize) obj.batchSize = parseInt(batchSize, 10)
         if (timeout) obj.timeout = parseInt(timeout, 10)
 
-        const model = new OpenAIEmbeddings(obj)
+        const model = new OpenAIEmbeddings(obj, { basePath })
         return model
     }
 }

--- a/packages/components/nodes/llms/OpenAI/OpenAI.ts
+++ b/packages/components/nodes/llms/OpenAI/OpenAI.ts
@@ -106,6 +106,13 @@ class OpenAI_LLMs implements INode {
                 type: 'number',
                 optional: true,
                 additionalParams: true
+            },
+            {
+                label: 'BasePath',
+                name: 'basepath',
+                type: 'string',
+                optional: true,
+                additionalParams: true
             }
         ]
     }
@@ -122,6 +129,7 @@ class OpenAI_LLMs implements INode {
         const batchSize = nodeData.inputs?.batchSize as string
         const bestOf = nodeData.inputs?.bestOf as string
         const streaming = nodeData.inputs?.streaming as boolean
+        const basePath = nodeData.inputs?.basepath as string
 
         const obj: Partial<OpenAIInput> & { openAIApiKey?: string } = {
             temperature: parseInt(temperature, 10),
@@ -138,7 +146,9 @@ class OpenAI_LLMs implements INode {
         if (batchSize) obj.batchSize = parseInt(batchSize, 10)
         if (bestOf) obj.bestOf = parseInt(bestOf, 10)
 
-        const model = new OpenAI(obj)
+        const model = new OpenAI(obj, {
+            basePath
+        })
         return model
     }
 }


### PR DESCRIPTION
This pull request is aimed at adding a new configuration option, `basePath`, to the project. This is motivated by the need to support an OpenAI mirror site in China. (such as https://api2d.com/)

The `basePath` will allow users in China to conveniently redirect their requests to a local mirror, thus significantly improving access speed and reliability.

Please consider integrating this change to enhance the user experience for a large number of users in China. 