### PR TITLE
Text output for Text File and Plain Text components

### DIFF
--- a/packages/components/nodes/documentloaders/PlainText/PlainText.ts
+++ b/packages/components/nodes/documentloaders/PlainText/PlainText.ts
@@ -18,7 +18,7 @@ class PlainText_DocumentLoaders implements INode {
     constructor() {
         this.label = 'Plain Text'
         this.name = 'plainText'
-        this.version = 1.0
+        this.version = 2.0
         this.type = 'Document'
         this.icon = 'plaintext.svg'
         this.category = 'Document Loaders'

--- a/packages/components/nodes/documentloaders/PlainText/PlainText.ts
+++ b/packages/components/nodes/documentloaders/PlainText/PlainText.ts
@@ -1,6 +1,7 @@
-import { INode, INodeData, INodeParams } from '../../../src/Interface'
+import { INode, INodeData, INodeOutputsValue, INodeParams } from '../../../src/Interface'
 import { TextSplitter } from 'langchain/text_splitter'
 import { Document } from 'langchain/document'
+import { handleEscapeCharacters } from '../../../src'
 
 class PlainText_DocumentLoaders implements INode {
     label: string
@@ -12,6 +13,7 @@ class PlainText_DocumentLoaders implements INode {
     category: string
     baseClasses: string[]
     inputs: INodeParams[]
+    outputs: INodeOutputsValue[]
 
     constructor() {
         this.label = 'Plain Text'
@@ -45,12 +47,25 @@ class PlainText_DocumentLoaders implements INode {
                 additionalParams: true
             }
         ]
+        this.outputs = [
+            {
+                label: 'Document',
+                name: 'document',
+                baseClasses: this.baseClasses
+            },
+            {
+                label: 'Text',
+                name: 'text',
+                baseClasses: ['string', 'json']
+            }
+        ]
     }
 
     async init(nodeData: INodeData): Promise<any> {
         const textSplitter = nodeData.inputs?.textSplitter as TextSplitter
         const text = nodeData.inputs?.text as string
         const metadata = nodeData.inputs?.metadata
+        const output = nodeData.outputs?.output as string
 
         let alldocs: Document<Record<string, any>>[] = []
 
@@ -65,9 +80,9 @@ class PlainText_DocumentLoaders implements INode {
             )
         }
 
+        let finaldocs: Document<Record<string, any>>[] = []
         if (metadata) {
             const parsedMetadata = typeof metadata === 'object' ? metadata : JSON.parse(metadata)
-            let finaldocs: Document<Record<string, any>>[] = []
             for (const doc of alldocs) {
                 const newdoc = {
                     ...doc,
@@ -78,10 +93,19 @@ class PlainText_DocumentLoaders implements INode {
                 }
                 finaldocs.push(newdoc)
             }
-            return finaldocs
+        } else {
+            finaldocs = alldocs
         }
 
-        return alldocs
+        if (output === 'document') {
+            return finaldocs
+        } else {
+            let finaltext = ''
+            for (const doc of finaldocs) {
+                finaltext += `${doc.pageContent}\n`
+            }
+            return handleEscapeCharacters(finaltext, false)
+        }
     }
 }
 

--- a/packages/components/nodes/documentloaders/Text/Text.ts
+++ b/packages/components/nodes/documentloaders/Text/Text.ts
@@ -1,6 +1,8 @@
-import { INode, INodeData, INodeParams } from '../../../src/Interface'
+import { INode, INodeData, INodeOutputsValue, INodeParams } from '../../../src/Interface'
 import { TextSplitter } from 'langchain/text_splitter'
 import { TextLoader } from 'langchain/document_loaders/fs/text'
+import { Document } from 'langchain/document'
+import { handleEscapeCharacters } from '../../../src'
 
 class Text_DocumentLoaders implements INode {
     label: string
@@ -12,6 +14,7 @@ class Text_DocumentLoaders implements INode {
     category: string
     baseClasses: string[]
     inputs: INodeParams[]
+    outputs: INodeOutputsValue[]
 
     constructor() {
         this.label = 'Text File'
@@ -43,12 +46,25 @@ class Text_DocumentLoaders implements INode {
                 additionalParams: true
             }
         ]
+        this.outputs = [
+            {
+                label: 'Document',
+                name: 'document',
+                baseClasses: this.baseClasses
+            },
+            {
+                label: 'Text',
+                name: 'text',
+                baseClasses: ['string', 'json']
+            }
+        ]
     }
 
     async init(nodeData: INodeData): Promise<any> {
         const textSplitter = nodeData.inputs?.textSplitter as TextSplitter
         const txtFileBase64 = nodeData.inputs?.txtFile as string
         const metadata = nodeData.inputs?.metadata
+        const output = nodeData.outputs?.output as string
 
         let alldocs = []
         let files: string[] = []
@@ -75,9 +91,9 @@ class Text_DocumentLoaders implements INode {
             }
         }
 
+        let finaldocs: Document<Record<string, any>>[] = []
         if (metadata) {
             const parsedMetadata = typeof metadata === 'object' ? metadata : JSON.parse(metadata)
-            let finaldocs = []
             for (const doc of alldocs) {
                 const newdoc = {
                     ...doc,
@@ -88,9 +104,19 @@ class Text_DocumentLoaders implements INode {
                 }
                 finaldocs.push(newdoc)
             }
-            return finaldocs
+        } else {
+            finaldocs = alldocs
         }
-        return alldocs
+
+        if (output === 'document') {
+            return finaldocs
+        } else {
+            let finaltext = ''
+            for (const doc of finaldocs) {
+                finaltext += `${doc.pageContent}\n`
+            }
+            return handleEscapeCharacters(finaltext, false)
+        }
     }
 }
 

--- a/packages/components/nodes/documentloaders/Text/Text.ts
+++ b/packages/components/nodes/documentloaders/Text/Text.ts
@@ -19,7 +19,7 @@ class Text_DocumentLoaders implements INode {
     constructor() {
         this.label = 'Text File'
         this.name = 'textFile'
-        this.version = 1.0
+        this.version = 2.0
         this.type = 'Document'
         this.icon = 'textFile.svg'
         this.category = 'Document Loaders'


### PR DESCRIPTION
Added possibility to select "Text output" instead of "Document" for components "Text File" and "Plain Text". It allows to use the output directly as a value of a variable in prompt.

![Screenshot_20231010_164409](https://github.com/FlowiseAI/Flowise/assets/11959693/df79ac35-24a0-47b9-be0a-fb90cb7f6f07)
