### PR TITLE
Bugfix/Empty ChatHistory

### DIFF
--- a/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
+++ b/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
@@ -85,43 +85,46 @@ class OpenAIAssistant_Agents implements INode {
         return null
     }
 
-    async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
-        const selectedAssistantId = nodeData.inputs?.selectedAssistant as string
-        const appDataSource = options.appDataSource as DataSource
-        const databaseEntities = options.databaseEntities as IDatabaseEntity
-        let sessionId = nodeData.inputs?.sessionId as string
+    //@ts-ignore
+    memoryMethods = {
+        async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
+            const selectedAssistantId = nodeData.inputs?.selectedAssistant as string
+            const appDataSource = options.appDataSource as DataSource
+            const databaseEntities = options.databaseEntities as IDatabaseEntity
+            let sessionId = nodeData.inputs?.sessionId as string
 
-        const assistant = await appDataSource.getRepository(databaseEntities['Assistant']).findOneBy({
-            id: selectedAssistantId
-        })
-
-        if (!assistant) {
-            options.logger.error(`Assistant ${selectedAssistantId} not found`)
-            return
-        }
-
-        if (!sessionId && options.chatId) {
-            const chatmsg = await appDataSource.getRepository(databaseEntities['ChatMessage']).findOneBy({
-                chatId: options.chatId
+            const assistant = await appDataSource.getRepository(databaseEntities['Assistant']).findOneBy({
+                id: selectedAssistantId
             })
-            if (!chatmsg) {
-                options.logger.error(`Chat Message with Chat Id: ${options.chatId} not found`)
+
+            if (!assistant) {
+                options.logger.error(`Assistant ${selectedAssistantId} not found`)
                 return
             }
-            sessionId = chatmsg.sessionId
-        }
 
-        const credentialData = await getCredentialData(assistant.credential ?? '', options)
-        const openAIApiKey = getCredentialParam('openAIApiKey', credentialData, nodeData)
-        if (!openAIApiKey) {
-            options.logger.error(`OpenAI ApiKey not found`)
-            return
-        }
+            if (!sessionId && options.chatId) {
+                const chatmsg = await appDataSource.getRepository(databaseEntities['ChatMessage']).findOneBy({
+                    chatId: options.chatId
+                })
+                if (!chatmsg) {
+                    options.logger.error(`Chat Message with Chat Id: ${options.chatId} not found`)
+                    return
+                }
+                sessionId = chatmsg.sessionId
+            }
 
-        const openai = new OpenAI({ apiKey: openAIApiKey })
-        options.logger.info(`Clearing OpenAI Thread ${sessionId}`)
-        if (sessionId) await openai.beta.threads.del(sessionId)
-        options.logger.info(`Successfully cleared OpenAI Thread ${sessionId}`)
+            const credentialData = await getCredentialData(assistant.credential ?? '', options)
+            const openAIApiKey = getCredentialParam('openAIApiKey', credentialData, nodeData)
+            if (!openAIApiKey) {
+                options.logger.error(`OpenAI ApiKey not found`)
+                return
+            }
+
+            const openai = new OpenAI({ apiKey: openAIApiKey })
+            options.logger.info(`Clearing OpenAI Thread ${sessionId}`)
+            if (sessionId) await openai.beta.threads.del(sessionId)
+            options.logger.info(`Successfully cleared OpenAI Thread ${sessionId}`)
+        }
     }
 
     async run(nodeData: INodeData, input: string, options: ICommonObject): Promise<string | object> {
@@ -359,7 +362,10 @@ class OpenAIAssistant_Agents implements INode {
                             }
 
                             // Replace the text with a footnote
-                            message_content.value = message_content.value.replace(`${annotation.text}`, `${filePath}`)
+                            message_content.value = message_content.value.replace(
+                                `${annotation.text}`,
+                                `${disableFileDownload ? '' : filePath}`
+                            )
                         }
 
                         returnVal += message_content.value

--- a/packages/components/nodes/memory/DynamoDb/DynamoDb.ts
+++ b/packages/components/nodes/memory/DynamoDb/DynamoDb.ts
@@ -1,4 +1,13 @@
-import { ICommonObject, INode, INodeData, INodeParams, getBaseClasses, getCredentialData, getCredentialParam } from '../../../src'
+import {
+    ICommonObject,
+    INode,
+    INodeData,
+    INodeParams,
+    getBaseClasses,
+    getCredentialData,
+    getCredentialParam,
+    serializeChatHistory
+} from '../../../src'
 import { DynamoDBChatMessageHistory } from 'langchain/stores/message/dynamodb'
 import { BufferMemory, BufferMemoryInput } from 'langchain/memory'
 
@@ -70,13 +79,23 @@ class DynamoDb_Memory implements INode {
         return initalizeDynamoDB(nodeData, options)
     }
 
-    async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
-        const dynamodbMemory = await initalizeDynamoDB(nodeData, options)
-        const sessionId = nodeData.inputs?.sessionId as string
-        const chatId = options?.chatId as string
-        options.logger.info(`Clearing DynamoDb memory session ${sessionId ? sessionId : chatId}`)
-        await dynamodbMemory.clear()
-        options.logger.info(`Successfully cleared DynamoDb memory session ${sessionId ? sessionId : chatId}`)
+    //@ts-ignore
+    memoryMethods = {
+        async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
+            const dynamodbMemory = await initalizeDynamoDB(nodeData, options)
+            const sessionId = nodeData.inputs?.sessionId as string
+            const chatId = options?.chatId as string
+            options.logger.info(`Clearing DynamoDb memory session ${sessionId ? sessionId : chatId}`)
+            await dynamodbMemory.clear()
+            options.logger.info(`Successfully cleared DynamoDb memory session ${sessionId ? sessionId : chatId}`)
+        },
+        async getChatMessages(nodeData: INodeData, options: ICommonObject): Promise<string> {
+            const memoryKey = nodeData.inputs?.memoryKey as string
+            const dynamodbMemory = await initalizeDynamoDB(nodeData, options)
+            const key = memoryKey ?? 'chat_history'
+            const memoryResult = await dynamodbMemory.loadMemoryVariables({})
+            return serializeChatHistory(memoryResult[key])
+        }
     }
 }
 

