### PR TITLE
Build error fixed (TS)

### DIFF
--- a/packages/components/nodes/vectorstores/Milvus/Milvus_Upsert.ts
+++ b/packages/components/nodes/vectorstores/Milvus/Milvus_Upsert.ts
@@ -252,7 +252,7 @@ class MilvusUpsert extends Milvus {
             collection_name: this.collectionName
         })
 
-        if (descIndexResp.status.error_code === ErrorCode.INDEX_NOT_EXIST) {
+        if (descIndexResp.status.error_code === ErrorCode.IndexNotExist) {
             const resp = await this.client.createIndex({
                 collection_name: this.collectionName,
                 field_name: this.vectorField,


### PR DESCRIPTION
Error: "Property 'INDEX_NOT_EXIST' does not exist on type 'typeof ErrorCode'. Did you mean 'IndexNotExist'?ts(2551)
error.d.ts(39, 5): 'IndexNotExist' is declared here."
in "packages/components/nodes/vectorstores/Milvus/Milvus_Upsert.ts".

Fixed: Replaced INDEX_NOT_EXIST with IndexNotExist

issue described here: #1135