### PR TITLE
LatexTextSplitter Integration #226 

### DIFF
--- a/packages/components/nodes/textsplitters/LatexTextSplitter/LatexTextSplitter.ts
+++ b/packages/components/nodes/textsplitters/LatexTextSplitter/LatexTextSplitter.ts
@@ -1,0 +1,52 @@
+import { INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses } from '../../../src/utils'
+import { RecursiveCharacterTextSplitter, RecursiveCharacterTextSplitterParams } from 'langchain/text_splitter'
+
+class LatexTextSplitter_TextSplitters implements INode {
+    label: string
+    name: string
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    inputs: INodeParams[]
+    constructor() {
+        this.label = 'Latex Text Splitter'
+        this.name = 'latexTextSplitter'
+        this.type = 'LatexTextSplitter'
+        this.icon = 'latexTextSplitter.svg'
+        this.category = 'Text Splitters'
+        this.description = `Split documents along Latex headings, headlines, enumerations and more.`
+        this.baseClasses = [this.type, ...getBaseClasses(RecursiveCharacterTextSplitter)]
+        this.inputs = [
+            {
+                label: 'Chunk Size',
+                name: 'chunkSize',
+                type: 'number',
+                default: 1000,
+                optional: true
+            },
+            {
+                label: 'Chunk Overlap',
+                name: 'chunkOverlap',
+                type: 'number',
+                optional: true
+            }
+        ]
+    }
+    async init(nodeData: INodeData): Promise<any> {
+        const chunkSize = nodeData.inputs?.chunkSize as string
+        const chunkOverlap = nodeData.inputs?.chunkOverlap as string
+
+        const obj = {} as RecursiveCharacterTextSplitterParams
+
+        if (chunkSize) obj.chunkSize = parseInt(chunkSize, 10)
+        if (chunkOverlap) obj.chunkOverlap = parseInt(chunkOverlap, 10)
+
+        const splitter = RecursiveCharacterTextSplitter.fromLanguage('latex', obj)
+
+        return splitter
+    }
+}
+module.exports = { nodeClass: LatexTextSplitter_TextSplitters }

--- a/packages/components/nodes/textsplitters/LatexTextSplitter/latexTextSplitter.svg
+++ b/packages/components/nodes/textsplitters/LatexTextSplitter/latexTextSplitter.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-markdown" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M3 5m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z"></path>
+   <path d="M7 15v-6l2 2l2 -2v6"></path>
+   <path d="M14 13l2 2l2 -2m-2 2v-6"></path>
+</svg>


### PR DESCRIPTION
Added the LatexTextSplitter. 
For now I used the Markdown svg logo for it. 
<img width="171" alt="Screenshot 2023-06-15 at 7 25 18 AM" src="https://github.com/FlowiseAI/Flowise/assets/97941488/0c6f90eb-a730-47ad-8b4c-7fc310f5f90a">

(Created a new PR because the older PRs changes where getting a bit messy to resolve together)