### PR TITLE
Bugfix/Update log path

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Flowise support different environment variables to configure your instance. You 
 | FLOWISE_USERNAME | Username to login                                                | String                                           |
 | FLOWISE_PASSWORD | Password to login                                                | String                                           |
 | DEBUG            | Print logs from components                                       | Boolean                                          |
-| LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/logs`            |
+| LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/packages/server` |
 | LOG_LEVEL        | Different levels of logs                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
 | DATABASE_PATH    | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
 | APIKEY_PATH      | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -39,7 +39,7 @@ Flowise support different environment variables to configure your instance. You 
 | FLOWISE_USERNAME | Username to login                                                | String                                           |
 | FLOWISE_PASSWORD | Password to login                                                | String                                           |
 | DEBUG            | Print logs from components                                       | Boolean                                          |
-| LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/logs`            |
+| LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/packages/server` |
 | LOG_LEVEL        | Different levels of logs                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
 | DATABASE_PATH    | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
 | APIKEY_PATH      | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |

--- a/packages/server/src/utils/config.ts
+++ b/packages/server/src/utils/config.ts
@@ -7,7 +7,7 @@ dotenv.config({ path: path.join(__dirname, '..', '..', '.env'), override: true }
 
 // default config
 const loggingConfig = {
-    dir: process.env.LOG_PATH ?? path.join(__dirname, '..', '..', '..', '..', 'logs'),
+    dir: process.env.LOG_PATH ?? path.join(__dirname, '..', '..', 'logs'),
     server: {
         level: process.env.LOG_LEVEL ?? 'info',
         filename: 'server.log',


### PR DESCRIPTION
Bug - https://github.com/FlowiseAI/Flowise/issues/543

When docker compose install Flowise, it is unable to find the path to store the logs on root level.
Changing the path to `packages/server` should resolve the issue