### PR TITLE
Add milvusTextField configuration for Milvus

### DIFF
--- a/packages/components/nodes/vectorstores/Milvus/Milvus.ts
+++ b/packages/components/nodes/vectorstores/Milvus/Milvus.ts
@@ -66,6 +66,14 @@ class Milvus_VectorStores implements INode {
                 type: 'string'
             },
             {
+                label: 'Milvus Text Field',
+                name: 'milvusTextField',
+                type: 'string',
+                placeholder: 'langchain_text',
+                optional: true,
+                additionalParams: true
+            },
+            {
                 label: 'Milvus Filter',
                 name: 'milvusFilter',
                 type: 'string',
@@ -150,6 +158,7 @@ class Milvus_VectorStores implements INode {
         const address = nodeData.inputs?.milvusServerUrl as string
         const collectionName = nodeData.inputs?.milvusCollection as string
         const milvusFilter = nodeData.inputs?.milvusFilter as string
+        const textField = nodeData.inputs?.milvusTextField as string
 
         // embeddings
         const embeddings = nodeData.inputs?.embeddings as Embeddings
@@ -169,7 +178,8 @@ class Milvus_VectorStores implements INode {
         // init MilvusLibArgs
         const milVusArgs: MilvusLibArgs = {
             url: address,
-            collectionName: collectionName
+            collectionName: collectionName,
+            textField: textField
         }
 
         if (milvusUser) milVusArgs.username = milvusUser


### PR DESCRIPTION
langchain python use `text` 
https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/vectorstores/milvus.py#L119

while langchian js use `langchain_text` 
https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-community/src/vectorstores/milvus.ts#L61

so it is necessary to add milvusTextField configuration for Milvus.