### PR TITLE
Bugfix/SQLDBChain Streaming

### DIFF
--- a/packages/components/nodes/chains/SqlDatabaseChain/SqlDatabaseChain.ts
+++ b/packages/components/nodes/chains/SqlDatabaseChain/SqlDatabaseChain.ts
@@ -66,7 +66,7 @@ class SqlDatabaseChain_Chains implements INode {
 
         const chain = await getSQLDBChain(databaseType, dbFilePath, model)
         if (options.socketIO && options.socketIOClientId) {
-            const handler = new CustomChainHandler(options.socketIO, options.socketIOClientId)
+            const handler = new CustomChainHandler(options.socketIO, options.socketIOClientId, 2)
             const res = await chain.run(input, [handler])
             return res
         } else {


### PR DESCRIPTION
Current bug: 
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/d9f7a0dc-7568-45bd-8624-7a54c68f802e)

Streaming prints the output of sql query

Fix:
skip the first LLM streaming, only stream the 2nd part