### PR TITLE
Fix for #911, CRLF line endings, new fix.

### DIFF
--- a/packages/server/bin/.gitattributes
+++ b/packages/server/bin/.gitattributes
@@ -1,0 +1,2 @@
+dev eol=lf
+run eol=lf


### PR DESCRIPTION
As an alternative to the failed PR #1054 from me, I've created a new fix that simply adds `.gitattributes` to the folder where the `dev` and `run` scripts exist and no other changes.

This causes git to put the proper line endings when it touches the file. As a note, any existing clone will continue to fail to build Docker on Windows, but if the file is touched or the repo is re-cloned, it will work.

I tested this fix on both Windows and Linux Ubuntu 22.04.6 LTS Docker builds. In both cases it built, deployed and ran properly. So I am hoping this will fix #911 without further issues.