### PR TITLE
Fix  "'INDEX_NOT_EXIST' does not exist" error in Milvus_Upsert.ts

### DIFF
--- a/packages/components/nodes/vectorstores/Milvus/Milvus_Upsert.ts
+++ b/packages/components/nodes/vectorstores/Milvus/Milvus_Upsert.ts
@@ -252,7 +252,7 @@ class MilvusUpsert extends Milvus {
             collection_name: this.collectionName
         })
 
-        if (descIndexResp.status.error_code === ErrorCode.INDEX_NOT_EXIST) {
+        if (descIndexResp.status.error_code === ErrorCode.IndexNotExist) {
             const resp = await this.client.createIndex({
                 collection_name: this.collectionName,
                 field_name: this.vectorField,


### PR DESCRIPTION
When I tried to run `yarn build` I was getting this error. 
![image](https://github.com/FlowiseAI/Flowise/assets/851664/5c3a18f4-d72c-4546-81d6-e58aad0ac7d5)

nodes/vectorstores/Milvus/Milvus_Upsert.ts(255,59): error TS2551: Property 'INDEX_NOT_EXIST' does not exist on type 'typeof ErrorCode'. Did you mean 'IndexNotExist'?

Probably just something that someone forgot while doing a refactor in the code.

After that change, build success:
![image](https://github.com/FlowiseAI/Flowise/assets/851664/7ed8900c-f3a3-4d3c-9f63-9733f2658c03)
