### PR TITLE
New Html To Markdown TextSplitter

### DIFF
--- a/packages/components/nodes/textsplitters/HtmlToMarkdownTextSplitter/HtmlToMarkdownTextSplitter.ts
+++ b/packages/components/nodes/textsplitters/HtmlToMarkdownTextSplitter/HtmlToMarkdownTextSplitter.ts
@@ -59,13 +59,8 @@ class HtmlToMarkdownTextSplitter extends MarkdownTextSplitter implements Markdow
         }
     }
     splitText(text: string): Promise<string[]> {
-        return new Promise((resolve, reject) => {
-            const markdown = NodeHtmlMarkdown.translate(
-                /* html */ text,
-                /* options (optional) */ {},
-                /* customTranslators (optional) */ undefined,
-                /* customCodeBlockTranslators (optional) */ undefined
-            )
+        return new Promise((resolve) => {
+            const markdown = NodeHtmlMarkdown.translate(text)
             super.splitText(markdown).then((result) => {
                 resolve(result)
             })

--- a/packages/components/nodes/textsplitters/HtmlToMarkdownTextSplitter/HtmlToMarkdownTextSplitter.ts
+++ b/packages/components/nodes/textsplitters/HtmlToMarkdownTextSplitter/HtmlToMarkdownTextSplitter.ts
@@ -1,0 +1,75 @@
+import { INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses } from '../../../src/utils'
+import { MarkdownTextSplitter, MarkdownTextSplitterParams } from 'langchain/text_splitter'
+import { NodeHtmlMarkdown } from 'node-html-markdown'
+
+class HtmlToMarkdownTextSplitter_TextSplitters implements INode {
+    label: string
+    name: string
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'HtmlToMarkdown Text Splitter'
+        this.name = 'htmlToMarkdownTextSplitter'
+        this.type = 'HtmlToMarkdownTextSplitter'
+        this.icon = 'htmlToMarkdownTextSplitter.svg'
+        this.category = 'Text Splitters'
+        this.description = `Converts Html to Markdown and then split your content into documents based on the Markdown headers`
+        this.baseClasses = [this.type, ...getBaseClasses(HtmlToMarkdownTextSplitter)]
+        this.inputs = [
+            {
+                label: 'Chunk Size',
+                name: 'chunkSize',
+                type: 'number',
+                default: 1000,
+                optional: true
+            },
+            {
+                label: 'Chunk Overlap',
+                name: 'chunkOverlap',
+                type: 'number',
+                optional: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData): Promise<any> {
+        const chunkSize = nodeData.inputs?.chunkSize as string
+        const chunkOverlap = nodeData.inputs?.chunkOverlap as string
+
+        const obj = {} as MarkdownTextSplitterParams
+
+        if (chunkSize) obj.chunkSize = parseInt(chunkSize, 10)
+        if (chunkOverlap) obj.chunkOverlap = parseInt(chunkOverlap, 10)
+
+        const splitter = new HtmlToMarkdownTextSplitter(obj)
+
+        return splitter
+    }
+}
+class HtmlToMarkdownTextSplitter extends MarkdownTextSplitter implements MarkdownTextSplitterParams {
+    constructor(fields?: Partial<MarkdownTextSplitterParams>) {
+        {
+            super(fields)
+        }
+    }
+    splitText(text: string): Promise<string[]> {
+        return new Promise((resolve, reject) => {
+            const markdown = NodeHtmlMarkdown.translate(
+                /* html */ text,
+                /* options (optional) */ {},
+                /* customTranslators (optional) */ undefined,
+                /* customCodeBlockTranslators (optional) */ undefined
+            )
+            super.splitText(markdown).then((result) => {
+                resolve(result)
+            })
+        })
+    }
+}
+module.exports = { nodeClass: HtmlToMarkdownTextSplitter_TextSplitters }

--- a/packages/components/nodes/textsplitters/HtmlToMarkdownTextSplitter/htmlToMarkdownTextSplitter.svg
+++ b/packages/components/nodes/textsplitters/HtmlToMarkdownTextSplitter/htmlToMarkdownTextSplitter.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-markdown" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M3 5m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z"></path>
+   <path d="M7 15v-6l2 2l2 -2v6"></path>
+   <path d="M14 13l2 2l2 -2m-2 2v-6"></path>
+</svg>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,6 +42,7 @@
         "mammoth": "^1.5.1",
         "moment": "^2.29.3",
         "node-fetch": "^2.6.11",
+        "node-html-markdown": "^1.3.0",
         "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^3.7.107",
         "playwright": "^1.35.0",


### PR DESCRIPTION
## Motivation

When using webcrawlers as document loaders to embed and store in a Vector Store, much of what is embedded are useless scripts and styles. This creates a semantic mess for the embeddings.

## Solution

I've introduced a new `HtmlToMarkDownTextSplitter` that inherits from `MarkdownTextSplitter`. This new splitter uses the [`node-html-markdown`](https://www.npmjs.com/package/node-html-markdown) package to convert HTML to Markdown before spliting. Markdown is much more semantically significant for vector embedding.

This approach helps to clean up the embeddings and make them leaner and more meaningful as markdown.

Here's the main code change:

```typescript
splitText(text: string): Promise<string[]> {
    return new Promise((resolve) => {
        const markdown = NodeHtmlMarkdown.translate(text)
        super.splitText(markdown).then((result) => {
            resolve(result)
        })
    })
}
```

## Results

![image](https://github.com/FlowiseAI/Flowise/assets/4365623/3ecc46f5-81ca-438d-a86a-9ff0ef021b54)
