### PR TITLE
Bugfix/Redis Backed Memory fix

### DIFF
--- a/packages/components/nodes/agents/ConversationalAgent/ConversationalAgent.ts
+++ b/packages/components/nodes/agents/ConversationalAgent/ConversationalAgent.ts
@@ -95,8 +95,12 @@ class ConversationalAgent_Agents implements INode {
         const callbacks = await additionalCallbacks(nodeData, options)
 
         if (options && options.chatHistory) {
-            memory.chatHistory = mapChatHistory(options)
-            executor.memory = memory
+            const chatHistoryClassName = memory.chatHistory.constructor.name
+            // Only replace when its In-Memory
+            if (chatHistoryClassName && chatHistoryClassName === 'ChatMessageHistory') {
+                memory.chatHistory = mapChatHistory(options)
+                executor.memory = memory
+            }
         }
 
         const result = await executor.call({ input }, [...callbacks])

--- a/packages/components/nodes/agents/ConversationalRetrievalAgent/ConversationalRetrievalAgent.ts
+++ b/packages/components/nodes/agents/ConversationalRetrievalAgent/ConversationalRetrievalAgent.ts
@@ -82,7 +82,11 @@ class ConversationalRetrievalAgent_Agents implements INode {
         if (executor.memory) {
             ;(executor.memory as any).memoryKey = 'chat_history'
             ;(executor.memory as any).outputKey = 'output'
-            ;(executor.memory as any).chatHistory = mapChatHistory(options)
+            const chatHistoryClassName = (executor.memory as any).chatHistory.constructor.name
+            // Only replace when its In-Memory
+            if (chatHistoryClassName && chatHistoryClassName === 'ChatMessageHistory') {
+                ;(executor.memory as any).chatHistory = mapChatHistory(options)
+            }
         }
 
         const loggerHandler = new ConsoleCallbackHandler(options.logger)

--- a/packages/components/nodes/agents/OpenAIFunctionAgent/OpenAIFunctionAgent.ts
+++ b/packages/components/nodes/agents/OpenAIFunctionAgent/OpenAIFunctionAgent.ts
@@ -81,8 +81,12 @@ class OpenAIFunctionAgent_Agents implements INode {
         const memory = nodeData.inputs?.memory as BaseChatMemory
 
         if (options && options.chatHistory) {
-            memory.chatHistory = mapChatHistory(options)
-            executor.memory = memory
+            const chatHistoryClassName = memory.chatHistory.constructor.name
+            // Only replace when its In-Memory
+            if (chatHistoryClassName && chatHistoryClassName === 'ChatMessageHistory') {
+                memory.chatHistory = mapChatHistory(options)
+                executor.memory = memory
+            }
         }
 
         const loggerHandler = new ConsoleCallbackHandler(options.logger)

--- a/packages/components/nodes/chains/ConversationChain/ConversationChain.ts
+++ b/packages/components/nodes/chains/ConversationChain/ConversationChain.ts
@@ -106,8 +106,12 @@ class ConversationChain_Chains implements INode {
         const memory = nodeData.inputs?.memory as BufferMemory
 
         if (options && options.chatHistory) {
-            memory.chatHistory = mapChatHistory(options)
-            chain.memory = memory
+            const chatHistoryClassName = memory.chatHistory.constructor.name
+            // Only replace when its In-Memory
+            if (chatHistoryClassName && chatHistoryClassName === 'ChatMessageHistory') {
+                memory.chatHistory = mapChatHistory(options)
+                chain.memory = memory
+            }
         }
 
         const loggerHandler = new ConsoleCallbackHandler(options.logger)

--- a/packages/components/nodes/chains/ConversationalRetrievalQAChain/ConversationalRetrievalQAChain.ts
+++ b/packages/components/nodes/chains/ConversationalRetrievalQAChain/ConversationalRetrievalQAChain.ts
@@ -179,7 +179,11 @@ class ConversationalRetrievalQAChain_Chains implements INode {
         const obj = { question: input }
 
         if (options && options.chatHistory && chain.memory) {
-            ;(chain.memory as any).chatHistory = mapChatHistory(options)
+            const chatHistoryClassName = (chain.memory as any).chatHistory.constructor.name
+            // Only replace when its In-Memory
+            if (chatHistoryClassName && chatHistoryClassName === 'ChatMessageHistory') {
+                ;(chain.memory as any).chatHistory = mapChatHistory(options)
+            }
         }
 
         const loggerHandler = new ConsoleCallbackHandler(options.logger)


### PR DESCRIPTION
Bug: when using RedisBackedChatMemory, the `chatHistory` is being override with `InMemory`, causing it not to work.
Fix: place a check to only replacing history if `InMemory` is being used.

`InMemory` nodes are `BufferMemory`, `BufferWindowMemory`, `ConversationSummaryMemory`