### PR TITLE
add -H "Content-Type: application/json" in curl command

### DIFF
--- a/packages/ui/src/views/chatflows/APICodeDialog.js
+++ b/packages/ui/src/views/chatflows/APICodeDialog.js
@@ -319,7 +319,7 @@ query(formData).then((response) => {
         } else if (codeLang === 'cURL') {
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
      -X POST \\${getConfigExamplesForCurl(configData, 'formData')} \\
-     -H "Content-Type: application/json"`
+     -H "Content-Type: multipart/form-data"`
         }
         return ''
     }
@@ -366,7 +366,7 @@ query(formData).then((response) => {
         } else if (codeLang === 'cURL') {
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
      -X POST \\${getConfigExamplesForCurl(configData, 'formData')} \\
-     -H "Content-Type: application/json" \\
+     -H "Content-Type: multipart/form-data" \\
      -H "Authorization: Bearer ${selectedApiKey?.apiKey}"`
         }
         return ''

--- a/packages/ui/src/views/chatflows/APICodeDialog.js
+++ b/packages/ui/src/views/chatflows/APICodeDialog.js
@@ -204,7 +204,8 @@ query({"question": "Hey, how are you?"}).then((response) => {
         } else if (codeLang === 'cURL') {
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
      -X POST \\
-     -d '{"question": "Hey, how are you?"}'`
+     -d '{"question": "Hey, how are you?"}' \\
+     -H "Content-Type: application/json"`
         }
         return ''
     }
@@ -246,6 +247,7 @@ query({"question": "Hey, how are you?"}).then((response) => {
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
      -X POST \\
      -d '{"question": "Hey, how are you?"}' \\
+     -H "Content-Type: application/json" \\
      -H "Authorization: Bearer ${selectedApiKey?.apiKey}"`
         }
         return ''
@@ -316,7 +318,8 @@ query(formData).then((response) => {
 `
         } else if (codeLang === 'cURL') {
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
-     -X POST \\${getConfigExamplesForCurl(configData, 'formData')}`
+     -X POST \\${getConfigExamplesForCurl(configData, 'formData')} \\
+     -H "Content-Type: application/json"`
         }
         return ''
     }
@@ -363,6 +366,7 @@ query(formData).then((response) => {
         } else if (codeLang === 'cURL') {
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
      -X POST \\${getConfigExamplesForCurl(configData, 'formData')} \\
+     -H "Content-Type: application/json" \\
      -H "Authorization: Bearer ${selectedApiKey?.apiKey}"`
         }
         return ''
@@ -410,7 +414,8 @@ query({
         } else if (codeLang === 'cURL') {
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
      -X POST \\
-     -d '{"question": "Hey, how are you?", "overrideConfig": {${getConfigExamplesForCurl(configData, 'json')}}'`
+     -d '{"question": "Hey, how are you?", "overrideConfig": {${getConfigExamplesForCurl(configData, 'json')}}' \\
+     -H "Content-Type: application/json"`
         }
         return ''
     }
@@ -460,6 +465,7 @@ query({
             return `curl ${baseURL}/api/v1/prediction/${dialogProps.chatflowid} \\
      -X POST \\
      -d '{"question": "Hey, how are you?", "overrideConfig": {${getConfigExamplesForCurl(configData, 'json')}}' \\
+     -H "Content-Type: application/json" \\
      -H "Authorization: Bearer ${selectedApiKey?.apiKey}"`
         }
         return ''


### PR DESCRIPTION
this is copy from [discord](https://discord.com/channels/1087698854775881778/1096265567058534461/1130069743760588883)

after I deploy flowise on render.com and make some LLM chain, we can not call the LLM via curl and javascript, but python can connect.
after some workaround, I found we have to explicitly specify the encoding of data in JSON, for example adding -H "Content-Type: application/json"in curl command.
python do this specification and thus no error happened.

this is curl version