### PR TITLE
Adding ability to hide node param from UI

### DIFF
--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -72,6 +72,7 @@ export interface INodeParams {
     fileType?: string
     additionalParams?: boolean
     loadMethod?: string
+    hidden?: boolean
 }
 
 export interface INodeExecutionData {

--- a/packages/ui/src/views/canvas/CanvasNode.js
+++ b/packages/ui/src/views/canvas/CanvasNode.js
@@ -207,9 +207,11 @@ const CanvasNode = ({ data }) => {
                         {data.inputAnchors.map((inputAnchor, index) => (
                             <NodeInputHandler key={index} inputAnchor={inputAnchor} data={data} />
                         ))}
-                        {data.inputParams.map((inputParam, index) => (
-                            <NodeInputHandler key={index} inputParam={inputParam} data={data} />
-                        ))}
+                        {data.inputParams
+                            .filter((inputParam) => !inputParam.hidden)
+                            .map((inputParam, index) => (
+                                <NodeInputHandler key={index} inputParam={inputParam} data={data} />
+                            ))}
                         {data.inputParams.find((param) => param.additionalParams) && (
                             <div
                                 style={{


### PR DESCRIPTION
This feature adds the ability for node params to mark themselves as `hidden` from the UI.

This is required for nodes which don't have static API credentials, but rather have session context tokens or otherwise that are dependent and change when the chatbot is embedded, and should not be set in the UI.

These params can still be targeted and passed a value through `chatflowConfig` options. In addition, the `i` info button continues to show these parameters inside of `NodeInfoDialog` so that developers know they exist.