### PR TITLE
fix: docker should install chromium and puppeteer should be no sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ FROM node:18-alpine
 RUN apk add --update libc6-compat python3 make g++
 # needed for pdfjs-dist
 RUN apk add --no-cache build-base cairo-dev pango-dev
+
+# Install Chromium
+RUN apk add --no-cache chromium
+
 ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 WORKDIR /usr/src/packages
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,12 @@ RUN apk add --no-cache git
 RUN apk add --no-cache python3 py3-pip make g++
 # needed for pdfjs-dist
 RUN apk add --no-cache build-base cairo-dev pango-dev
+
+# Install Chromium
+RUN apk add --no-cache chromium
+
 ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # You can install a specific version like: flowise@1.0.0
 RUN npm install -g flowise

--- a/packages/components/nodes/documentloaders/Puppeteer/Puppeteer.ts
+++ b/packages/components/nodes/documentloaders/Puppeteer/Puppeteer.ts
@@ -73,7 +73,12 @@ class Puppeteer_DocumentLoaders implements INode {
 
         const puppeteerLoader = async (url: string): Promise<any> => {
             let docs = []
-            const loader = new PuppeteerWebBaseLoader(url)
+            const loader = new PuppeteerWebBaseLoader(url, {
+                launchOptions: {
+                    args: ['--no-sandbox'],
+                    headless: 'new'
+                }
+            })
             if (textSplitter) {
                 docs = await loader.loadAndSplit(textSplitter)
             } else {


### PR DESCRIPTION
A couple of considerations here:

- 1) `--no-sandbox` means that puppeteer and chromium won't execute in a sandbox. This could theoretically have security implications, but since this is in a docker image I doubt it will matter. Maybe something to discuss further.
- 2) I'm not entirely sure the context around `ENV PUPPETEER_SKIP_DOWNLOAD=true` in the Dockerfile, although based on [this pr](https://github.com/FlowiseAI/Flowise/pull/350) it seems that the default install script was causing an error. I'm not seeing this error during build time here, and my thinking is through the Dockerfile there's more control anyway.