### PR TITLE
Correct DockerHub link in docs from private to public repo page

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Flowise Docker Hub Image
 
-Starts Flowise from [DockerHub Image](https://hub.docker.com/repository/docker/flowiseai/flowise/general)
+Starts Flowise from [DockerHub Image](https://hub.docker.com/r/flowiseai/flowise)
 
 ## Usage
 


### PR DESCRIPTION
The current link requires authentication to view, the new link is the public repo page for the image.