--- a/packages/components/nodes/memory/MongoDBMemory/MongoDBMemory.ts
+++ b/packages/components/nodes/memory/MongoDBMemory/MongoDBMemory.ts
@@ -1,4 +1,13 @@
-import { getBaseClasses, getCredentialData, getCredentialParam, ICommonObject, INode, INodeData, INodeParams } from '../../../src'
+import {
+    getBaseClasses,
+    getCredentialData,
+    getCredentialParam,
+    ICommonObject,
+    INode,
+    INodeData,
+    INodeParams,
+    serializeChatHistory
+} from '../../../src'
 import { MongoDBChatMessageHistory } from 'langchain/stores/message/mongodb'
 import { BufferMemory, BufferMemoryInput } from 'langchain/memory'
 import { BaseMessage, mapStoredMessageToChatMessage } from 'langchain/schema'
@@ -67,13 +76,23 @@ class MongoDB_Memory implements INode {
         return initializeMongoDB(nodeData, options)
     }
 
-    async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
-        const mongodbMemory = await initializeMongoDB(nodeData, options)
-        const sessionId = nodeData.inputs?.sessionId as string
-        const chatId = options?.chatId as string
-        options.logger.info(`Clearing MongoDB memory session ${sessionId ? sessionId : chatId}`)
-        await mongodbMemory.clear()
-        options.logger.info(`Successfully cleared MongoDB memory session ${sessionId ? sessionId : chatId}`)
+    //@ts-ignore
+    memoryMethods = {
+        async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
+            const mongodbMemory = await initializeMongoDB(nodeData, options)
+            const sessionId = nodeData.inputs?.sessionId as string
+            const chatId = options?.chatId as string
+            options.logger.info(`Clearing MongoDB memory session ${sessionId ? sessionId : chatId}`)
+            await mongodbMemory.clear()
+            options.logger.info(`Successfully cleared MongoDB memory session ${sessionId ? sessionId : chatId}`)
+        },
+        async getChatMessages(nodeData: INodeData, options: ICommonObject): Promise<string> {
+            const memoryKey = nodeData.inputs?.memoryKey as string
+            const mongodbMemory = await initializeMongoDB(nodeData, options)
+            const key = memoryKey ?? 'chat_history'
+            const memoryResult = await mongodbMemory.loadMemoryVariables({})
+            return serializeChatHistory(memoryResult[key])
+        }
     }
 }
 

