### PR TITLE
Bugfix/Change encryption key path

### DIFF
--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -428,16 +428,7 @@ export const getEnvironmentVariable = (name: string): string | undefined => {
  * @returns {string}
  */
 const getEncryptionKeyFilePath = (): string => {
-    const checkPaths = [
-        path.join(__dirname, '..', '..', 'encryption.key'),
-        path.join(__dirname, '..', '..', 'server', 'encryption.key'),
-        path.join(__dirname, '..', '..', '..', 'encryption.key'),
-        path.join(__dirname, '..', '..', '..', 'server', 'encryption.key'),
-        path.join(__dirname, '..', '..', '..', '..', 'encryption.key'),
-        path.join(__dirname, '..', '..', '..', '..', 'server', 'encryption.key'),
-        path.join(__dirname, '..', '..', '..', '..', '..', 'encryption.key'),
-        path.join(__dirname, '..', '..', '..', '..', '..', 'server', 'encryption.key')
-    ]
+    const checkPaths = [path.join(getUserHome(), '.flowise', 'encryption.key')]
     for (const checkPath of checkPaths) {
         if (fs.existsSync(checkPath)) {
             return checkPath

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -859,7 +859,7 @@ export const isFlowValidForStream = (reactFlowNodes: IReactFlowNode[], endingNod
 export const getEncryptionKeyPath = (): string => {
     return process.env.SECRETKEY_PATH
         ? path.join(process.env.SECRETKEY_PATH, 'encryption.key')
-        : path.join(__dirname, '..', '..', 'encryption.key')
+        : path.join(getUserHome(), '.flowise', 'encryption.key')
 }
 
 /**


### PR DESCRIPTION
When doing `npm install -g flowise`, then `npx flowise start`, the default path for `encryption.key` is created within the Flowise folder.

Problem arises when user upgrade flowise by running `npm install -g flowise`. This will remove all the files including `encryption.key` and recreate a new one.

Fix: change the default path to be user home `.flowise`, the same place where `database.sqlite` is located