### PR TITLE
Bugfix/Upsert Vector API

### DIFF
--- a/packages/server/src/ChatflowPool.ts
+++ b/packages/server/src/ChatflowPool.ts
@@ -16,7 +16,7 @@ export class ChatflowPool {
      * @param {IReactFlowNode[]} startingNodes
      * @param {ICommonObject} overrideConfig
      */
-    add(chatflowid: string, endingNodeData: INodeData, startingNodes: IReactFlowNode[], overrideConfig?: ICommonObject) {
+    add(chatflowid: string, endingNodeData: INodeData | undefined, startingNodes: IReactFlowNode[], overrideConfig?: ICommonObject) {
         this.activeChatflows[chatflowid] = {
             startingNodes,
             endingNodeData,

--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -172,7 +172,7 @@ export interface IncomingInput {
 export interface IActiveChatflows {
     [key: string]: {
         startingNodes: IReactFlowNode[]
-        endingNodeData: INodeData
+        endingNodeData?: INodeData
         inSync: boolean
         overrideConfig?: ICommonObject
     }


### PR DESCRIPTION
Steps to replicate:
1.) Construct a RAG flow and upsert the document through UI:
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/fcb41f7d-aabc-4ab6-8422-80b91da88018)

2.) Hit `/api/v1/vector/upsert` API to upload another document:
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/b2123dbe-f2ef-4e69-8725-041d195f068d)

3.) Back to UI or use `/prediction` API to ask something about the 2nd document.

Expected: answer can be succesfully retrieved from vector store
Actual: AI answer dont know
Bug: `overrideConfig` is not being saved to `ChatflowPool`, causing the flow to be reused.
Fix: save the `overrideConfig`, causing flow to be re-executed from the start, hence calling the `init` of the vector store, loading the new stuff in