### PR TITLE
[BUGFIX/REGRESSION] Fix wrong elastic client setup when use custom URL

### DIFF
--- a/packages/components/nodes/vectorstores/Elasticsearch/Elasticsearch.ts
+++ b/packages/components/nodes/vectorstores/Elasticsearch/Elasticsearch.ts
@@ -183,13 +183,26 @@ const prepareConnectionOptions = (
     } else if (cloudId) {
         let username = getCredentialParam('username', credentialData, nodeData)
         let password = getCredentialParam('password', credentialData, nodeData)
-        elasticSearchClientOptions = {
-            cloud: {
-                id: cloudId
-            },
-            auth: {
-                username: username,
-                password: password
+        if (cloudId.startsWith('http')) {
+            elasticSearchClientOptions = {
+                node: cloudId,
+                auth: {
+                    username: username,
+                    password: password
+                },
+                tls: {
+                    rejectUnauthorized: false
+                }
+            }
+        } else {
+            elasticSearchClientOptions = {
+                cloud: {
+                    id: cloudId
+                },
+                auth: {
+                    username: username,
+                    password: password
+                }
             }
         }
     }


### PR DESCRIPTION
In the new Elastic node, there is the same connection error that was solved in the deprecated nodes whenever connecting to a custom server URL. 
The bug was previously solved in #1262 