### PR TITLE
Feature/Add FLOWISE_SECRETKEY_OVERWRITE

### DIFF
--- a/CONTRIBUTING-ZH.md
+++ b/CONTRIBUTING-ZH.md
@@ -118,25 +118,26 @@ Flowise 在一个单一的单体存储库中有 3 个不同的模块。
 
 Flowise 支持不同的环境变量来配置您的实例。您可以在 `packages/server` 文件夹中的 `.env` 文件中指定以下变量。阅读[更多信息](https://docs.flowiseai.com/environment-variables)
 
-| 变量名                     | 描述                                                   | 类型                                            | 默认值                              |
-| -------------------------- | ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------- |
-| PORT                       | Flowise 运行的 HTTP 端口                               | 数字                                            | 3000                                |
-| FLOWISE_USERNAME           | 登录用户名                                             | 字符串                                          |                                     |
-| FLOWISE_PASSWORD           | 登录密码                                               | 字符串                                          |                                     |
-| DEBUG                      | 打印组件的日志                                         | 布尔值                                          |                                     |
-| LOG_PATH                   | 存储日志文件的位置                                     | 字符串                                          | `your-path/Flowise/logs`            |
-| LOG_LEVEL                  | 日志的不同级别                                         | 枚举字符串: `error`, `info`, `verbose`, `debug` | `info`                              |
-| APIKEY_PATH                | 存储 API 密钥的位置                                    | 字符串                                          | `your-path/Flowise/packages/server` |
-| TOOL_FUNCTION_BUILTIN_DEP  | 用于工具函数的 NodeJS 内置模块                         | 字符串                                          |                                     |
-| TOOL_FUNCTION_EXTERNAL_DEP | 用于工具函数的外部模块                                 | 字符串                                          |                                     |
-| OVERRIDE_DATABASE          | 是否使用默认值覆盖当前数据库                           | 枚举字符串: `true`, `false`                     | `true`                              |
-| DATABASE_TYPE              | 存储 flowise 数据的数据库类型                          | 枚举字符串: `sqlite`, `mysql`, `postgres`       | `sqlite`                            |
-| DATABASE_PATH              | 数据库保存的位置（当 DATABASE_TYPE 是 sqlite 时）      | 字符串                                          | `your-home-dir/.flowise`            |
-| DATABASE_HOST              | 主机 URL 或 IP 地址（当 DATABASE_TYPE 不是 sqlite 时） | 字符串                                          |                                     |
-| DATABASE_PORT              | 数据库端口（当 DATABASE_TYPE 不是 sqlite 时）          | 字符串                                          |                                     |
-| DATABASE_USERNAME          | 数据库用户名（当 DATABASE_TYPE 不是 sqlite 时）        | 字符串                                          |                                     |
-| DATABASE_PASSWORD          | 数据库密码（当 DATABASE_TYPE 不是 sqlite 时）          | 字符串                                          |                                     |
-| DATABASE_NAME              | 数据库名称（当 DATABASE_TYPE 不是 sqlite 时）          | 字符串                                          |                                     |
+| 变量名                      | 描述                                                   | 类型                                            | 默认值                              |
+| --------------------------- | ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------- |
+| PORT                        | Flowise 运行的 HTTP 端口                               | 数字                                            | 3000                                |
+| FLOWISE_USERNAME            | 登录用户名                                             | 字符串                                          |                                     |
+| FLOWISE_PASSWORD            | 登录密码                                               | 字符串                                          |                                     |
+| DEBUG                       | 打印组件的日志                                         | 布尔值                                          |                                     |
+| LOG_PATH                    | 存储日志文件的位置                                     | 字符串                                          | `your-path/Flowise/logs`            |
+| LOG_LEVEL                   | 日志的不同级别                                         | 枚举字符串: `error`, `info`, `verbose`, `debug` | `info`                              |
+| APIKEY_PATH                 | 存储 API 密钥的位置                                    | 字符串                                          | `your-path/Flowise/packages/server` |
+| TOOL_FUNCTION_BUILTIN_DEP   | 用于工具函数的 NodeJS 内置模块                         | 字符串                                          |                                     |
+| TOOL_FUNCTION_EXTERNAL_DEP  | 用于工具函数的外部模块                                 | 字符串                                          |                                     |
+| DATABASE_TYPE               | 存储 flowise 数据的数据库类型                          | 枚举字符串: `sqlite`, `mysql`, `postgres`       | `sqlite`                            |
+| DATABASE_PATH               | 数据库保存的位置（当 DATABASE_TYPE 是 sqlite 时）      | 字符串                                          | `your-home-dir/.flowise`            |
+| DATABASE_HOST               | 主机 URL 或 IP 地址（当 DATABASE_TYPE 不是 sqlite 时） | 字符串                                          |                                     |
+| DATABASE_PORT               | 数据库端口（当 DATABASE_TYPE 不是 sqlite 时）          | 字符串                                          |                                     |
+| DATABASE_USERNAME           | 数据库用户名（当 DATABASE_TYPE 不是 sqlite 时）        | 字符串                                          |                                     |
+| DATABASE_PASSWORD           | 数据库密码（当 DATABASE_TYPE 不是 sqlite 时）          | 字符串                                          |                                     |
+| DATABASE_NAME               | 数据库名称（当 DATABASE_TYPE 不是 sqlite 时）          | 字符串                                          |                                     |
+| SECRETKEY_PATH              | 保存加密密钥（用于加密/解密凭据）的位置                | 字符串                                          | `your-path/Flowise/packages/server` |
+| FLOWISE_SECRETKEY_OVERWRITE | 加密密钥用于替代存储在 SECRETKEY_PATH 中的密钥         | 字符串                                          |
 
 您也可以在使用 `npx` 时指定环境变量。例如：
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,27 +120,26 @@ Flowise has 3 different modules in a single mono repository.
 
 Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder. Read [more](https://docs.flowiseai.com/environment-variables)
 
-| Variable                   | Description                                                                  | Type                                             | Default                             |
-| -------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
-| PORT                       | The HTTP port Flowise runs on                                                | Number                                           | 3000                                |
-| FLOWISE_USERNAME           | Username to login                                                            | String                                           |                                     |
-| FLOWISE_PASSWORD           | Password to login                                                            | String                                           |                                     |
-| DEBUG                      | Print logs from components                                                   | Boolean                                          |                                     |
-| LOG_PATH                   | Location where log files are stored                                          | String                                           | `your-path/Flowise/logs`            |
-| LOG_LEVEL                  | Different levels of logs                                                     | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
-| APIKEY_PATH                | Location where api keys are saved                                            | String                                           | `your-path/Flowise/packages/server` |
-| TOOL_FUNCTION_BUILTIN_DEP  | NodeJS built-in modules to be used for Tool Function                         | String                                           |                                     |
-| TOOL_FUNCTION_EXTERNAL_DEP | External modules to be used for Tool Function                                | String                                           |                                     |
-| OVERRIDE_DATABASE          | Override current database with default                                       | Enum String: `true`, `false`                     | `true`                              |
-| DATABASE_TYPE              | Type of database to store the flowise data                                   | Enum String: `sqlite`, `mysql`, `postgres`       | `sqlite`                            |
-| DATABASE_PATH              | Location where database is saved (When DATABASE_TYPE is sqlite)              | String                                           | `your-home-dir/.flowise`            |
-| DATABASE_HOST              | Host URL or IP address (When DATABASE_TYPE is not sqlite)                    | String                                           |                                     |
-| DATABASE_PORT              | Database port (When DATABASE_TYPE is not sqlite)                             | String                                           |                                     |
-| DATABASE_USER              | Database username (When DATABASE_TYPE is not sqlite)                         | String                                           |                                     |
-| DATABASE_PASSWORD          | Database password (When DATABASE_TYPE is not sqlite)                         | String                                           |                                     |
-| DATABASE_NAME              | Database name (When DATABASE_TYPE is not sqlite)                             | String                                           |                                     |
-| PASSPHRASE                 | Passphrase used to create encryption key                                     | String                                           | `MYPASSPHRASE`                      |
-| SECRETKEY_PATH             | Location where encryption key (used to encrypt/decrypt credentials) is saved | String                                           | `your-path/Flowise/packages/server` |
+| Variable                    | Description                                                                  | Type                                             | Default                             |
+| --------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- | --- |
+| PORT                        | The HTTP port Flowise runs on                                                | Number                                           | 3000                                |
+| FLOWISE_USERNAME            | Username to login                                                            | String                                           |                                     |
+| FLOWISE_PASSWORD            | Password to login                                                            | String                                           |                                     |
+| DEBUG                       | Print logs from components                                                   | Boolean                                          |                                     |
+| LOG_PATH                    | Location where log files are stored                                          | String                                           | `your-path/Flowise/logs`            |
+| LOG_LEVEL                   | Different levels of logs                                                     | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |
+| APIKEY_PATH                 | Location where api keys are saved                                            | String                                           | `your-path/Flowise/packages/server` |
+| TOOL_FUNCTION_BUILTIN_DEP   | NodeJS built-in modules to be used for Tool Function                         | String                                           |                                     |
+| TOOL_FUNCTION_EXTERNAL_DEP  | External modules to be used for Tool Function                                | String                                           |                                     |     |
+| DATABASE_TYPE               | Type of database to store the flowise data                                   | Enum String: `sqlite`, `mysql`, `postgres`       | `sqlite`                            |
+| DATABASE_PATH               | Location where database is saved (When DATABASE_TYPE is sqlite)              | String                                           | `your-home-dir/.flowise`            |
+| DATABASE_HOST               | Host URL or IP address (When DATABASE_TYPE is not sqlite)                    | String                                           |                                     |
+| DATABASE_PORT               | Database port (When DATABASE_TYPE is not sqlite)                             | String                                           |                                     |
+| DATABASE_USER               | Database username (When DATABASE_TYPE is not sqlite)                         | String                                           |                                     |
+| DATABASE_PASSWORD           | Database password (When DATABASE_TYPE is not sqlite)                         | String                                           |                                     |
+| DATABASE_NAME               | Database name (When DATABASE_TYPE is not sqlite)                             | String                                           |                                     |
+| SECRETKEY_PATH              | Location where encryption key (used to encrypt/decrypt credentials) is saved | String                                           | `your-path/Flowise/packages/server` |
+| FLOWISE_SECRETKEY_OVERWRITE | Encryption key to be used instead of the key stored in SECRETKEY_PATH        | String                                           |
 
 You can also specify the env variables when using `npx`. For example:
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,5 +1,4 @@
 PORT=3000
-PASSPHRASE=MYPASSPHRASE # Passphrase used to create encryption key
 DATABASE_PATH=/root/.flowise
 APIKEY_PATH=/root/.flowise
 SECRETKEY_PATH=/root/.flowise
@@ -13,10 +12,10 @@ LOG_PATH=/root/.flowise/logs
 # DATABASE_NAME="flowise"
 # DATABASE_USER=""
 # DATABASE_PASSWORD=""
-# OVERRIDE_DATABASE=true
 
 # FLOWISE_USERNAME=user
 # FLOWISE_PASSWORD=1234
+# FLOWISE_SECRETKEY_OVERWRITE=myencryptionkey
 # DEBUG=true
 # LOG_LEVEL=debug (error | warn | info | verbose | debug)
 # TOOL_FUNCTION_BUILTIN_DEP=crypto,fs

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,13 +6,13 @@ services:
         restart: always
         environment:
             - PORT=${PORT}
-            - PASSPHRASE=${PASSPHRASE}
             - FLOWISE_USERNAME=${FLOWISE_USERNAME}
             - FLOWISE_PASSWORD=${FLOWISE_PASSWORD}
             - DEBUG=${DEBUG}
             - DATABASE_PATH=${DATABASE_PATH}
             - APIKEY_PATH=${APIKEY_PATH}
             - SECRETKEY_PATH=${SECRETKEY_PATH}
+            - FLOWISE_SECRETKEY_OVERWRITE=${FLOWISE_SECRETKEY_OVERWRITE}
             - LOG_LEVEL=${LOG_LEVEL}
             - LOG_PATH=${LOG_PATH}
         ports:

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -396,6 +396,9 @@ const getEncryptionKeyPath = (): string => {
  * @returns {Promise<string>}
  */
 const getEncryptionKey = async (): Promise<string> => {
+    if (process.env.FLOWISE_SECRETKEY_OVERWRITE !== undefined && process.env.FLOWISE_SECRETKEY_OVERWRITE !== '') {
+        return process.env.FLOWISE_SECRETKEY_OVERWRITE
+    }
     try {
         return await fs.promises.readFile(getEncryptionKeyPath(), 'utf8')
     } catch (error) {

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,5 +1,4 @@
 PORT=3000
-PASSPHRASE=MYPASSPHRASE # Passphrase used to create encryption key
 # DATABASE_PATH=/your_database_path/.flowise
 # APIKEY_PATH=/your_api_key_path/.flowise
 # SECRETKEY_PATH=/your_api_key_path/.flowise
@@ -13,10 +12,10 @@ PASSPHRASE=MYPASSPHRASE # Passphrase used to create encryption key
 # DATABASE_NAME="flowise"
 # DATABASE_USER=""
 # DATABASE_PASSWORD=""
-# OVERRIDE_DATABASE=true
 
 # FLOWISE_USERNAME=user
 # FLOWISE_PASSWORD=1234
+# FLOWISE_SECRETKEY_OVERWRITE=myencryptionkey
 # DEBUG=true
 # LOG_LEVEL=debug (error | warn | info | verbose | debug)
 # TOOL_FUNCTION_BUILTIN_DEP=crypto,fs

--- a/packages/server/README-ZH.md
+++ b/packages/server/README-ZH.md
@@ -35,26 +35,6 @@ FLOWISE_PASSWORD=1234
 
 Flowise 支持不同的环境变量来配置您的实例。您可以在`packages/server`文件夹中的`.env`文件中指定以下变量。阅读[更多](https://docs.flowiseai.com/environment-variables)
 
-| 变量                       | 描述                                                   | 类型                                            | 默认值                              |
-| -------------------------- | ------------------------------------------------------ | ----------------------------------------------- | ----------------------------------- |
-| PORT                       | Flowise 运行的 HTTP 端口                               | 数字                                            | 3000                                |
-| FLOWISE_USERNAME           | 登录的用户名                                           | 字符串                                          |                                     |
-| FLOWISE_PASSWORD           | 登录的密码                                             | 字符串                                          |                                     |
-| DEBUG                      | 打印组件的日志                                         | 布尔值                                          |                                     |
-| LOG_PATH                   | 存储日志文件的位置                                     | 字符串                                          | `your-path/Flowise/logs`            |
-| LOG_LEVEL                  | 日志的不同级别                                         | 枚举字符串：`error`、`info`、`verbose`、`debug` | `info`                              |
-| APIKEY_PATH                | 存储 API 密钥的位置                                    | 字符串                                          | `your-path/Flowise/packages/server` |
-| TOOL_FUNCTION_BUILTIN_DEP  | 用于工具函数的 NodeJS 内置模块                         | 字符串                                          |                                     |
-| TOOL_FUNCTION_EXTERNAL_DEP | 用于工具函数的外部模块                                 | 字符串                                          |                                     |
-| OVERRIDE_DATABASE          | 使用默认值覆盖当前数据库                               | 枚举字符串：`true`、`false`                     | `true`                              |
-| DATABASE_TYPE              | 存储 flowise 数据的数据库类型                          | 枚举字符串：`sqlite`、`mysql`、`postgres`       | `sqlite`                            |
-| DATABASE_PATH              | 数据库的保存位置（当 DATABASE_TYPE 为 sqlite 时）      | 字符串                                          | `your-home-dir/.flowise`            |
-| DATABASE_HOST              | 主机 URL 或 IP 地址（当 DATABASE_TYPE 不为 sqlite 时） | 字符串                                          |                                     |
-| DATABASE_PORT              | 数据库端口（当 DATABASE_TYPE 不为 sqlite 时）          | 字符串                                          |                                     |
-| DATABASE_USERNAME          | 数据库用户名（当 DATABASE_TYPE 不为 sqlite 时）        | 字符串                                          |                                     |
-| DATABASE_PASSWORD          | 数据库密码（当 DATABASE_TYPE 不为 sqlite 时）          | 字符串                                          |                                     |
-| DATABASE_NAME              | 数据库名称（当 DATABASE_TYPE 不为 sqlite 时）          | 字符串                                          |                                     |
-
 您还可以在使用`npx`时指定环境变量。例如：
 
 ```

--- a/packages/server/src/commands/start.ts
+++ b/packages/server/src/commands/start.ts
@@ -19,15 +19,14 @@ export default class Start extends Command {
         FLOWISE_USERNAME: Flags.string(),
         FLOWISE_PASSWORD: Flags.string(),
         PORT: Flags.string(),
-        PASSPHRASE: Flags.string(),
         DEBUG: Flags.string(),
         APIKEY_PATH: Flags.string(),
         SECRETKEY_PATH: Flags.string(),
+        FLOWISE_SECRETKEY_OVERWRITE: Flags.string(),
         LOG_PATH: Flags.string(),
         LOG_LEVEL: Flags.string(),
         TOOL_FUNCTION_BUILTIN_DEP: Flags.string(),
         TOOL_FUNCTION_EXTERNAL_DEP: Flags.string(),
-        OVERRIDE_DATABASE: Flags.string(),
         DATABASE_TYPE: Flags.string(),
         DATABASE_PATH: Flags.string(),
         DATABASE_PORT: Flags.string(),
@@ -80,8 +79,8 @@ export default class Start extends Command {
         if (flags.APIKEY_PATH) process.env.APIKEY_PATH = flags.APIKEY_PATH
 
         // Credentials
-        if (flags.PASSPHRASE) process.env.PASSPHRASE = flags.PASSPHRASE
         if (flags.SECRETKEY_PATH) process.env.SECRETKEY_PATH = flags.SECRETKEY_PATH
+        if (flags.FLOWISE_SECRETKEY_OVERWRITE) process.env.FLOWISE_SECRETKEY_OVERWRITE = flags.FLOWISE_SECRETKEY_OVERWRITE
 
         // Logs
         if (flags.LOG_PATH) process.env.LOG_PATH = flags.LOG_PATH
@@ -92,7 +91,6 @@ export default class Start extends Command {
         if (flags.TOOL_FUNCTION_EXTERNAL_DEP) process.env.TOOL_FUNCTION_EXTERNAL_DEP = flags.TOOL_FUNCTION_EXTERNAL_DEP
 
         // Database config
-        if (flags.OVERRIDE_DATABASE) process.env.OVERRIDE_DATABASE = flags.OVERRIDE_DATABASE
         if (flags.DATABASE_TYPE) process.env.DATABASE_TYPE = flags.DATABASE_TYPE
         if (flags.DATABASE_PATH) process.env.DATABASE_PATH = flags.DATABASE_PATH
         if (flags.DATABASE_PORT) process.env.DATABASE_PORT = flags.DATABASE_PORT

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -28,7 +28,7 @@ import {
     convertChatHistoryToText
 } from 'flowise-components'
 import { scryptSync, randomBytes, timingSafeEqual } from 'crypto'
-import { lib, PBKDF2, AES, enc } from 'crypto-js'
+import { AES, enc } from 'crypto-js'
 
 import { ChatFlow } from '../database/entities/ChatFlow'
 import { ChatMessage } from '../database/entities/ChatMessage'
@@ -814,12 +814,7 @@ export const getEncryptionKeyPath = (): string => {
  * @returns {string}
  */
 export const generateEncryptKey = (): string => {
-    const salt = lib.WordArray.random(128 / 8)
-    const key256Bits = PBKDF2(process.env.PASSPHRASE || 'MYPASSPHRASE', salt, {
-        keySize: 256 / 32,
-        iterations: 1000
-    })
-    return key256Bits.toString()
+    return randomBytes(24).toString('base64')
 }
 
 /**
@@ -827,6 +822,9 @@ export const generateEncryptKey = (): string => {
  * @returns {Promise<string>}
  */
 export const getEncryptionKey = async (): Promise<string> => {
+    if (process.env.FLOWISE_SECRETKEY_OVERWRITE !== undefined && process.env.FLOWISE_SECRETKEY_OVERWRITE !== '') {
+        return process.env.FLOWISE_SECRETKEY_OVERWRITE
+    }
     try {
         return await fs.promises.readFile(getEncryptionKeyPath(), 'utf8')
     } catch (error) {
@@ -868,7 +866,7 @@ export const decryptCredentialData = async (
         return JSON.parse(decryptedData.toString(enc.Utf8))
     } catch (e) {
         console.error(e)
-        throw new Error('Credentials could not be decrypted.')
+        return {}
     }
 }
 


### PR DESCRIPTION
- Ability to use `FLOWISE_SECRETKEY_OVERWRITE` to replace the key set in `SECRETKEY_PATH`. 
- Issues related:
  - https://github.com/FlowiseAI/Flowise/issues/915
  - https://github.com/FlowiseAI/Flowise/issues/643
  - https://github.com/FlowiseAI/Flowise/issues/896
  - https://twitter.com/_alissonryan/status/1702819282848031048 