### PR TITLE
feat: prevent submission during IME composition

### DIFF
--- a/packages/ui/src/views/chatmessage/ChatMessage.js
+++ b/packages/ui/src/views/chatmessage/ChatMessage.js
@@ -163,7 +163,9 @@ export const ChatMessage = ({ open, chatflowid, isDialog }) => {
 
     // Prevent blank submissions and allow for multiline input
     const handleEnter = (e) => {
-        if (e.key === 'Enter' && userInput) {
+        // Check if IME composition is in progress
+        const isIMEComposition = e.isComposing || e.keyCode === 229
+        if (e.key === 'Enter' && userInput && !isIMEComposition) {
             if (!e.shiftKey && userInput) {
                 handleSubmit(e)
             }


### PR DESCRIPTION
Fixed to prevent submission during converting using IME like Japanese
In Safari, `isComposing` is not as expected, so use `keyCode` to determine

https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event

If this fix is acceptable,I will also create a PR for FlowiseAI/FlowiseChatEmbed.