### PR TITLE
GitGuardian - Fix for MongoDB False Positive Alert

### DIFF
--- a/packages/components/credentials/MongoDBUrlApi.credential.ts
+++ b/packages/components/credentials/MongoDBUrlApi.credential.ts
@@ -16,7 +16,7 @@ class MongoDBUrlApi implements INodeCredential {
                 label: 'ATLAS Connection URL',
                 name: 'mongoDBConnectUrl',
                 type: 'string',
-                placeholder: 'mongodb+srv://myDatabaseUser:D1fficultP%40ssw0rd@cluster0.example.mongodb.net/?retryWrites=true&w=majority'
+                placeholder: 'mongodb+srv://<user>:<pwd>@cluster0.example.mongodb.net/?retryWrites=true&w=majority'
             }
         ]
     }


### PR DESCRIPTION
The placeholder url raises a false positive on GitGuardian (leakage of MongoDB secrets). 