### PR TITLE
Add sentence config option to Vectara

### DIFF
--- a/packages/components/nodes/vectorstores/Vectara_Existing/Vectara_Existing.ts
+++ b/packages/components/nodes/vectorstores/Vectara_Existing/Vectara_Existing.ts
@@ -43,6 +43,7 @@ class VectaraExisting_VectorStores implements INode {
             {
                 label: 'Sentences Before',
                 name: 'sentencesBefore',
+                description: 'Number of sentences to fetch before the matched sentence. Defaults to 2.',
                 type: 'number',
                 additionalParams: true,
                 optional: true
@@ -50,6 +51,7 @@ class VectaraExisting_VectorStores implements INode {
             {
                 label: 'Sentences After',
                 name: 'sentencesAfter',
+                description: 'Number of sentences to fetch after the matched sentence. Defaults to 2.',
                 type: 'number',
                 additionalParams: true,
                 optional: true
@@ -57,6 +59,8 @@ class VectaraExisting_VectorStores implements INode {
             {
                 label: 'Lambda',
                 name: 'lambda',
+                description:
+                    'Improves retrieval accuracy by adjusting the balance (from 0 to 1) between neural search and keyword-based search factors.',
                 type: 'number',
                 additionalParams: true,
                 optional: true

--- a/packages/components/nodes/vectorstores/Vectara_Existing/Vectara_Existing.ts
+++ b/packages/components/nodes/vectorstores/Vectara_Existing/Vectara_Existing.ts
@@ -1,6 +1,6 @@
 import { ICommonObject, INode, INodeData, INodeOutputsValue, INodeParams } from '../../../src/Interface'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
-import { VectaraStore, VectaraLibArgs, VectaraFilter } from 'langchain/vectorstores/vectara'
+import { VectaraStore, VectaraLibArgs, VectaraFilter, VectaraContextConfig } from 'langchain/vectorstores/vectara'
 
 class VectaraExisting_VectorStores implements INode {
     label: string
@@ -41,6 +41,20 @@ class VectaraExisting_VectorStores implements INode {
                 optional: true
             },
             {
+                label: 'Sentences Before',
+                name: 'sentencesBefore',
+                type: 'number',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Sentences After',
+                name: 'sentencesAfter',
+                type: 'number',
+                additionalParams: true,
+                optional: true
+            },
+            {
                 label: 'Lambda',
                 name: 'lambda',
                 type: 'number',
@@ -77,6 +91,8 @@ class VectaraExisting_VectorStores implements INode {
         const corpusId = getCredentialParam('corpusID', credentialData, nodeData)
 
         const vectaraMetadataFilter = nodeData.inputs?.filter as string
+        const sentencesBefore = nodeData.inputs?.sentencesBefore as number
+        const sentencesAfter = nodeData.inputs?.sentencesAfter as number
         const lambda = nodeData.inputs?.lambda as number
         const output = nodeData.outputs?.output as string
         const topK = nodeData.inputs?.topK as string
@@ -91,6 +107,11 @@ class VectaraExisting_VectorStores implements INode {
         const vectaraFilter: VectaraFilter = {}
         if (vectaraMetadataFilter) vectaraFilter.filter = vectaraMetadataFilter
         if (lambda) vectaraFilter.lambda = lambda
+
+        const vectaraContextConfig: VectaraContextConfig = {}
+        if (sentencesBefore) vectaraContextConfig.sentencesBefore = sentencesBefore
+        if (sentencesAfter) vectaraContextConfig.sentencesAfter = sentencesAfter
+        vectaraFilter.contextConfig = vectaraContextConfig
 
         const vectorStore = new VectaraStore(vectaraArgs)
 

--- a/packages/components/nodes/vectorstores/Vectara_Upsert/Vectara_Upsert.ts
+++ b/packages/components/nodes/vectorstores/Vectara_Upsert/Vectara_Upsert.ts
@@ -1,7 +1,7 @@
 import { ICommonObject, INode, INodeData, INodeOutputsValue, INodeParams } from '../../../src/Interface'
 import { Embeddings } from 'langchain/embeddings/base'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
-import { VectaraStore, VectaraLibArgs, VectaraFilter } from 'langchain/vectorstores/vectara'
+import { VectaraStore, VectaraLibArgs, VectaraFilter, VectaraContextConfig } from 'langchain/vectorstores/vectara'
 import { Document } from 'langchain/document'
 import { flatten } from 'lodash'
 
@@ -50,6 +50,20 @@ class VectaraUpsert_VectorStores implements INode {
                 optional: true
             },
             {
+                label: 'Sentences Before',
+                name: 'sentencesBefore',
+                type: 'number',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Sentences After',
+                name: 'sentencesAfter',
+                type: 'number',
+                additionalParams: true,
+                optional: true
+            },
+            {
                 label: 'Lambda',
                 name: 'lambda',
                 type: 'number',
@@ -88,6 +102,8 @@ class VectaraUpsert_VectorStores implements INode {
         const docs = nodeData.inputs?.document as Document[]
         const embeddings = {} as Embeddings
         const vectaraMetadataFilter = nodeData.inputs?.filter as string
+        const sentencesBefore = nodeData.inputs?.sentencesBefore as number
+        const sentencesAfter = nodeData.inputs?.sentencesAfter as number
         const lambda = nodeData.inputs?.lambda as number
         const output = nodeData.outputs?.output as string
         const topK = nodeData.inputs?.topK as string
@@ -102,6 +118,11 @@ class VectaraUpsert_VectorStores implements INode {
         const vectaraFilter: VectaraFilter = {}
         if (vectaraMetadataFilter) vectaraFilter.filter = vectaraMetadataFilter
         if (lambda) vectaraFilter.lambda = lambda
+
+        const vectaraContextConfig: VectaraContextConfig = {}
+        if (sentencesBefore) vectaraContextConfig.sentencesBefore = sentencesBefore
+        if (sentencesAfter) vectaraContextConfig.sentencesAfter = sentencesAfter
+        vectaraFilter.contextConfig = vectaraContextConfig
 
         const flattenDocs = docs && docs.length ? flatten(docs) : []
         const finalDocs = []

--- a/packages/components/nodes/vectorstores/Vectara_Upsert/Vectara_Upsert.ts
+++ b/packages/components/nodes/vectorstores/Vectara_Upsert/Vectara_Upsert.ts
@@ -52,6 +52,7 @@ class VectaraUpsert_VectorStores implements INode {
             {
                 label: 'Sentences Before',
                 name: 'sentencesBefore',
+                description: 'Number of sentences to fetch before the matched sentence. Defaults to 2.',
                 type: 'number',
                 additionalParams: true,
                 optional: true
@@ -59,6 +60,7 @@ class VectaraUpsert_VectorStores implements INode {
             {
                 label: 'Sentences After',
                 name: 'sentencesAfter',
+                description: 'Number of sentences to fetch after the matched sentence. Defaults to 2.',
                 type: 'number',
                 additionalParams: true,
                 optional: true
@@ -66,6 +68,8 @@ class VectaraUpsert_VectorStores implements INode {
             {
                 label: 'Lambda',
                 name: 'lambda',
+                description:
+                    'Improves retrieval accuracy by adjusting the balance (from 0 to 1) between neural search and keyword-based search factors.',
                 type: 'number',
                 additionalParams: true,
                 optional: true

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,7 @@
         "google-auth-library": "^9.0.0",
         "graphql": "^16.6.0",
         "html-to-text": "^9.0.5",
-        "langchain": "^0.0.122",
+        "langchain": "^0.0.126",
         "linkifyjs": "^4.1.1",
         "mammoth": "^1.5.1",
         "moment": "^2.29.3",


### PR DESCRIPTION
I had to update the langchain package version to use VectaraStore's new context config options, I hope this is okay.

Screenshot of config:
![Screenshot 2023-08-15 at 11 46 14 AM](https://github.com/vectara/Flowise/assets/29833473/fba330a4-c86a-45a0-b0ad-19532df24f20)