--- a/packages/components/nodes/memory/MotorheadMemory/MotorheadMemory.ts
+++ b/packages/components/nodes/memory/MotorheadMemory/MotorheadMemory.ts
@@ -3,6 +3,7 @@ import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../
 import { ICommonObject } from '../../../src'
 import { MotorheadMemory, MotorheadMemoryInput } from 'langchain/memory'
 import fetch from 'node-fetch'
+import { getBufferString } from 'langchain/memory'
 
 class MotorMemory_Memory implements INode {
     label: string
@@ -64,13 +65,23 @@ class MotorMemory_Memory implements INode {
         return initalizeMotorhead(nodeData, options)
     }
 
-    async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
-        const motorhead = await initalizeMotorhead(nodeData, options)
-        const sessionId = nodeData.inputs?.sessionId as string
-        const chatId = options?.chatId as string
-        options.logger.info(`Clearing Motorhead memory session ${sessionId ? sessionId : chatId}`)
-        await motorhead.clear()
-        options.logger.info(`Successfully cleared Motorhead memory session ${sessionId ? sessionId : chatId}`)
+    //@ts-ignore
+    memoryMethods = {
+        async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
+            const motorhead = await initalizeMotorhead(nodeData, options)
+            const sessionId = nodeData.inputs?.sessionId as string
+            const chatId = options?.chatId as string
+            options.logger.info(`Clearing Motorhead memory session ${sessionId ? sessionId : chatId}`)
+            await motorhead.clear()
+            options.logger.info(`Successfully cleared Motorhead memory session ${sessionId ? sessionId : chatId}`)
+        },
+        async getChatMessages(nodeData: INodeData, options: ICommonObject): Promise<string> {
+            const memoryKey = nodeData.inputs?.memoryKey as string
+            const motorhead = await initalizeMotorhead(nodeData, options)
+            const key = memoryKey ?? 'chat_history'
+            const memoryResult = await motorhead.loadMemoryVariables({})
+            return getBufferString(memoryResult[key])
+        }
     }
 }
 

--- a/packages/components/nodes/memory/RedisBackedChatMemory/RedisBackedChatMemory.ts
+++ b/packages/components/nodes/memory/RedisBackedChatMemory/RedisBackedChatMemory.ts
@@ -1,5 +1,5 @@
 import { INode, INodeData, INodeParams, ICommonObject } from '../../../src/Interface'
-import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { getBaseClasses, getCredentialData, getCredentialParam, serializeChatHistory } from '../../../src/utils'
 import { BufferMemory, BufferMemoryInput } from 'langchain/memory'
 import { RedisChatMessageHistory, RedisChatMessageHistoryInput } from 'langchain/stores/message/ioredis'
 import { mapStoredMessageToChatMessage, BaseMessage } from 'langchain/schema'
@@ -65,13 +65,23 @@ class RedisBackedChatMemory_Memory implements INode {
         return await initalizeRedis(nodeData, options)
     }
 
