### PR TITLE
ChatOpenAI + Helicone MVP

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -123,6 +123,16 @@ class ChatOpenAI_ChatModels implements INode {
                 label: 'BasePath',
                 name: 'basepath',
                 type: 'string',
+                description: "Defaults to OpenAI's chat completion endpoint. Change this if you are using a proxy, like Helicone.",
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'HeliconeApiKey',
+                name: 'heliconeApiKey',
+                type: 'password',
+                description:
+                    "Helicone API Key. If informed, you will need to change the BasePath to Helicone's proxy URL (https://oai.hconeai.com/v1).",
                 optional: true,
                 additionalParams: true
             }
@@ -139,6 +149,7 @@ class ChatOpenAI_ChatModels implements INode {
         const timeout = nodeData.inputs?.timeout as string
         const streaming = nodeData.inputs?.streaming as boolean
         const basePath = nodeData.inputs?.basepath as string
+        const heliconeApiKey = nodeData.inputs?.heliconeApiKey as string
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const openAIApiKey = getCredentialParam('openAIApiKey', credentialData, nodeData)
@@ -156,8 +167,19 @@ class ChatOpenAI_ChatModels implements INode {
         if (presencePenalty) obj.presencePenalty = parseFloat(presencePenalty)
         if (timeout) obj.timeout = parseInt(timeout, 10)
 
+        let baseOptions: any | undefined = undefined
+
+        if (heliconeApiKey) {
+            baseOptions = {
+                headers: {
+                    'Helicone-Auth': 'Bearer ' + heliconeApiKey
+                }
+            }
+        }
+
         const model = new ChatOpenAI(obj, {
-            basePath
+            basePath,
+            baseOptions
         })
         return model
     }


### PR DESCRIPTION
## Motivation 
This is an working MVP (Minimum Viable Product) that enables integration with Helicone, for monitoring requests.

The necessary changes for an initial working feature were minimal. There are many other customizations possible (Like custom parameters, helicone caching, rate limiting), that can be implemented further.

As I don't know if the team will agree on this architecture (Adding a Helicone API Key to the OpenAi Chat Model), I decided to start simple to minimize the impact.

I tried creating this property as a credential, but it would become a node connection instead of the dropdown, so i opted for a password input.

## Screenshots (local env)

![Helicone on the OpenAI Chat Model](https://github.com/FlowiseAI/Flowise/assets/4365623/5736a82a-3002-44b5-8486-98baa0178460)
_How it looks on the OpenAI Chat Model node_


![Added description to BasePath](https://github.com/FlowiseAI/Flowise/assets/4365623/29dfb34b-5f84-4161-929a-1eed5d1591ab)
_Added description to BasePath_


![Description of Helicone Api Key Input](https://github.com/FlowiseAI/Flowise/assets/4365623/ab810905-39a4-494c-a7c4-97d1a8ce7a09)
_Description of Helicone Api Key Input_


![Our Request on Helicone Dashboard](https://github.com/FlowiseAI/Flowise/assets/4365623/ca6105cb-e970-494f-ace8-4b4a58a70b0c)
_Successfully integrated to Helicone_


## Future
Maybe make Helicone / Langsmith and proxy services as such as a Node to be connected to a Model, this way we could successfully use credentials, be platform-agnostic, and add a lot of custom values.