### PR TITLE
Bugfix/Chatflow API Authentication

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -809,18 +809,18 @@ export class App {
      * @param {Response} res
      * @param {ChatFlow} chatflow
      */
-    async validateKey(req: Request, res: Response, chatflow: ChatFlow) {
+    async validateKey(req: Request, chatflow: ChatFlow) {
         const chatFlowApiKeyId = chatflow.apikeyid
         const authorizationHeader = (req.headers['Authorization'] as string) ?? (req.headers['authorization'] as string) ?? ''
-
-        if (chatFlowApiKeyId && !authorizationHeader) return res.status(401).send(`Unauthorized`)
-
+        if (chatFlowApiKeyId && !authorizationHeader) return false
         const suppliedKey = authorizationHeader.split(`Bearer `).pop()
         if (chatFlowApiKeyId && suppliedKey) {
             const keys = await getAPIKeys()
             const apiSecret = keys.find((key) => key.id === chatFlowApiKeyId)?.apiSecret
-            if (!compareKeys(apiSecret, suppliedKey)) return res.status(401).send(`Unauthorized`)
+            if (!compareKeys(apiSecret, suppliedKey)) return false
+            return true
         }
+        return false
     }
 
     /**
@@ -846,7 +846,8 @@ export class App {
             if (!chatId) chatId = chatflowid
 
             if (!isInternal) {
-                await this.validateKey(req, res, chatflow)
+                const isKeyValidated = await this.validateKey(req, chatflow)
+                if (!isKeyValidated) return res.status(401).send('Unauthorized')
             }
 
             let isStreamValid = false


### PR DESCRIPTION
When authenticate chatflow with API in v1.3.8, error occurs due to incorrect return format.
Fix: Return boolean and proper error message