### PR TITLE
Fix for issue#1323 - delete duplicate chatflow

### DIFF
--- a/packages/ui/src/views/canvas/index.js
+++ b/packages/ui/src/views/canvas/index.js
@@ -170,7 +170,7 @@ const Canvas = () => {
             try {
                 await chatflowsApi.deleteChatflow(chatflow.id)
                 localStorage.removeItem(`${chatflow.id}_INTERNAL`)
-                navigate(-1)
+                navigate('/')
             } catch (error) {
                 const errorData = error.response.data || `${error.response.status}: ${error.response.statusText}`
                 enqueueSnackbar({


### PR DESCRIPTION
This commit fixes #1323 that I found.

Previously after deleting it was calling `navigate('-1')`, but if it's duplicate it's in a new window with no history.

Here I changed it to `navigate('/')` which will have almost identical behaviour (in almost all cases they come from chatflows) and fixes the defect.