### PR TITLE
Feature/Nodes Search Quality of Life Updates

### DIFF
--- a/packages/ui/src/views/canvas/AddNodes.js
+++ b/packages/ui/src/views/canvas/AddNodes.js
@@ -34,7 +34,7 @@ import Transitions from 'ui-component/extended/Transitions'
 import { StyledFab } from 'ui-component/button/StyledFab'
 
 // icons
-import { IconPlus, IconSearch, IconMinus } from '@tabler/icons'
+import { IconPlus, IconSearch, IconMinus, IconX } from '@tabler/icons'
 
 // const
 import { baseURL } from 'store/constant'
@@ -61,11 +61,20 @@ const AddNodes = ({ nodesData, node }) => {
         }
     }
 
+    const getSearchedNodes = (value) => {
+        const passed = nodesData.filter((nd) => {
+            const passesQuery = nd.name.toLowerCase().includes(value.toLowerCase())
+            const passesCategory = nd.category.toLowerCase().includes(value.toLowerCase())
+            return passesQuery || passesCategory
+        })
+        return passed
+    }
+
     const filterSearch = (value) => {
         setSearchValue(value)
         setTimeout(() => {
             if (value) {
-                const returnData = nodesData.filter((nd) => nd.name.toLowerCase().includes(value.toLowerCase()))
+                const returnData = getSearchedNodes(value)
                 groupByCategory(returnData, true)
                 scrollTop()
             } else if (value === '') {
@@ -167,7 +176,7 @@ const AddNodes = ({ nodesData, node }) => {
                                             <Typography variant='h4'>Add Nodes</Typography>
                                         </Stack>
                                         <OutlinedInput
-                                            sx={{ width: '100%', pr: 1, pl: 2, my: 2 }}
+                                            sx={{ width: '100%', pr: 2, pl: 2, my: 2 }}
                                             id='input-search-node'
                                             value={searchValue}
                                             onChange={(e) => filterSearch(e.target.value)}
@@ -175,6 +184,28 @@ const AddNodes = ({ nodesData, node }) => {
                                             startAdornment={
                                                 <InputAdornment position='start'>
                                                     <IconSearch stroke={1.5} size='1rem' color={theme.palette.grey[500]} />
+                                                </InputAdornment>
+                                            }
+                                            endAdornment={
+                                                <InputAdornment
+                                                    position='end'
+                                                    sx={{
+                                                        cursor: 'pointer',
+                                                        color: theme.palette.grey[500],
+                                                        '&:hover': {
+                                                            color: theme.palette.grey[900]
+                                                        }
+                                                    }}
+                                                    title='Clear Search'
+                                                >
+                                                    <IconX
+                                                        stroke={1.5}
+                                                        size='1rem'
+                                                        onClick={() => filterSearch('')}
+                                                        style={{
+                                                            cursor: 'pointer'
+                                                        }}
+                                                    />
                                                 </InputAdornment>
                                             }
                                             aria-describedby='search-helper-text'


### PR DESCRIPTION
If you search for a category, then all of the nodes that match that category will show up. This doesn't break existing functionality, as searching for a specific node still reveals that node as expected. I also added a clear button, which will clear and reset the node filter, that way you don't have to manually clear it.
<img width="586" alt="Screenshot 2023-07-06 at 4 59 31 PM" src="https://github.com/FlowiseAI/Flowise/assets/45406132/bb384d8f-a520-44c9-b72a-6ab339cf65f2">
<img width="591" alt="Screenshot 2023-07-06 at 4 59 47 PM" src="https://github.c
<img width="548" alt="Screenshot 2023-07-06 at 5 00 06 PM" src="https://github.com/FlowiseAI/Flowise/assets/45406132/b763bbb9-aa47-404c-9c88-e572d3420351">
om/FlowiseAI/Flowise/assets/45406132/ad789c0e-caea-48de-a1ac-e03b5edfffcb">

Here are some examples. This is just an update that I personally wanted, I'm happy to make changes or add other QoL features to search that might be nice to have. As the number of nodes grows, search functionality will need to be able to scale.
