### PR TITLE
Bugfix/LLMChain PromptValues Undefined

### DIFF
--- a/packages/components/nodes/chains/LLMChain/LLMChain.ts
+++ b/packages/components/nodes/chains/LLMChain/LLMChain.ts
@@ -116,7 +116,7 @@ const runPrediction = async (
      */
     const promptValues = handleEscapeCharacters(promptValuesRaw, true)
 
-    if (inputVariables.length > 0) {
+    if (promptValues && inputVariables.length > 0) {
         let seen: string[] = []
 
         for (const variable of inputVariables) {


### PR DESCRIPTION
When using few shot prompt, promptValues is undefined: 
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/600d2442-9636-412a-afa2-0eee2582fb6e)

This is a minor fix when promptValues is undefined