### PR TITLE
Bugfix/SQLITE_NOT_NULL

### DIFF
--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -9,6 +9,7 @@ export interface IChatFlow {
     id: string
     name: string
     flowData: string
+    deployed: boolean
     isPublic: boolean
     updatedDate: Date
     createdDate: Date

--- a/packages/server/src/entity/ChatFlow.ts
+++ b/packages/server/src/entity/ChatFlow.ts
@@ -14,6 +14,9 @@ export class ChatFlow implements IChatFlow {
     flowData: string
 
     @Column()
+    deployed: boolean
+
+    @Column()
     isPublic: boolean
 
     @Column({ nullable: true })

--- a/packages/ui/src/views/canvas/index.js
+++ b/packages/ui/src/views/canvas/index.js
@@ -201,6 +201,7 @@ const Canvas = () => {
             if (!chatflow.id) {
                 const newChatflowBody = {
                     name: chatflowName,
+                    deployed: false,
                     isPublic: false,
                     flowData
                 }


### PR DESCRIPTION
Bug:
```
⚡️[server]: Flowise Server is listening at 3000
❌[server]: Error during Data Source initialization: QueryFailedError: SQLITE_CONSTRAINT: NOT NULL constraint failed: temporary_chat_flow.isPublic
    at Statement.handler (/Users/yongtae/Documents/personal/code/Flowise_yong/node_modules/typeorm/driver/sqlite/SqliteQueryRunner.js:81:26) {
  query: 'INSERT INTO "temporary_chat_flow"("id", "name", "flowData", "apikeyid", "createdDate", "updatedDate") SELECT "id", "name", "flowData", "apikeyid", "createdDate", "updatedDate" FROM "chat_flow"',
  parameters: undefined,
  driverError: [Error: SQLITE_CONSTRAINT: NOT NULL constraint failed: temporary_chat_flow.isPublic] {
    errno: 19,
    code: 'SQLITE_CONSTRAINT'
  },
  errno: 19,
  code: 'SQLITE_CONSTRAINT'
}
```