### PR TITLE
Remove unnecessary Langfuse inputs

### DIFF
--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -238,9 +238,6 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                     })
                     callbacks.push(tracer)
                 } else if (provider === 'langFuse') {
-                    const flushAt = analytic[provider].flushAt as string
-                    const flushInterval = analytic[provider].flushInterval as string
-                    const requestTimeout = analytic[provider].requestTimeout as string
                     const release = analytic[provider].release as string
 
                     const langFuseSecretKey = getCredentialParam('langFuseSecretKey', credentialData, nodeData)
@@ -252,9 +249,6 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                         publicKey: langFusePublicKey,
                         baseUrl: langFuseEndpoint ?? 'https://cloud.langfuse.com'
                     }
-                    if (flushAt) langFuseOptions.flushAt = parseInt(flushAt, 10)
-                    if (flushInterval) langFuseOptions.flushInterval = parseInt(flushInterval, 10)
-                    if (requestTimeout) langFuseOptions.requestTimeout = parseInt(requestTimeout, 10)
                     if (release) langFuseOptions.release = release
 
                     const handler = new CallbackHandler(langFuseOptions)

--- a/packages/ui/src/ui-component/dialog/AnalyseFlowDialog.js
+++ b/packages/ui/src/ui-component/dialog/AnalyseFlowDialog.js
@@ -82,27 +82,6 @@ const analyticProviders = [
                 credentialNames: ['langfuseApi']
             },
             {
-                label: 'Flush At',
-                name: 'flushAt',
-                type: 'number',
-                optional: true,
-                description: 'Number of queued requests'
-            },
-            {
-                label: 'Flush Interval',
-                name: 'flushInterval',
-                type: 'number',
-                optional: true,
-                description: 'Interval in ms to flush requests'
-            },
-            {
-                label: 'Request Timeout',
-                name: 'requestTimeout',
-                type: 'number',
-                optional: true,
-                description: 'Timeout in ms for requests'
-            },
-            {
                 label: 'Release',
                 name: 'release',
                 type: 'string',


### PR DESCRIPTION
The optional inputs `flushAt`, `flushInterval` and `requestTimeout` only need to be changed in edge cases. I suggest to remove them from Flowise to simplify getting started with Langfuse.