### PR TITLE
Bugfix/Add JSON parse fix

### DIFF
--- a/packages/components/nodes/prompts/ChatPromptTemplate/ChatPromptTemplate.ts
+++ b/packages/components/nodes/prompts/ChatPromptTemplate/ChatPromptTemplate.ts
@@ -51,7 +51,7 @@ class ChatPromptTemplate_Prompts implements INode {
     async init(nodeData: INodeData): Promise<any> {
         const systemMessagePrompt = nodeData.inputs?.systemMessagePrompt as string
         const humanMessagePrompt = nodeData.inputs?.humanMessagePrompt as string
-        const promptValuesStr = nodeData.inputs?.promptValues as string
+        const promptValuesStr = nodeData.inputs?.promptValues
 
         const prompt = ChatPromptTemplate.fromMessages([
             SystemMessagePromptTemplate.fromTemplate(systemMessagePrompt),
@@ -60,7 +60,11 @@ class ChatPromptTemplate_Prompts implements INode {
 
         let promptValues: ICommonObject = {}
         if (promptValuesStr) {
-            promptValues = JSON.parse(promptValuesStr)
+            try {
+                promptValues = typeof promptValuesStr === 'object' ? promptValuesStr : JSON.parse(promptValuesStr)
+            } catch (exception) {
+                throw new Error("Invalid JSON in the ChatPromptTemplate's promptValues: " + exception)
+            }
         }
         // @ts-ignore
         prompt.promptValues = promptValues

--- a/packages/components/nodes/prompts/FewShotPromptTemplate/FewShotPromptTemplate.ts
+++ b/packages/components/nodes/prompts/FewShotPromptTemplate/FewShotPromptTemplate.ts
@@ -80,7 +80,7 @@ class FewShotPromptTemplate_Prompts implements INode {
     }
 
     async init(nodeData: INodeData): Promise<any> {
-        const examplesStr = nodeData.inputs?.examples as string
+        const examplesStr = nodeData.inputs?.examples
         const prefix = nodeData.inputs?.prefix as string
         const suffix = nodeData.inputs?.suffix as string
         const exampleSeparator = nodeData.inputs?.exampleSeparator as string
@@ -88,7 +88,15 @@ class FewShotPromptTemplate_Prompts implements INode {
         const examplePrompt = nodeData.inputs?.examplePrompt as PromptTemplate
 
         const inputVariables = getInputVariables(suffix)
-        const examples: Example[] = JSON.parse(examplesStr)
+
+        let examples: Example[] = []
+        if (examplesStr) {
+            try {
+                examples = typeof examplesStr === 'object' ? examplesStr : JSON.parse(examplesStr)
+            } catch (exception) {
+                throw new Error("Invalid JSON in the FewShotPromptTemplate's examples: " + exception)
+            }
+        }
 
         try {
             const obj: FewShotPromptTemplateInput = {

--- a/packages/components/nodes/prompts/PromptTemplate/PromptTemplate.ts
+++ b/packages/components/nodes/prompts/PromptTemplate/PromptTemplate.ts
@@ -43,11 +43,15 @@ class PromptTemplate_Prompts implements INode {
 
     async init(nodeData: INodeData): Promise<any> {
         const template = nodeData.inputs?.template as string
-        const promptValuesStr = nodeData.inputs?.promptValues as string
+        const promptValuesStr = nodeData.inputs?.promptValues
 
         let promptValues: ICommonObject = {}
         if (promptValuesStr) {
-            promptValues = JSON.parse(promptValuesStr)
+            try {
+                promptValues = typeof promptValuesStr === 'object' ? promptValuesStr : JSON.parse(promptValuesStr)
+            } catch (exception) {
+                throw new Error("Invalid JSON in the PromptTemplate's promptValues: " + exception)
+            }
         }
 
         const inputVariables = getInputVariables(template)

--- a/packages/components/nodes/textsplitters/RecursiveCharacterTextSplitter/RecursiveCharacterTextSplitter.ts
+++ b/packages/components/nodes/textsplitters/RecursiveCharacterTextSplitter/RecursiveCharacterTextSplitter.ts
@@ -51,7 +51,7 @@ class RecursiveCharacterTextSplitter_TextSplitters implements INode {
     async init(nodeData: INodeData): Promise<any> {
         const chunkSize = nodeData.inputs?.chunkSize as string
         const chunkOverlap = nodeData.inputs?.chunkOverlap as string
-        const separators = nodeData.inputs?.separators as string
+        const separators = nodeData.inputs?.separators
 
         const obj = {} as RecursiveCharacterTextSplitterParams
 
@@ -59,7 +59,7 @@ class RecursiveCharacterTextSplitter_TextSplitters implements INode {
         if (chunkOverlap) obj.chunkOverlap = parseInt(chunkOverlap, 10)
         if (separators) {
             try {
-                obj.separators = JSON.parse(separators)
+                obj.separators = typeof separators === 'object' ? separators : JSON.parse(separators)
             } catch (e) {
                 throw new Error(e)
             }


### PR DESCRIPTION
Currently when using `overrideConfig` for json object, it causes error:
```
"overrideConfig": {
        "promptValues": {
            "input_language": "English",
            "output_language": "Italian"
        }
    }
```
Fix: only parse it when it is a string