### PR TITLE
credential should be-rebuild eveytimes

### DIFF
--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -481,6 +481,7 @@ export const isStartNodeDependOnInput = (startingNodes: IReactFlowNode[], nodes:
             const inputVariables = getInputVariables(node.data.inputs[inputName])
             if (inputVariables.length > 0) return true
         }
+        if (Object.prototype.hasOwnProperty.call(node.data, 'credential')) return true
     }
     const whitelistNodeNames = ['vectorStoreToDocument', 'autoGPT']
     for (const node of nodes) {


### PR DESCRIPTION
When update the `credential` in `Credentials` page,  the `chatflow` will not rebuild, that's make the new `credential` not effected unless people click `save chatflow` button to make it `unsync`.

I think the chatflow with start node has `credential` should be rebuild every time.