### PR TITLE
Adding support for subpath hosting.

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,4 +1,5 @@
 PORT=3000
+# SUBPATH=/chatbot
 # DATABASE_PATH=/your_database_path/.flowise
 # APIKEY_PATH=/your_api_key_path/.flowise
 # SECRETKEY_PATH=/your_api_key_path/.flowise

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -149,10 +149,13 @@ export class App {
 
         const upload = multer({ dest: `${path.join(__dirname, '..', 'uploads')}/` })
 
+        // Use an index router for the API calls so they can be mapped to the primary path.
+        var indexRouter = express.Router()
+
         // ----------------------------------------
         // Configure number of proxies in Host Environment
         // ----------------------------------------
-        this.app.get('/api/v1/ip', (request, response) => {
+        indexRouter.get('/api/v1/ip', (request, response) => {
             response.send({
                 ip: request.ip,
                 msg: 'See the returned IP address in the response. If it matches your current IP address ( which you can get by going to http://ip.nfriedly.com/ or https://api.ipify.org/ ), then the number of proxies is correct and the rate limiter should now work correctly. If not, increase the number of proxies by 1 until the IP address matches your own. Visit https://docs.flowiseai.com/deployment#rate-limit-setup-guide for more information.'
@@ -164,7 +167,7 @@ export class App {
         // ----------------------------------------
 
         // Get all component nodes
-        this.app.get('/api/v1/nodes', (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/nodes', (req: Request, res: Response) => {
             const returnData = []
             for (const nodeName in this.nodesPool.componentNodes) {
                 const clonedNode = cloneDeep(this.nodesPool.componentNodes[nodeName])
@@ -174,7 +177,7 @@ export class App {
         })
 
         // Get all component credentials
-        this.app.get('/api/v1/components-credentials', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/components-credentials', async (req: Request, res: Response) => {
             const returnData = []
             for (const credName in this.nodesPool.componentCredentials) {
                 const clonedCred = cloneDeep(this.nodesPool.componentCredentials[credName])
@@ -184,7 +187,7 @@ export class App {
         })
 
         // Get specific component node via name
-        this.app.get('/api/v1/nodes/:name', (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/nodes/:name', (req: Request, res: Response) => {
             if (Object.prototype.hasOwnProperty.call(this.nodesPool.componentNodes, req.params.name)) {
                 return res.json(this.nodesPool.componentNodes[req.params.name])
             } else {
@@ -193,7 +196,7 @@ export class App {
         })
 
         // Get component credential via name
-        this.app.get('/api/v1/components-credentials/:name', (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/components-credentials/:name', (req: Request, res: Response) => {
             if (!req.params.name.includes('&')) {
                 if (Object.prototype.hasOwnProperty.call(this.nodesPool.componentCredentials, req.params.name)) {
                     return res.json(this.nodesPool.componentCredentials[req.params.name])
@@ -214,7 +217,7 @@ export class App {
         })
 
         // Returns specific component node icon via name
-        this.app.get('/api/v1/node-icon/:name', (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/node-icon/:name', (req: Request, res: Response) => {
             if (Object.prototype.hasOwnProperty.call(this.nodesPool.componentNodes, req.params.name)) {
                 const nodeInstance = this.nodesPool.componentNodes[req.params.name]
                 if (nodeInstance.icon === undefined) {
@@ -233,7 +236,7 @@ export class App {
         })
 
         // Returns specific component credential icon via name
-        this.app.get('/api/v1/components-credentials-icon/:name', (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/components-credentials-icon/:name', (req: Request, res: Response) => {
             if (Object.prototype.hasOwnProperty.call(this.nodesPool.componentCredentials, req.params.name)) {
                 const credInstance = this.nodesPool.componentCredentials[req.params.name]
                 if (credInstance.icon === undefined) {
@@ -252,7 +255,7 @@ export class App {
         })
 
         // load async options
-        this.app.post('/api/v1/node-load-method/:name', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/node-load-method/:name', async (req: Request, res: Response) => {
             const nodeData: INodeData = req.body
             if (Object.prototype.hasOwnProperty.call(this.nodesPool.componentNodes, req.params.name)) {
                 try {
@@ -279,13 +282,13 @@ export class App {
         // ----------------------------------------
 
         // Get all chatflows
-        this.app.get('/api/v1/chatflows', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/chatflows', async (req: Request, res: Response) => {
             const chatflows: IChatFlow[] = await getAllChatFlow()
             return res.json(chatflows)
         })
 
         // Get specific chatflow via api key
-        this.app.get('/api/v1/chatflows/apikey/:apiKey', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/chatflows/apikey/:apiKey', async (req: Request, res: Response) => {
             try {
                 const apiKey = await getApiKey(req.params.apiKey)
                 if (!apiKey) return res.status(401).send('Unauthorized')
@@ -304,7 +307,7 @@ export class App {
         })
 
         // Get specific chatflow via id
-        this.app.get('/api/v1/chatflows/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/chatflows/:id', async (req: Request, res: Response) => {
             const chatflow = await this.AppDataSource.getRepository(ChatFlow).findOneBy({
                 id: req.params.id
             })
@@ -313,7 +316,7 @@ export class App {
         })
 
         // Get specific chatflow via id (PUBLIC endpoint, used when sharing chatbot link)
-        this.app.get('/api/v1/public-chatflows/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/public-chatflows/:id', async (req: Request, res: Response) => {
             const chatflow = await this.AppDataSource.getRepository(ChatFlow).findOneBy({
                 id: req.params.id
             })
@@ -323,7 +326,7 @@ export class App {
         })
 
         // Save chatflow
-        this.app.post('/api/v1/chatflows', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/chatflows', async (req: Request, res: Response) => {
             const body = req.body
             const newChatFlow = new ChatFlow()
             Object.assign(newChatFlow, body)
@@ -335,7 +338,7 @@ export class App {
         })
 
         // Update chatflow
-        this.app.put('/api/v1/chatflows/:id', async (req: Request, res: Response) => {
+        indexRouter.put('/api/v1/chatflows/:id', async (req: Request, res: Response) => {
             const chatflow = await this.AppDataSource.getRepository(ChatFlow).findOneBy({
                 id: req.params.id
             })
@@ -362,13 +365,13 @@ export class App {
         })
 
         // Delete chatflow via id
-        this.app.delete('/api/v1/chatflows/:id', async (req: Request, res: Response) => {
+        indexRouter.delete('/api/v1/chatflows/:id', async (req: Request, res: Response) => {
             const results = await this.AppDataSource.getRepository(ChatFlow).delete({ id: req.params.id })
             return res.json(results)
         })
 
         // Check if chatflow valid for streaming
-        this.app.get('/api/v1/chatflows-streaming/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/chatflows-streaming/:id', async (req: Request, res: Response) => {
             const chatflow = await this.AppDataSource.getRepository(ChatFlow).findOneBy({
                 id: req.params.id
             })
@@ -402,7 +405,7 @@ export class App {
         // ----------------------------------------
 
         // Get all chatmessages from chatflowid
-        this.app.get('/api/v1/chatmessage/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/chatmessage/:id', async (req: Request, res: Response) => {
             const sortOrder = req.query?.order as string | undefined
             const chatId = req.query?.chatId as string | undefined
             const memoryType = req.query?.memoryType as string | undefined
@@ -440,20 +443,20 @@ export class App {
         })
 
         // Get internal chatmessages from chatflowid
-        this.app.get('/api/v1/internal-chatmessage/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/internal-chatmessage/:id', async (req: Request, res: Response) => {
             const chatmessages = await this.getChatMessage(req.params.id, chatType.INTERNAL)
             return res.json(chatmessages)
         })
 
         // Add chatmessages for chatflowid
-        this.app.post('/api/v1/chatmessage/:id', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/chatmessage/:id', async (req: Request, res: Response) => {
             const body = req.body
             const results = await this.addChatMessage(body)
             return res.json(results)
         })
 
         // Delete all chatmessages from chatId
-        this.app.delete('/api/v1/chatmessage/:id', async (req: Request, res: Response) => {
+        indexRouter.delete('/api/v1/chatmessage/:id', async (req: Request, res: Response) => {
             const chatflowid = req.params.id
             const chatflow = await this.AppDataSource.getRepository(ChatFlow).findOneBy({
                 id: chatflowid
@@ -499,7 +502,7 @@ export class App {
         // ----------------------------------------
 
         // Create new credential
-        this.app.post('/api/v1/credentials', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/credentials', async (req: Request, res: Response) => {
             const body = req.body
             const newCredential = await transformToCredentialEntity(body)
             const credential = this.AppDataSource.getRepository(Credential).create(newCredential)
@@ -508,7 +511,7 @@ export class App {
         })
 
         // Get all credentials
-        this.app.get('/api/v1/credentials', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/credentials', async (req: Request, res: Response) => {
             if (req.query.credentialName) {
                 let returnCredentials = []
                 if (Array.isArray(req.query.credentialName)) {
@@ -537,7 +540,7 @@ export class App {
         })
 
         // Get specific credential
-        this.app.get('/api/v1/credentials/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/credentials/:id', async (req: Request, res: Response) => {
             const credential = await this.AppDataSource.getRepository(Credential).findOneBy({
                 id: req.params.id
             })
@@ -558,7 +561,7 @@ export class App {
         })
 
         // Update credential
-        this.app.put('/api/v1/credentials/:id', async (req: Request, res: Response) => {
+        indexRouter.put('/api/v1/credentials/:id', async (req: Request, res: Response) => {
             const credential = await this.AppDataSource.getRepository(Credential).findOneBy({
                 id: req.params.id
             })
@@ -574,7 +577,7 @@ export class App {
         })
 
         // Delete all chatmessages from chatflowid
-        this.app.delete('/api/v1/credentials/:id', async (req: Request, res: Response) => {
+        indexRouter.delete('/api/v1/credentials/:id', async (req: Request, res: Response) => {
             const results = await this.AppDataSource.getRepository(Credential).delete({ id: req.params.id })
             return res.json(results)
         })
@@ -584,13 +587,13 @@ export class App {
         // ----------------------------------------
 
         // Get all tools
-        this.app.get('/api/v1/tools', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/tools', async (req: Request, res: Response) => {
             const tools = await this.AppDataSource.getRepository(Tool).find()
             return res.json(tools)
         })
 
         // Get specific tool
-        this.app.get('/api/v1/tools/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/tools/:id', async (req: Request, res: Response) => {
             const tool = await this.AppDataSource.getRepository(Tool).findOneBy({
                 id: req.params.id
             })
@@ -598,7 +601,7 @@ export class App {
         })
 
         // Add tool
-        this.app.post('/api/v1/tools', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/tools', async (req: Request, res: Response) => {
             const body = req.body
             const newTool = new Tool()
             Object.assign(newTool, body)
@@ -610,7 +613,7 @@ export class App {
         })
 
         // Update tool
-        this.app.put('/api/v1/tools/:id', async (req: Request, res: Response) => {
+        indexRouter.put('/api/v1/tools/:id', async (req: Request, res: Response) => {
             const tool = await this.AppDataSource.getRepository(Tool).findOneBy({
                 id: req.params.id
             })
@@ -631,7 +634,7 @@ export class App {
         })
 
         // Delete tool
-        this.app.delete('/api/v1/tools/:id', async (req: Request, res: Response) => {
+        indexRouter.delete('/api/v1/tools/:id', async (req: Request, res: Response) => {
             const results = await this.AppDataSource.getRepository(Tool).delete({ id: req.params.id })
             return res.json(results)
         })
@@ -965,7 +968,7 @@ export class App {
         // Configuration
         // ----------------------------------------
 
-        this.app.get('/api/v1/flow-config/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/flow-config/:id', async (req: Request, res: Response) => {
             const chatflow = await this.AppDataSource.getRepository(ChatFlow).findOneBy({
                 id: req.params.id
             })
@@ -977,13 +980,13 @@ export class App {
             return res.json(availableConfigs)
         })
 
-        this.app.post('/api/v1/node-config', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/node-config', async (req: Request, res: Response) => {
             const nodes = [{ data: req.body }] as IReactFlowNode[]
             const availableConfigs = findAvailableConfigs(nodes, this.nodesPool.componentCredentials)
             return res.json(availableConfigs)
         })
 
-        this.app.get('/api/v1/version', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/version', async (req: Request, res: Response) => {
             const getPackageJsonPath = (): string => {
                 const checkPaths = [
                     path.join(__dirname, '..', 'package.json'),
@@ -1015,7 +1018,7 @@ export class App {
         // Export Load Chatflow & ChatMessage & Apikeys
         // ----------------------------------------
 
-        this.app.get('/api/v1/database/export', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/database/export', async (req: Request, res: Response) => {
             const chatmessages = await this.AppDataSource.getRepository(ChatMessage).find()
             const chatflows = await this.AppDataSource.getRepository(ChatFlow).find()
             const apikeys = await getAPIKeys()
@@ -1027,7 +1030,7 @@ export class App {
             return res.json(result)
         })
 
-        this.app.post('/api/v1/database/load', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/database/load', async (req: Request, res: Response) => {
             const databaseItems: IDatabaseExport = req.body
 
             await this.AppDataSource.getRepository(ChatFlow).delete({})
@@ -1067,7 +1070,7 @@ export class App {
         // ----------------------------------------
 
         // Send input message and get prediction result (External)
-        this.app.post(
+        indexRouter.post(
             '/api/v1/prediction/:id',
             upload.array('files'),
             (req: Request, res: Response, next: NextFunction) => getRateLimiter(req, res, next),
@@ -1077,7 +1080,7 @@ export class App {
         )
 
         // Send input message and get prediction result (Internal)
-        this.app.post('/api/v1/internal-prediction/:id', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/internal-prediction/:id', async (req: Request, res: Response) => {
             await this.processPrediction(req, res, socketIO, true)
         })
 
@@ -1086,7 +1089,7 @@ export class App {
         // ----------------------------------------
 
         // Get all chatflows for marketplaces
-        this.app.get('/api/v1/marketplaces/chatflows', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/marketplaces/chatflows', async (req: Request, res: Response) => {
             const marketplaceDir = path.join(__dirname, '..', 'marketplaces', 'chatflows')
             const jsonsInDir = fs.readdirSync(marketplaceDir).filter((file) => path.extname(file) === '.json')
             const templates: any[] = []
@@ -1113,7 +1116,7 @@ export class App {
         })
 
         // Get all tools for marketplaces
-        this.app.get('/api/v1/marketplaces/tools', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/marketplaces/tools', async (req: Request, res: Response) => {
             const marketplaceDir = path.join(__dirname, '..', 'marketplaces', 'tools')
             const jsonsInDir = fs.readdirSync(marketplaceDir).filter((file) => path.extname(file) === '.json')
             const templates: any[] = []
@@ -1136,31 +1139,31 @@ export class App {
         // ----------------------------------------
 
         // Get api keys
-        this.app.get('/api/v1/apikey', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/apikey', async (req: Request, res: Response) => {
             const keys = await getAPIKeys()
             return res.json(keys)
         })
 
         // Add new api key
-        this.app.post('/api/v1/apikey', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/apikey', async (req: Request, res: Response) => {
             const keys = await addAPIKey(req.body.keyName)
             return res.json(keys)
         })
 
         // Update api key
-        this.app.put('/api/v1/apikey/:id', async (req: Request, res: Response) => {
+        indexRouter.put('/api/v1/apikey/:id', async (req: Request, res: Response) => {
             const keys = await updateAPIKey(req.params.id, req.body.keyName)
             return res.json(keys)
         })
 
         // Delete new api key
-        this.app.delete('/api/v1/apikey/:id', async (req: Request, res: Response) => {
+        indexRouter.delete('/api/v1/apikey/:id', async (req: Request, res: Response) => {
             const keys = await deleteAPIKey(req.params.id)
             return res.json(keys)
         })
 
         // Verify api key
-        this.app.get('/api/v1/verify/apikey/:apiKey', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/verify/apikey/:apiKey', async (req: Request, res: Response) => {
             try {
                 const apiKey = await getApiKey(req.params.apiKey)
                 if (!apiKey) return res.status(401).send('Unauthorized')
@@ -1178,7 +1181,11 @@ export class App {
         const uiBuildPath = path.join(packagePath, 'build')
         const uiHtmlPath = path.join(packagePath, 'build', 'index.html')
 
-        this.app.use('/', express.static(uiBuildPath))
+        // Get the subpath from the environment, or assume it's at the root.
+        const appPath = process.env.SUBPATH ?? '/'
+
+        this.app.use(appPath, express.static(uiBuildPath))
+        this.app.use(appPath, indexRouter)
 
         // All other requests not handled will return React app
         this.app.use((req, res) => {
@@ -1550,9 +1557,11 @@ export async function start(): Promise<void> {
     serverApp = new App()
 
     const port = parseInt(process.env.PORT || '', 10) || 3000
+    const subpath = process.env.SUBPATH ? process.env.SUBPATH + '/socket.io' : ''
     const server = http.createServer(serverApp.app)
 
     const io = new Server(server, {
+        path: subpath,
         cors: {
             origin: '*'
         }
@@ -1562,7 +1571,7 @@ export async function start(): Promise<void> {
     await serverApp.config(io)
 
     server.listen(port, () => {
-        logger.info(`⚡️ [server]: Flowise Server is listening at ${port}`)
+        logger.info(`⚡️ [server]: Flowise Server is listening at ${port}${process.env.SUBPATH ?? ''}`)
     })
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -644,13 +644,13 @@ export class App {
         // ----------------------------------------
 
         // Get all assistants
-        this.app.get('/api/v1/assistants', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/assistants', async (req: Request, res: Response) => {
             const assistants = await this.AppDataSource.getRepository(Assistant).find()
             return res.json(assistants)
         })
 
         // Get specific assistant
-        this.app.get('/api/v1/assistants/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/assistants/:id', async (req: Request, res: Response) => {
             const assistant = await this.AppDataSource.getRepository(Assistant).findOneBy({
                 id: req.params.id
             })
@@ -658,7 +658,7 @@ export class App {
         })
 
         // Get assistant object
-        this.app.get('/api/v1/openai-assistants/:id', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/openai-assistants/:id', async (req: Request, res: Response) => {
             const credentialId = req.query.credential as string
             const credential = await this.AppDataSource.getRepository(Credential).findOneBy({
                 id: credentialId
@@ -684,7 +684,7 @@ export class App {
         })
 
         // List available assistants
-        this.app.get('/api/v1/openai-assistants', async (req: Request, res: Response) => {
+        indexRouter.get('/api/v1/openai-assistants', async (req: Request, res: Response) => {
             const credentialId = req.query.credential as string
             const credential = await this.AppDataSource.getRepository(Credential).findOneBy({
                 id: credentialId
@@ -704,7 +704,7 @@ export class App {
         })
 
         // Add assistant
-        this.app.post('/api/v1/assistants', async (req: Request, res: Response) => {
+        indexRouter.post('/api/v1/assistants', async (req: Request, res: Response) => {
             const body = req.body
 
             if (!body.details) return res.status(500).send(`Invalid request body`)
@@ -819,7 +819,7 @@ export class App {
         })
 
         // Update assistant
-        this.app.put('/api/v1/assistants/:id', async (req: Request, res: Response) => {
+        indexRouter.put('/api/v1/assistants/:id', async (req: Request, res: Response) => {
             const assistant = await this.AppDataSource.getRepository(Assistant).findOneBy({
                 id: req.params.id
             })
@@ -927,7 +927,7 @@ export class App {
         })
 
         // Delete assistant
-        this.app.delete('/api/v1/assistants/:id', async (req: Request, res: Response) => {
+        indexRouter.delete('/api/v1/assistants/:id', async (req: Request, res: Response) => {
             const assistant = await this.AppDataSource.getRepository(Assistant).findOneBy({
                 id: req.params.id
             })

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import App from './App'
 import { store } from 'store'
 import { createRoot } from 'react-dom/client'
+import { subpath } from './store/constant'
 
 // style + assets
 import 'assets/scss/style.scss'
@@ -19,7 +20,7 @@ const root = createRoot(container)
 root.render(
     <React.StrictMode>
         <Provider store={store}>
-            <BrowserRouter>
+            <BrowserRouter basename={subpath}>
                 <SnackbarProvider>
                     <ConfirmContextProvider>
                         <ReactFlowContext>

--- a/packages/ui/src/store/constant.js
+++ b/packages/ui/src/store/constant.js
@@ -3,7 +3,8 @@ export const gridSpacing = 3
 export const drawerWidth = 260
 export const appDrawerWidth = 320
 export const maxScroll = 100000
-export const baseURL = process.env.NODE_ENV === 'production' ? window.location.origin : window.location.origin.replace(':8080', ':3000')
-export const uiBaseURL = window.location.origin
+export const subpath = process.env.PUBLIC_URL
+export const coreURL = process.env.NODE_ENV === 'production' ? window.location.origin : window.location.origin.replace(':8080', ':3000')
+export const baseURL = coreURL + subpath
 export const FLOWISE_CREDENTIAL_ID = 'FLOWISE_CREDENTIAL_ID'
 export const REDACTED_CREDENTIAL_VALUE = '_FLOWISE_BLANK_07167752-1a71-43b1-bf8f-4f32252165db'

--- a/packages/ui/src/views/canvas/CanvasHeader.js
+++ b/packages/ui/src/views/canvas/CanvasHeader.js
@@ -25,7 +25,7 @@ import useApi from 'hooks/useApi'
 
 // utils
 import { generateExportFlowData } from 'utils/genericHelper'
-import { uiBaseURL } from 'store/constant'
+import { baseURL } from 'store/constant'
 import { SET_CHATFLOW } from 'store/actions'
 
 // ==============================|| CANVAS HEADER ||============================== //
@@ -71,7 +71,7 @@ const CanvasHeader = ({ chatflow, handleSaveFlow, handleDeleteFlow, handleLoadFl
         } else if (setting === 'duplicateChatflow') {
             try {
                 localStorage.setItem('duplicatedFlowData', chatflow.flowData)
-                window.open(`${uiBaseURL}/canvas`, '_blank')
+                window.open(`${baseURL}/canvas`, '_blank')
             } catch (e) {
                 console.error(e)
             }

--- a/packages/ui/src/views/chatmessage/ChatMessage.js
+++ b/packages/ui/src/views/chatmessage/ChatMessage.js
@@ -27,7 +27,7 @@ import predictionApi from 'api/prediction'
 import useApi from 'hooks/useApi'
 
 // Const
-import { baseURL, maxScroll } from 'store/constant'
+import { coreURL, maxScroll, subpath } from 'store/constant'
 
 import robotPNG from 'assets/images/robot.png'
 import userPNG from 'assets/images/account.png'
@@ -220,7 +220,7 @@ export const ChatMessage = ({ open, chatflowid, isDialog }) => {
             getIsChatflowStreamingApi.request(chatflowid)
             scrollToBottom()
 
-            socket = socketIOClient(baseURL)
+            socket = socketIOClient(coreURL, { path: subpath + '/socket.io' })
 
             socket.on('connect', () => {
                 setSocketIOClientId(socket.id)


### PR DESCRIPTION
This PR works in conjunction with https://github.com/FlowiseAI/FlowiseChatEmbed/pull/46 to add subpath support to Flowise.

Subpath support is when Flowise is hosted via reverse proxy or otherwise not at `/`, but rather at a subpath such as `/chatbot`.

Previously if you followed React router guides and [best practices](https://create-react-app.dev/docs/deployment/#building-for-relative-paths), such as [this example](https://colekillian.com/posts/serving-a-react-app-on-a-subroute-with-express/), it would not work. With this PR it will by making the following changes in your local environment to enable it (if desired):

1. Edit `package.json` as documented by React router and set the `homepage` to your subpath, for example `"homepage": "/chatbot"`. Do this for every `package.json` file
2. Make a copy of the `.env.example` file in the `server` folder as `.env`, and uncomment the `SUBPATH` line and set the subpath to match the `package.json` file

After making these changes, run `yarn build` again and notice the following output:

> flowise-ui:build: The project was built assuming it is hosted at /chatbot/.

Then run `yarn start` and notice the following output:

> 2023-11-02 22:10:46 [INFO]: ⚡️ [server]: Flowise Server is listening at 3000/chatbot

In this example, you would now access Flowise via `http://localhost:3000/chatbot` and it will work correctly.

As usual, by default Flowise continues to be hosted at `/` with no loss or change in behaviour or functionality. This PR simply enables the possibility of hosting on a subpath. Unfortunately with React router in this deployment the decision must be made at build-time, not run-time (the `.` won't work for homepage in this case). However, at least it is possible.