### PR TITLE
Add Memory Node Input to Multi Prompt Chain

### DIFF
--- a/packages/components/nodes/chains/MultiPromptChain/MultiPromptChain.ts
+++ b/packages/components/nodes/chains/MultiPromptChain/MultiPromptChain.ts
@@ -35,6 +35,11 @@ class MultiPromptChain_Chains implements INode {
                 name: 'promptRetriever',
                 type: 'PromptRetriever',
                 list: true
+            },
+            {
+                label: 'Memory',
+                name: 'memory',
+                type: 'BaseMemory'
             }
         ]
     }


### PR DESCRIPTION
Expose the memory node input inside the Multi Prompt Chain. 

I didn't know how to hide the * as I assume this is label that signifies this is required? But I've done a test to see if its required and it doesn't seem to be.