### PR TITLE
Bugfix: Upsert successful, but failed to insert documents

### DIFF
--- a/packages/components/nodes/documentloaders/Notion/NotionDB.ts
+++ b/packages/components/nodes/documentloaders/Notion/NotionDB.ts
@@ -66,6 +66,10 @@ class NotionDB_DocumentLoaders implements INode {
                 auth: notionIntegrationToken
             },
             id: databaseId,
+            callerOptions: {
+                maxConcurrency: 64 // Default value
+            },
+            propertiesAsHeader: true, // Prepends a front matter header of the page properties to the page contents
             type: 'database'
         }
         const loader = new NotionAPILoader(obj)


### PR DESCRIPTION
Bugfix:: NotionDB Loader failed to insert documents into the vector store.