### PR TITLE
UI/Fix for icon bounding boxes in dark mode

### DIFF
--- a/packages/components/nodes/prompts/FewShotPromptTemplate/prompt.svg
+++ b/packages/components/nodes/prompts/FewShotPromptTemplate/prompt.svg
@@ -1,5 +1,4 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="32" height="32" fill="white"/>
 <rect x="5" y="7" width="22" height="18" rx="2" stroke="black" stroke-width="2"/>
 <path d="M11 12L15 16L11 20" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M17 20H21" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/packages/components/nodes/prompts/PromptTemplate/prompt.svg
+++ b/packages/components/nodes/prompts/PromptTemplate/prompt.svg
@@ -1,5 +1,4 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="32" height="32" fill="white"/>
 <rect x="5" y="7" width="22" height="18" rx="2" stroke="black" stroke-width="2"/>
 <path d="M11 12L15 16L11 20" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M17 20H21" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
![image](https://github.com/FlowiseAI/Flowise/assets/130513777/bc0a09b1-2533-4a20-8e1b-4364f2b8d500)

Quick fix to make icons not display bounding boxes in dark mode