### PR TITLE
fix: temperature should convert to float

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -132,7 +132,7 @@ class ChatOpenAI_ChatModels implements INode {
         const basePath = nodeData.inputs?.basepath as string
 
         const obj: Partial<OpenAIChatInput> & { openAIApiKey?: string } = {
-            temperature: parseInt(temperature, 10),
+            temperature: parseFloat(temperature),
             modelName,
             openAIApiKey,
             streaming: streaming ?? true


### PR DESCRIPTION
![image](https://github.com/FlowiseAI/Flowise/assets/22190579/e3bc7452-9829-4ee8-a146-150cd0956e17)

When init `ChatOpenAI`, `temperature` attribution should be float, otherwise we will always set temperature = 0

Before:
![image](https://github.com/FlowiseAI/Flowise/assets/22190579/cde28b36-4692-4982-b986-79030698bba8)

After fix:
![image](https://github.com/FlowiseAI/Flowise/assets/22190579/6f7d4095-a976-444a-b042-7d6f1f4f0914)
