### PR TITLE
Refactor API request to include Content-Type header

### DIFF
--- a/packages/ui/src/views/chatflows/APICodeDialog.js
+++ b/packages/ui/src/views/chatflows/APICodeDialog.js
@@ -310,9 +310,9 @@ async function query(formData) {
         {
             method: "POST",
             headers: {
-                "Content-Type": "application/json"
+                "Content-Type": "application/x-www-form-urlencoded"
             },
-            body: JSON.stringify(formData)
+            body: new URLSearchParams(formData)
         }
     );
     const result = await response.json();
@@ -358,10 +358,10 @@ async function query(formData) {
         {
             headers: {
                 Authorization: "Bearer ${selectedApiKey?.apiKey}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/x-www-form-urlencoded"
             },
             method: "POST",
-            body: JSON.stringify(formData)
+            body: new URLSearchParams(formData)
         }
     );
     const result = await response.json();

--- a/packages/ui/src/views/chatflows/APICodeDialog.js
+++ b/packages/ui/src/views/chatflows/APICodeDialog.js
@@ -309,10 +309,7 @@ async function query(formData) {
         "${baseURL}/api/v1/prediction/${dialogProps.chatflowid}",
         {
             method: "POST",
-            headers: {
-                "Content-Type": "application/x-www-form-urlencoded"
-            },
-            body: new URLSearchParams(formData)
+            body: formData
         }
     );
     const result = await response.json();
@@ -356,12 +353,9 @@ async function query(formData) {
     const response = await fetch(
         "${baseURL}/api/v1/prediction/${dialogProps.chatflowid}",
         {
-            headers: {
-                Authorization: "Bearer ${selectedApiKey?.apiKey}",
-                "Content-Type": "application/x-www-form-urlencoded"
-            },
+            headers: { Authorization: "Bearer ${selectedApiKey?.apiKey}" },
             method: "POST",
-            body: new URLSearchParams(formData)
+            body: formData
         }
     );
     const result = await response.json();

--- a/packages/ui/src/views/chatflows/APICodeDialog.js
+++ b/packages/ui/src/views/chatflows/APICodeDialog.js
@@ -190,7 +190,10 @@ output = query({
         "${baseURL}/api/v1/prediction/${dialogProps.chatflowid}",
         {
             method: "POST",
-            body: data
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(data)
         }
     );
     const result = await response.json();
@@ -229,9 +232,12 @@ output = query({
     const response = await fetch(
         "${baseURL}/api/v1/prediction/${dialogProps.chatflowid}",
         {
-            headers: { Authorization: "Bearer ${selectedApiKey?.apiKey}" },
+            headers: {
+                Authorization: "Bearer ${selectedApiKey?.apiKey}",
+                "Content-Type": "application/json"
+            },
             method: "POST",
-            body: data
+            body: JSON.stringify(data)
         }
     );
     const result = await response.json();
@@ -303,7 +309,10 @@ async function query(formData) {
         "${baseURL}/api/v1/prediction/${dialogProps.chatflowid}",
         {
             method: "POST",
-            body: formData
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(formData)
         }
     );
     const result = await response.json();
@@ -347,9 +356,12 @@ async function query(formData) {
     const response = await fetch(
         "${baseURL}/api/v1/prediction/${dialogProps.chatflowid}",
         {
-            headers: { Authorization: "Bearer ${selectedApiKey?.apiKey}" },
+            headers: {
+                Authorization: "Bearer ${selectedApiKey?.apiKey}",
+                "Content-Type": "application/json"
+            },
             method: "POST",
-            body: formData
+            body: JSON.stringify(formData)
         }
     );
     const result = await response.json();
@@ -392,7 +404,10 @@ output = query({
         "${baseURL}/api/v1/prediction/${dialogProps.chatflowid}",
         {
             method: "POST",
-            body: data
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(data)
         }
     );
     const result = await response.json();
@@ -439,9 +454,12 @@ output = query({
     const response = await fetch(
         "${baseURL}/api/v1/prediction/${dialogProps.chatflowid}",
         {
-            headers: { Authorization: "Bearer ${selectedApiKey?.apiKey}" },
+            headers: {
+                Authorization: "Bearer ${selectedApiKey?.apiKey}",
+                "Content-Type": "application/json"
+            },
             method: "POST",
-            body: data
+            body: JSON.stringify(data)
         }
     );
     const result = await response.json();


### PR DESCRIPTION
this is copy from [discord](https://discord.com/channels/1087698854775881778/1096265567058534461/1130069743760588883)

after I deploy flowise on render.com and make some LLM chain, we can not call the LLM via curl and javascript, but python can connect.
after some workaround, I found we have to explicitly specify the encoding of data in JSON, for example adding -H "Content-Type: application/json"in curl command.
python do this specification and thus no error happened.

this is jacascript version