### PR TITLE
add 32k model

### DIFF
--- a/packages/components/nodes/chatmodels/ChatGoogleVertexAI/ChatGoogleVertexAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleVertexAI/ChatGoogleVertexAI.ts
@@ -46,6 +46,14 @@ class GoogleVertexAI_ChatModels implements INode {
                     {
                         label: 'codechat-bison',
                         name: 'codechat-bison'
+                    },
+                    {
+                        label: 'chat-bison-32k',
+                        name: 'chat-bison-32k'
+                    },
+                    {
+                        label: 'codechat-bison-32k',
+                        name: 'codechat-bison-32k'
                     }
                 ],
                 default: 'chat-bison',

--- a/packages/components/nodes/llms/GoogleVertexAI/GoogleVertexAI.ts
+++ b/packages/components/nodes/llms/GoogleVertexAI/GoogleVertexAI.ts
@@ -50,6 +50,18 @@ class GoogleVertexAI_LLMs implements INode {
                     {
                         label: 'code-gecko',
                         name: 'code-gecko'
+                    },
+                    {
+                        label: 'text-bison-32k',
+                        name: 'text-bison-32k'
+                    },
+                    {
+                        label: 'code-bison-32k',
+                        name: 'code-bison-32k'
+                    },
+                    {
+                        label: 'code-gecko-32k',
+                        name: 'code-gecko-32k'
                     }
                 ],
                 default: 'text-bison'


### PR DESCRIPTION
Adaptation of [32k model of Vertex AI Embedding](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models#32k_models), which is published Google Could Next on last week! 🎉