### PR TITLE
Duplicate icon when market is empty

### DIFF
--- a/packages/ui/src/views/marketplaces/index.js
+++ b/packages/ui/src/views/marketplaces/index.js
@@ -175,19 +175,8 @@ const Marketplace = () => {
                         )}
                     </TabPanel>
                 ))}
-                {!isChatflowsLoading && (!getAllChatflowsMarketplacesApi.data || getAllChatflowsMarketplacesApi.data.length === 0) && (
-                    <Stack sx={{ alignItems: 'center', justifyContent: 'center' }} flexDirection='column'>
-                        <Box sx={{ p: 2, height: 'auto' }}>
-                            <img
-                                style={{ objectFit: 'cover', height: '30vh', width: 'auto' }}
-                                src={WorkflowEmptySVG}
-                                alt='WorkflowEmptySVG'
-                            />
-                        </Box>
-                        <div>No Marketplace Yet</div>
-                    </Stack>
-                )}
-                {!isToolsLoading && (!getAllToolsMarketplacesApi.data || getAllToolsMarketplacesApi.data.length === 0) && (
+                {((!isChatflowsLoading && (!getAllChatflowsMarketplacesApi.data || getAllChatflowsMarketplacesApi.data.length === 0)) ||
+                    (!isToolsLoading && (!getAllToolsMarketplacesApi.data || getAllToolsMarketplacesApi.data.length === 0))) && (
                     <Stack sx={{ alignItems: 'center', justifyContent: 'center' }} flexDirection='column'>
                         <Box sx={{ p: 2, height: 'auto' }}>
                             <img


### PR DESCRIPTION
See the snapshot:
<img width="986" alt="image" src="https://github.com/FlowiseAI/Flowise/assets/8669744/5b882c4c-8949-44ca-9e24-b6c20820cbf5">
