### PR TITLE
Added BaseOptions to ChatOpenAI

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -125,6 +125,13 @@ class ChatOpenAI_ChatModels implements INode {
                 type: 'string',
                 optional: true,
                 additionalParams: true
+            },
+            {
+                label: 'BaseOptions',
+                name: 'baseOptions',
+                type: 'json',
+                optional: true,
+                additionalParams: true
             }
         ]
     }
@@ -139,6 +146,7 @@ class ChatOpenAI_ChatModels implements INode {
         const timeout = nodeData.inputs?.timeout as string
         const streaming = nodeData.inputs?.streaming as boolean
         const basePath = nodeData.inputs?.basepath as string
+        const baseOptions = nodeData.inputs?.baseOptions
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const openAIApiKey = getCredentialParam('openAIApiKey', credentialData, nodeData)
@@ -156,8 +164,18 @@ class ChatOpenAI_ChatModels implements INode {
         if (presencePenalty) obj.presencePenalty = parseFloat(presencePenalty)
         if (timeout) obj.timeout = parseInt(timeout, 10)
 
+        let parsedBaseOptions: any | undefined = undefined
+
+        if (baseOptions) {
+            try {
+                parsedBaseOptions = typeof baseOptions === 'object' ? baseOptions : JSON.parse(baseOptions)
+            } catch (exception) {
+                throw new Error("Invalid JSON in the ChatOpenAI's BaseOptions: " + exception)
+            }
+        }
         const model = new ChatOpenAI(obj, {
-            basePath
+            basePath,
+            baseOptions: parsedBaseOptions
         })
         return model
     }


### PR DESCRIPTION
## Motivation:
Had the need to pass Helicone's API key but there was no way to pass the BaseOptions needed on the documentation. 

Used a very similar code to pupeteer's node metadata input. Just added a try..catch, in case something is wrong with the JSON, so the user can identify where it is coming from.

![BaseOptions](https://github.com/FlowiseAI/Flowise/assets/4365623/cb18e8ab-1632-4dc0-8450-c131edd70075)
_BaseOptions on ChatOpenAI node_

![image](https://github.com/FlowiseAI/Flowise/assets/4365623/fb482adb-952b-4e99-b8d1-5d2c21b830c8)
_Example call to Helicone_

![image](https://github.com/FlowiseAI/Flowise/assets/4365623/475f8552-2259-417b-8072-9fa166d8cad7)
_Custom properties working as well, so any use you may have for BaseOptions now are possible_