### PR TITLE
update server project name to fix conflict issue

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "flowise",
+    "name": "flowise-server",
     "version": "1.3.1",
     "description": "Flowiseai Server",
     "main": "dist/index",


### PR DESCRIPTION
yarn version: 3.2.0

$ yarn
Internal Error: Duplicate workspace name flowise: C:\Users\xxxx\Desktop\Flowise\packages\server conflicts with C:\Users\xxxx\Desktop\Flowise