### PR TITLE
ChatMessage Order Fixed

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -312,7 +312,7 @@ export class App {
                 },
                 order: {
                     createdDate: 'ASC'
-                },
+                }
             })
             return res.json(chatmessages)
         })

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -306,8 +306,13 @@ export class App {
 
         // Get all chatmessages from chatflowid
         this.app.get('/api/v1/chatmessage/:id', async (req: Request, res: Response) => {
-            const chatmessages = await this.AppDataSource.getRepository(ChatMessage).findBy({
-                chatflowid: req.params.id
+            const chatmessages = await this.AppDataSource.getRepository(ChatMessage).find({
+                where: {
+                    chatflowid: req.params.id
+                },
+                order: {
+                    createdDate: 'ASC'
+                },
             })
             return res.json(chatmessages)
         })


### PR DESCRIPTION
Currently the chat message order is coming random because of order of UUID.

Added order by as per the createdDate to ASC to get the chat message in order