### PR TITLE
Bugfix/VM2 security

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,19 @@ FLOWISE_PASSWORD=1234
 
 Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder.
 
-| Variable         | Description                                                      | Type                                             | Default                             |
-| ---------------- | ---------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
-| PORT             | The HTTP port Flowise runs on                                    | Number                                           | 3000                                |
-| FLOWISE_USERNAME | Username to login                                                | String                                           |
-| FLOWISE_PASSWORD | Password to login                                                | String                                           |
-| DEBUG            | Print logs from components                                       | Boolean                                          |
-| LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/logs`            |
-| LOG_LEVEL        | Different levels of logs                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
-| DATABASE_PATH    | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
-| APIKEY_PATH      | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |
-| EXECUTION_MODE   | Whether predictions run in their own process or the main process | Enum String: `child`, `main`                     | `main`                              |
+| Variable                   | Description                                                      | Type                                             | Default                             |
+| -------------------------- | ---------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
+| PORT                       | The HTTP port Flowise runs on                                    | Number                                           | 3000                                |
+| FLOWISE_USERNAME           | Username to login                                                | String                                           |
+| FLOWISE_PASSWORD           | Password to login                                                | String                                           |
+| DEBUG                      | Print logs from components                                       | Boolean                                          |
+| LOG_PATH                   | Location where log files are stored                              | String                                           | `your-path/Flowise/logs`            |
+| LOG_LEVEL                  | Different levels of logs                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
+| DATABASE_PATH              | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
+| APIKEY_PATH                | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |
+| EXECUTION_MODE             | Whether predictions run in their own process or the main process | Enum String: `child`, `main`                     | `main`                              |
+| TOOL_FUNCTION_BUILTIN_DEP  | NodeJS built-in modules to be used for Tool Function             | String                                           |                                     |
+| TOOL_FUNCTION_EXTERNAL_DEP | External modules to be used for Tool Function                    | String                                           |                                     |
 
 You can also specify the env variables when using `npx`. For example:
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -6,3 +6,5 @@ PORT=3000
 # APIKEY_PATH=/your_api_key_path/.flowise
 # LOG_PATH=/your_log_path/logs
 # EXECUTION_MODE=child or main
+# TOOL_FUNCTION_BUILTIN_DEP=crypto,fs
+# TOOL_FUNCTION_EXTERNAL_DEP=moment,lodash

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,8 @@ services:
             - LOG_PATH=${LOG_PATH}
             - EXECUTION_MODE=${EXECUTION_MODE}
             - DEBUG=${DEBUG}
+            - TOOL_FUNCTION_BUILTIN_DEP=${TOOL_FUNCTION_BUILTIN_DEP}
+            - TOOL_FUNCTION_EXTERNAL_DEP=${TOOL_FUNCTION_EXTERNAL_DEP}
         ports:
             - '${PORT}:${PORT}'
         volumes:

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -7,3 +7,5 @@ PORT=3000
 # LOG_PATH=/your_log_path/logs
 # LOG_LEVEL=debug (error | warn | info | verbose | debug)
 # EXECUTION_MODE=main (child | main)
+# TOOL_FUNCTION_BUILTIN_DEP=crypto,fs
+# TOOL_FUNCTION_EXTERNAL_DEP=moment,lodash

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -33,17 +33,19 @@ FLOWISE_PASSWORD=1234
 
 Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder.
 
-| Variable         | Description                                                      | Type                                             | Default                             |
-| ---------------- | ---------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
-| PORT             | The HTTP port Flowise runs on                                    | Number                                           | 3000                                |
-| FLOWISE_USERNAME | Username to login                                                | String                                           |
-| FLOWISE_PASSWORD | Password to login                                                | String                                           |
-| DEBUG            | Print logs from components                                       | Boolean                                          |
-| LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/logs`            |
-| LOG_LEVEL        | Different levels of logs                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
-| DATABASE_PATH    | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
-| APIKEY_PATH      | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |
-| EXECUTION_MODE   | Whether predictions run in their own process or the main process | Enum String: `child`, `main`                     | `main`                              |
+| Variable                   | Description                                                      | Type                                             | Default                             |
+| -------------------------- | ---------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
+| PORT                       | The HTTP port Flowise runs on                                    | Number                                           | 3000                                |
+| FLOWISE_USERNAME           | Username to login                                                | String                                           |
+| FLOWISE_PASSWORD           | Password to login                                                | String                                           |
+| DEBUG                      | Print logs from components                                       | Boolean                                          |
+| LOG_PATH                   | Location where log files are stored                              | String                                           | `your-path/Flowise/logs`            |
+| LOG_LEVEL                  | Different levels of logs                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
+| DATABASE_PATH              | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
+| APIKEY_PATH                | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |
+| EXECUTION_MODE             | Whether predictions run in their own process or the main process | Enum String: `child`, `main`                     | `main`                              |
+| TOOL_FUNCTION_BUILTIN_DEP  | NodeJS built-in modules to be used for Tool Function             | String                                           |                                     |
+| TOOL_FUNCTION_EXTERNAL_DEP | External modules to be used for Tool Function                    | String                                           |                                     |
 
 You can also specify the env variables when using `npx`. For example:
 

--- a/packages/server/src/commands/start.ts
+++ b/packages/server/src/commands/start.ts
@@ -24,7 +24,9 @@ export default class Start extends Command {
         APIKEY_PATH: Flags.string(),
         LOG_PATH: Flags.string(),
         LOG_LEVEL: Flags.string(),
-        EXECUTION_MODE: Flags.string()
+        EXECUTION_MODE: Flags.string(),
+        TOOL_FUNCTION_BUILTIN_DEP: Flags.string(),
+        TOOL_FUNCTION_EXTERNAL_DEP: Flags.string()
     }
 
     async stopProcess() {
@@ -65,6 +67,8 @@ export default class Start extends Command {
         if (flags.LOG_LEVEL) process.env.LOG_LEVEL = flags.LOG_LEVEL
         if (flags.EXECUTION_MODE) process.env.EXECUTION_MODE = flags.EXECUTION_MODE
         if (flags.DEBUG) process.env.DEBUG = flags.DEBUG
+        if (flags.TOOL_FUNCTION_BUILTIN_DEP) process.env.TOOL_FUNCTION_BUILTIN_DEP = flags.TOOL_FUNCTION_BUILTIN_DEP
+        if (flags.TOOL_FUNCTION_EXTERNAL_DEP) process.env.TOOL_FUNCTION_EXTERNAL_DEP = flags.TOOL_FUNCTION_EXTERNAL_DEP
 
         await (async () => {
             try {


### PR DESCRIPTION
Current implementation allow all built in modules, this exposed vulnerabilities to malicious attack using `fs` modules.

Added a set of default allowed dependencies, and configs where users can choose to specify from process env variables