### PR TITLE
Feature/qdrant port fix

### DIFF
--- a/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
+++ b/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
@@ -268,7 +268,6 @@ class Qdrant_VectorStores implements INode {
             port = 80
         }
 
-
         return port
     }
 }

--- a/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
+++ b/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
@@ -149,7 +149,7 @@ class Qdrant_VectorStores implements INode {
             const credentialData = await getCredentialData(nodeData.credential ?? '', options)
             const qdrantApiKey = getCredentialParam('qdrantApiKey', credentialData, nodeData)
 
-            const port = Qdrant_VectorStores.determinePortByUrl(qdrantServerUrl);
+            const port = Qdrant_VectorStores.determinePortByUrl(qdrantServerUrl)
 
             const client = new QdrantClient({
                 url: qdrantServerUrl,
@@ -201,7 +201,7 @@ class Qdrant_VectorStores implements INode {
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const qdrantApiKey = getCredentialParam('qdrantApiKey', credentialData, nodeData)
 
-        const port = Qdrant_VectorStores.determinePortByUrl(qdrantServerUrl);
+        const port = Qdrant_VectorStores.determinePortByUrl(qdrantServerUrl)
 
         const client = new QdrantClient({
             url: qdrantServerUrl,
@@ -256,20 +256,20 @@ class Qdrant_VectorStores implements INode {
      * See: https://stackoverflow.com/questions/59104197/nodejs-new-url-urlhttps-myurl-com80-lists-the-port-as-empty
      * @param qdrantServerUrl the url to get the port from
      */
-    static determinePortByUrl(qdrantServerUrl: string) :number {
-        const parsedUrl = new URL(qdrantServerUrl);
+    static determinePortByUrl(qdrantServerUrl: string): number {
+        const parsedUrl = new URL(qdrantServerUrl)
 
         let port = parsedUrl.port ? parseInt(parsedUrl.port) : 6663
 
         if (parsedUrl.protocol === 'https:' && parsedUrl.port === '') {
-            port = 443;
+            port = 443
         }
         if (parsedUrl.protocol === 'http:' && parsedUrl.port === '') {
-            port = 80;
+            port = 80
         }
 
 
-        return port;
+        return port
     }
 }
 

--- a/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
+++ b/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
@@ -149,9 +149,12 @@ class Qdrant_VectorStores implements INode {
             const credentialData = await getCredentialData(nodeData.credential ?? '', options)
             const qdrantApiKey = getCredentialParam('qdrantApiKey', credentialData, nodeData)
 
+            const port = Qdrant_VectorStores.determinePortByUrl(qdrantServerUrl);
+
             const client = new QdrantClient({
                 url: qdrantServerUrl,
-                apiKey: qdrantApiKey
+                apiKey: qdrantApiKey,
+                port: port
             })
 
             const flattenDocs = docs && docs.length ? flatten(docs) : []
@@ -198,9 +201,12 @@ class Qdrant_VectorStores implements INode {
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const qdrantApiKey = getCredentialParam('qdrantApiKey', credentialData, nodeData)
 
+        const port = Qdrant_VectorStores.determinePortByUrl(qdrantServerUrl);
+
         const client = new QdrantClient({
             url: qdrantServerUrl,
-            apiKey: qdrantApiKey
+            apiKey: qdrantApiKey,
+            port: port
         })
 
         const dbConfig: QdrantLibArgs = {
@@ -241,6 +247,25 @@ class Qdrant_VectorStores implements INode {
             return vectorStore
         }
         return vectorStore
+    }
+
+    /**
+     * Determine the port number from the given URL.
+     *
+     * The problem is when not doing this the qdrant-client.js will fall back on 6663 when you enter a port 443 and 80.
+     * See: https://stackoverflow.com/questions/59104197/nodejs-new-url-urlhttps-myurl-com80-lists-the-port-as-empty
+     * @param qdrantServerUrl the url to get the port from
+     */
+    static determinePortByUrl(qdrantServerUrl: string) :number {
+        let port = 6333;
+        const parsedUrl = new URL(qdrantServerUrl);
+        if (parsedUrl.protocol === 'https:' && parsedUrl.port === '') {
+            port = 443;
+        }
+        if (parsedUrl.protocol === 'http:' && parsedUrl.port === '') {
+            port = 80;
+        }
+        return port;
     }
 }
 

--- a/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
+++ b/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
@@ -257,14 +257,18 @@ class Qdrant_VectorStores implements INode {
      * @param qdrantServerUrl the url to get the port from
      */
     static determinePortByUrl(qdrantServerUrl: string) :number {
-        let port = 6333;
         const parsedUrl = new URL(qdrantServerUrl);
+
+        let port = parsedUrl.port ? parseInt(parsedUrl.port) : 6663
+
         if (parsedUrl.protocol === 'https:' && parsedUrl.port === '') {
             port = 443;
         }
         if (parsedUrl.protocol === 'http:' && parsedUrl.port === '') {
             port = 80;
         }
+
+
         return port;
     }
 }


### PR DESCRIPTION
Hello :)

We have our qdrant running behind an ingress which is doing https and listens on port 443.

The problem is that the qdrant-client.js pareses the qdrant server url with new Url(url).

As mentioned in https://stackoverflow.com/questions/59104197/nodejs-new-url-urlhttps-myurl-com80-lists-the-port-as-empty giving 443 or 80 as port results in an empty port in the url object. This leads the qdrant-client to default back to 6663.

So for example using a qdrant server url like: https://mysuperserver:443 results into https://mysuperserver:6663.