-    async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
-        const redis = await initalizeRedis(nodeData, options)
-        const sessionId = nodeData.inputs?.sessionId as string
-        const chatId = options?.chatId as string
-        options.logger.info(`Clearing Redis memory session ${sessionId ? sessionId : chatId}`)
-        await redis.clear()
-        options.logger.info(`Successfully cleared Redis memory session ${sessionId ? sessionId : chatId}`)
+    //@ts-ignore
+    memoryMethods = {
+        async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
+            const redis = await initalizeRedis(nodeData, options)
+            const sessionId = nodeData.inputs?.sessionId as string
+            const chatId = options?.chatId as string
+            options.logger.info(`Clearing Redis memory session ${sessionId ? sessionId : chatId}`)
+            await redis.clear()
+            options.logger.info(`Successfully cleared Redis memory session ${sessionId ? sessionId : chatId}`)
+        },
+        async getChatMessages(nodeData: INodeData, options: ICommonObject): Promise<string> {
+            const memoryKey = nodeData.inputs?.memoryKey as string
+            const redis = await initalizeRedis(nodeData, options)
+            const key = memoryKey ?? 'chat_history'
+            const memoryResult = await redis.loadMemoryVariables({})
+            return serializeChatHistory(memoryResult[key])
+        }
     }
 }
 

--- a/packages/components/nodes/memory/UpstashRedisBackedChatMemory/UpstashRedisBackedChatMemory.ts
+++ b/packages/components/nodes/memory/UpstashRedisBackedChatMemory/UpstashRedisBackedChatMemory.ts
@@ -1,5 +1,5 @@
 import { INode, INodeData, INodeParams } from '../../../src/Interface'
-import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { getBaseClasses, getCredentialData, getCredentialParam, serializeChatHistory } from '../../../src/utils'
 import { ICommonObject } from '../../../src'
 import { BufferMemory, BufferMemoryInput } from 'langchain/memory'
 import { UpstashRedisChatMessageHistory } from 'langchain/stores/message/upstash_redis'
@@ -63,13 +63,22 @@ class UpstashRedisBackedChatMemory_Memory implements INode {
         return initalizeUpstashRedis(nodeData, options)
     }
 
-    async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
-        const redis = await initalizeUpstashRedis(nodeData, options)
-        const sessionId = nodeData.inputs?.sessionId as string
-        const chatId = options?.chatId as string
-        options.logger.info(`Clearing Upstash Redis memory session ${sessionId ? sessionId : chatId}`)
-        await redis.clear()
-        options.logger.info(`Successfully cleared Upstash Redis memory session ${sessionId ? sessionId : chatId}`)
+    //@ts-ignore
+    memoryMethods = {
+        async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
+            const redis = await initalizeUpstashRedis(nodeData, options)
+            const sessionId = nodeData.inputs?.sessionId as string
+            const chatId = options?.chatId as string
+            options.logger.info(`Clearing Upstash Redis memory session ${sessionId ? sessionId : chatId}`)
+            await redis.clear()
+            options.logger.info(`Successfully cleared Upstash Redis memory session ${sessionId ? sessionId : chatId}`)
+        },
+        async getChatMessages(nodeData: INodeData, options: ICommonObject): Promise<string> {
+            const redis = await initalizeUpstashRedis(nodeData, options)
+            const key = 'chat_history'
+            const memoryResult = await redis.loadMemoryVariables({})
+            return serializeChatHistory(memoryResult[key])
+        }
     }
 }
 

--- a/packages/components/nodes/memory/ZepMemory/ZepMemory.ts
+++ b/packages/components/nodes/memory/ZepMemory/ZepMemory.ts
@@ -3,6 +3,7 @@ import { INode, INodeData, INodeParams } from '../../../src/Interface'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 import { ZepMemory, ZepMemoryInput } from 'langchain/memory/zep'
 import { ICommonObject } from '../../../src'
