### PR TITLE
fix: ChatPromptTemplate function name

### DIFF
--- a/packages/components/nodes/chains/ConversationChain/ConversationChain.ts
+++ b/packages/components/nodes/chains/ConversationChain/ConversationChain.ts
@@ -90,7 +90,7 @@ class ConversationChain_Chains implements INode {
             verbose: process.env.DEBUG === 'true' ? true : false
         }
 
-        const chatPrompt = ChatPromptTemplate.fromPromptMessages([
+        const chatPrompt = ChatPromptTemplate.fromMessages([
             SystemMessagePromptTemplate.fromTemplate(prompt ? `${prompt}\n${systemMessage}` : systemMessage),
             new MessagesPlaceholder(memory.memoryKey ?? 'chat_history'),
             HumanMessagePromptTemplate.fromTemplate('{input}')

--- a/packages/components/nodes/prompts/ChatPromptTemplate/ChatPromptTemplate.ts
+++ b/packages/components/nodes/prompts/ChatPromptTemplate/ChatPromptTemplate.ts
@@ -53,7 +53,7 @@ class ChatPromptTemplate_Prompts implements INode {
         const humanMessagePrompt = nodeData.inputs?.humanMessagePrompt as string
         const promptValuesStr = nodeData.inputs?.promptValues as string
 
-        const prompt = ChatPromptTemplate.fromPromptMessages([
+        const prompt = ChatPromptTemplate.fromMessages([
             SystemMessagePromptTemplate.fromTemplate(systemMessagePrompt),
             HumanMessagePromptTemplate.fromTemplate(humanMessagePrompt)
         ])


### PR DESCRIPTION
@deprecated — Renamed to .fromMessages

<img width="309" alt="Screen Shot 2023-10-16 at 6 48 57 pm" src="https://github.com/FlowiseAI/Flowise/assets/6112201/dd1da963-c68c-43e4-be15-614f3f0d89eb">
