### PR TITLE
Feature/JSONL Logs Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ FLOWISE_PASSWORD=1234
 
 ## 🌱 Env Variables
 
-Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder.
+Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder. Read [more](https://docs.flowiseai.com/environment-variables)
 
 | Variable         | Description                                                      | Type                                             | Default                             |
 | ---------------- | ---------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ Flowise support different environment variables to configure your instance. You 
 | PORT             | The HTTP port Flowise runs on                                    | Number                                           | 3000                                |
 | FLOWISE_USERNAME | Username to login                                                | String                                           |
 | FLOWISE_PASSWORD | Password to login                                                | String                                           |
-| DEBUG            | Print logs from components                                       | Boolean                                          |
+| DEBUG            | Print logs onto terminal/console                                 | Boolean                                          |
 | LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/packages/server` |
-| LOG_LEVEL        | Different levels of logs                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
+| LOG_LEVEL        | Different log levels for loggers to be saved                     | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
 | DATABASE_PATH    | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
 | APIKEY_PATH      | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |
 | EXECUTION_MODE   | Whether predictions run in their own process or the main process | Enum String: `child`, `main`                     | `main`                              |

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,8 +1,9 @@
 PORT=3000
+DATABASE_PATH=/root/.flowise
+APIKEY_PATH=/root/.flowise
+LOG_PATH=/root/.flowise/logs
 # FLOWISE_USERNAME=user
 # FLOWISE_PASSWORD=1234
 # DEBUG=true
-# DATABASE_PATH=/your_database_path/.flowise
-# APIKEY_PATH=/your_api_key_path/.flowise
-# LOG_PATH=/your_log_path/logs
+# LOG_LEVEL=debug (error | warn | info | verbose | debug)
 # EXECUTION_MODE=child or main

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ Starts Flowise from [DockerHub Image](https://hub.docker.com/repository/docker/f
 3. Open [http://localhost:3000](http://localhost:3000)
 4. You can bring the containers down by `docker-compose stop`
 
-## With Authrorization
+## 🔒 Authrorization
 
 1. Create `.env` file and specify the `PORT`, `FLOWISE_USERNAME`, and `FLOWISE_PASSWORD` (refer to `.env.example`)
 2. Pass `FLOWISE_USERNAME` and `FLOWISE_PASSWORD` to the `docker-compose.yml` file:
@@ -22,3 +22,25 @@ Starts Flowise from [DockerHub Image](https://hub.docker.com/repository/docker/f
 3. `docker-compose up -d`
 4. Open [http://localhost:3000](http://localhost:3000)
 5. You can bring the containers down by `docker-compose stop`
+
+## 🌱 Env Variables
+
+If you like to persist your data (flows, logs, apikeys), set these variables in the `.env` file inside `docker` folder:
+
+-   DATABASE_PATH=/root/.flowise
+-   APIKEY_PATH=/root/.flowise
+-   LOG_PATH=/root/.flowise/logs
+
+Flowise also support different environment variables to configure your instance. Read [more](https://docs.flowiseai.com/environment-variables)
+
+| Variable         | Description                                                      | Type                                             | Default                             |
+| ---------------- | ---------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
+| PORT             | The HTTP port Flowise runs on                                    | Number                                           | 3000                                |
+| FLOWISE_USERNAME | Username to login                                                | String                                           |
+| FLOWISE_PASSWORD | Password to login                                                | String                                           |
+| DEBUG            | Print logs onto terminal/console                                 | Boolean                                          |
+| LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/packages/server` |
+| LOG_LEVEL        | Different log levels for loggers to be saved                     | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
+| DATABASE_PATH    | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
+| APIKEY_PATH      | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |
+| EXECUTION_MODE   | Whether predictions run in their own process or the main process | Enum String: `child`, `main`                     | `main`                              |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,11 +8,12 @@ services:
             - PORT=${PORT}
             - FLOWISE_USERNAME=${FLOWISE_USERNAME}
             - FLOWISE_PASSWORD=${FLOWISE_PASSWORD}
+            - DEBUG=${DEBUG}
             - DATABASE_PATH=${DATABASE_PATH}
             - APIKEY_PATH=${APIKEY_PATH}
             - LOG_PATH=${LOG_PATH}
+            - LOG_LEVEL=${LOG_LEVEL}
             - EXECUTION_MODE=${EXECUTION_MODE}
-            - DEBUG=${DEBUG}
         ports:
             - '${PORT}:${PORT}'
         volumes:

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -4,6 +4,6 @@ PORT=3000
 # DEBUG=true
 # DATABASE_PATH=/your_database_path/.flowise
 # APIKEY_PATH=/your_api_key_path/.flowise
-# LOG_PATH=/your_log_path/logs
+# LOG_PATH=/your_log_path/.flowise/logs
 # LOG_LEVEL=debug (error | warn | info | verbose | debug)
 # EXECUTION_MODE=main (child | main)

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -38,9 +38,9 @@ Flowise support different environment variables to configure your instance. You 
 | PORT             | The HTTP port Flowise runs on                                    | Number                                           | 3000                                |
 | FLOWISE_USERNAME | Username to login                                                | String                                           |
 | FLOWISE_PASSWORD | Password to login                                                | String                                           |
-| DEBUG            | Print logs from components                                       | Boolean                                          |
+| DEBUG            | Print logs onto terminal/console                                 | Boolean                                          |
 | LOG_PATH         | Location where log files are stored                              | String                                           | `your-path/Flowise/packages/server` |
-| LOG_LEVEL        | Different levels of logs                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
+| LOG_LEVEL        | Different log levels for loggers to be saved                     | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
 | DATABASE_PATH    | Location where database is saved                                 | String                                           | `your-home-dir/.flowise`            |
 | APIKEY_PATH      | Location where api keys are saved                                | String                                           | `your-path/Flowise/packages/server` |
 | EXECUTION_MODE   | Whether predictions run in their own process or the main process | Enum String: `child`, `main`                     | `main`                              |

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -31,7 +31,7 @@ FLOWISE_PASSWORD=1234
 
 ## 🌱 Env Variables
 
-Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder.
+Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder. Read [more](https://docs.flowiseai.com/environment-variables)
 
 | Variable         | Description                                                      | Type                                             | Default                             |
 | ---------------- | ---------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -59,9 +59,6 @@ export class App {
 
     constructor() {
         this.app = express()
-
-        // Add the expressRequestLogger middleware to log all requests
-        this.app.use(expressRequestLogger)
     }
 
     async initDatabase() {
@@ -91,6 +88,9 @@ export class App {
 
         // Allow access from *
         this.app.use(cors())
+
+        // Add the expressRequestLogger middleware to log all requests
+        this.app.use(expressRequestLogger)
 
         if (process.env.FLOWISE_USERNAME && process.env.FLOWISE_PASSWORD) {
             const username = process.env.FLOWISE_USERNAME

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -57,43 +57,46 @@ const logger = createLogger({
  *   this.app.use(expressRequestLogger)
  */
 export function expressRequestLogger(req: Request, res: Response, next: NextFunction): void {
-    const fileLogger = createLogger({
-        format: combine(timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), format.json(), errors({ stack: true })),
-        defaultMeta: {
-            package: 'server',
-            request: {
-                method: req.method,
-                url: req.url,
-                body: req.body,
-                query: req.query,
-                params: req.params,
-                headers: req.headers
-            }
-        },
-        transports: [
-            new transports.File({
-                filename: path.join(logDir, config.logging.express.filename ?? 'server-requests.log.jsonl'),
-                level: config.logging.express.level ?? 'debug'
-            })
-        ]
-    })
+    const unwantedLogURLs = ['/api/v1/node-icon/']
+    if (req.url.includes('/api/v1/') && !unwantedLogURLs.some((url) => req.url.includes(url))) {
+        const fileLogger = createLogger({
+            format: combine(timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), format.json(), errors({ stack: true })),
+            defaultMeta: {
+                package: 'server',
+                request: {
+                    method: req.method,
+                    url: req.url,
+                    body: req.body,
+                    query: req.query,
+                    params: req.params,
+                    headers: req.headers
+                }
+            },
+            transports: [
+                new transports.File({
+                    filename: path.join(logDir, config.logging.express.filename ?? 'server-requests.log.jsonl'),
+                    level: config.logging.express.level ?? 'debug'
+                })
+            ]
+        })
 
-    const getRequestEmoji = (method: string) => {
-        const requetsEmojis: Record<string, string> = {
-            GET: '⬇️',
-            POST: '⬆️',
-            PUT: '🖊',
-            DELETE: '❌'
+        const getRequestEmoji = (method: string) => {
+            const requetsEmojis: Record<string, string> = {
+                GET: '⬇️',
+                POST: '⬆️',
+                PUT: '🖊',
+                DELETE: '❌'
+            }
+
+            return requetsEmojis[method] || '?'
         }
 
-        return requetsEmojis[method] || '?'
-    }
-
-    if (req.method !== 'GET') {
-        fileLogger.info(`${getRequestEmoji(req.method)} ${req.method} ${req.url}`)
-        logger.info(`${getRequestEmoji(req.method)} ${req.method} ${req.url}`)
-    } else {
-        fileLogger.http(`${getRequestEmoji(req.method)} ${req.method} ${req.url}`)
+        if (req.method !== 'GET') {
+            fileLogger.info(`${getRequestEmoji(req.method)} ${req.method} ${req.url}`)
+            logger.info(`${getRequestEmoji(req.method)} ${req.method} ${req.url}`)
+        } else {
+            fileLogger.http(`${getRequestEmoji(req.method)} ${req.method} ${req.url}`)
+        }
     }
 
     next()


### PR DESCRIPTION
added unwanted log urls to prevent logging node-icon api calls to jsonl file

`server-requests.log.jsonl`
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/882eb43e-2215-4f5d-b612-c1019fee293f)

`server.log`
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/44899da5-d064-4696-8e38-602bc34f4f4f)

`server-error.log`
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/8fbe0b66-20d4-4fd3-8366-5a3b3efa4342)

`terminal`
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/fc7aa6fc-a867-47a5-8a84-71c8fe9c6f5b)