+import { getBufferString } from 'langchain/memory'
 
 class ZepMemory_Memory implements INode {
     label: string
@@ -140,13 +141,25 @@ class ZepMemory_Memory implements INode {
         return zep
     }
 
-    async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
-        const zep = await initalizeZep(nodeData, options)
-        const sessionId = nodeData.inputs?.sessionId as string
-        const chatId = options?.chatId as string
-        options.logger.info(`Clearing Zep memory session ${sessionId ? sessionId : chatId}`)
-        await zep.clear()
-        options.logger.info(`Successfully cleared Zep memory session ${sessionId ? sessionId : chatId}`)
+    //@ts-ignore
+    memoryMethods = {
+        async clearSessionMemory(nodeData: INodeData, options: ICommonObject): Promise<void> {
+            const zep = await initalizeZep(nodeData, options)
+            const sessionId = nodeData.inputs?.sessionId as string
+            const chatId = options?.chatId as string
+            options.logger.info(`Clearing Zep memory session ${sessionId ? sessionId : chatId}`)
+            await zep.clear()
+            options.logger.info(`Successfully cleared Zep memory session ${sessionId ? sessionId : chatId}`)
+        },
+        async getChatMessages(nodeData: INodeData, options: ICommonObject): Promise<string> {
+            const memoryKey = nodeData.inputs?.memoryKey as string
+            const aiPrefix = nodeData.inputs?.aiPrefix as string
+            const humanPrefix = nodeData.inputs?.humanPrefix as string
+            const zep = await initalizeZep(nodeData, options)
+            const key = memoryKey ?? 'chat_history'
+            const memoryResult = await zep.loadMemoryVariables({})
+            return getBufferString(memoryResult[key], humanPrefix, aiPrefix)
+        }
     }
 }
 

--- a/packages/components/nodes/tools/ChainTool/core.ts
+++ b/packages/components/nodes/tools/ChainTool/core.ts
@@ -1,5 +1,6 @@
 import { DynamicTool, DynamicToolInput } from 'langchain/tools'
 import { BaseChain } from 'langchain/chains'
+import { handleEscapeCharacters } from '../../../src/utils'
 
 export interface ChainToolInput extends Omit<DynamicToolInput, 'func'> {
     chain: BaseChain
@@ -14,7 +15,8 @@ export class ChainTool extends DynamicTool {
             func: async (input, runManager) => {
                 // To enable LLM Chain which has promptValues
                 if ((chain as any).prompt && (chain as any).prompt.promptValues) {
-                    const values = await chain.call((chain as any).prompt.promptValues, runManager?.getChild())
+                    const promptValues = handleEscapeCharacters((chain as any).prompt.promptValues, true)
+                    const values = await chain.call(promptValues, runManager?.getChild())
                     return values?.text
                 }
                 return chain.run(input, runManager?.getChild())

--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -107,9 +107,12 @@ export interface INode extends INodeProperties {
         search: (nodeData: INodeData, options?: ICommonObject) => Promise<any>
         delete: (nodeData: INodeData, options?: ICommonObject) => Promise<void>
     }
+    memoryMethods?: {
+        clearSessionMemory: (nodeData: INodeData, options?: ICommonObject) => Promise<void>
+        getChatMessages: (nodeData: INodeData, options?: ICommonObject) => Promise<string>
+    }
     init?(nodeData: INodeData, input: string, options?: ICommonObject): Promise<any>
     run?(nodeData: INodeData, input: string, options?: ICommonObject): Promise<string | ICommonObject>
-    clearSessionMemory?(nodeData: INodeData, options?: ICommonObject): Promise<void>
 }
 
 export interface INodeData extends INodeProperties {

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -550,6 +550,18 @@ export const convertChatHistoryToText = (chatHistory: IMessage[] = []): string =
 }
 
 /**
+ * Serialize array chat history to string
+ * @param {IMessage[]} chatHistory
+ * @returns {string}
+ */
+export const serializeChatHistory = (chatHistory: string | Array<string>) => {
+    if (Array.isArray(chatHistory)) {
+        return chatHistory.join('\n')
+    }
+    return chatHistory
+}
+
+/**
  * Convert schema to zod schema
  * @param {string | object} schema
  * @returns {ICommonObject}


### PR DESCRIPTION
Bug: When specifying prompt variable using chatHistory:
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/535900f7-e497-45dd-afbd-d35a2e5568f1)
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/cda9a4a8-a5a6-4642-aed9-33b9a514dfe5)

It is empty when:
- used together with Memory nodes with SessionId
- called via API

Reason being there is no `incomingInput.history` passed from the API body request.

Fix: retrieve chat history automatically when detected `incomingInput.history` is empty.

![image](https://github.com/FlowiseAI/Flowise/assets/26460777/50989efe-38f1-4d9b-a42f-86686451f5a0)
