### PR TITLE
Feature/SessionId Tracking

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
         "ioredis": "^5.3.2",
         "langchain": "^0.0.214",
         "langfuse": "2.0.2",
-        "langfuse-langchain": "2.0.2",
+        "langfuse-langchain": "2.3.3",
         "langsmith": "0.0.53",
         "linkifyjs": "^4.1.1",
         "llmonitor": "^0.5.5",

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -1,13 +1,13 @@
-import { BaseTracer, Run, BaseCallbackHandler } from 'langchain/callbacks'
+import { BaseTracer, Run, BaseCallbackHandler, LangChainTracer } from 'langchain/callbacks'
 import { AgentAction, ChainValues } from 'langchain/schema'
 import { Logger } from 'winston'
 import { Server } from 'socket.io'
 import { Client } from 'langsmith'
-import { LangChainTracer } from 'langchain/callbacks'
-import { LLMonitorHandler } from 'langchain/callbacks/handlers/llmonitor'
+import { LLMonitorHandler, LLMonitorHandlerFields } from 'langchain/callbacks/handlers/llmonitor'
 import { getCredentialData, getCredentialParam } from './utils'
 import { ICommonObject, INodeData } from './Interface'
 import CallbackHandler from 'langfuse-langchain'
+import { LangChainTracerFields } from '@langchain/core/tracers/tracer_langchain'
 import { RunTree, RunTreeConfig, Client as LangsmithClient } from 'langsmith'
 import { Langfuse, LangfuseTraceClient, LangfuseSpanClient, LangfuseGenerationClient } from 'langfuse'
 import monitor from 'llmonitor'
@@ -235,11 +235,16 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                         apiKey: langSmithApiKey
                     })
 
-                    const tracer = new LangChainTracer({
+                    let langSmithField: LangChainTracerFields = {
                         projectName: langSmithProject ?? 'default',
-                        //@ts-ignore
                         client
-                    })
+                    }
+
+                    if (nodeData?.inputs?.analytics?.langSmith) {
+                        langSmithField = { ...langSmithField, ...nodeData?.inputs?.analytics?.langSmith }
+                    }
+
+                    const tracer = new LangChainTracer(langSmithField)
                     callbacks.push(tracer)
                 } else if (provider === 'langFuse') {
                     const release = analytic[provider].release as string
@@ -248,13 +253,17 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                     const langFusePublicKey = getCredentialParam('langFusePublicKey', credentialData, nodeData)
                     const langFuseEndpoint = getCredentialParam('langFuseEndpoint', credentialData, nodeData)
 
-                    const langFuseOptions: any = {
+                    let langFuseOptions: any = {
                         secretKey: langFuseSecretKey,
                         publicKey: langFusePublicKey,
                         baseUrl: langFuseEndpoint ?? 'https://cloud.langfuse.com'
                     }
                     if (release) langFuseOptions.release = release
-                    if (options.chatId) langFuseOptions.userId = options.chatId
+                    if (options.chatId) langFuseOptions.sessionId = options.chatId
+
+                    if (nodeData?.inputs?.analytics?.langFuse) {
+                        langFuseOptions = { ...langFuseOptions, ...nodeData?.inputs?.analytics?.langFuse }
+                    }
 
                     const handler = new CallbackHandler(langFuseOptions)
                     callbacks.push(handler)
@@ -262,9 +271,13 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                     const llmonitorAppId = getCredentialParam('llmonitorAppId', credentialData, nodeData)
                     const llmonitorEndpoint = getCredentialParam('llmonitorEndpoint', credentialData, nodeData)
 
-                    const llmonitorFields: ICommonObject = {
+                    let llmonitorFields: LLMonitorHandlerFields = {
                         appId: llmonitorAppId,
                         apiUrl: llmonitorEndpoint ?? 'https://app.llmonitor.com'
+                    }
+
+                    if (nodeData?.inputs?.analytics?.llmonitor) {
+                        llmonitorFields = { ...llmonitorFields, ...nodeData?.inputs?.analytics?.llmonitor }
                     }
 
                     const handler = new LLMonitorHandler(llmonitorFields)
@@ -360,7 +373,8 @@ export class AnalyticHandler {
                     },
                     serialized: {},
                     project_name: this.handlers['langSmith'].langSmithProject,
-                    client: this.handlers['langSmith'].client
+                    client: this.handlers['langSmith'].client,
+                    ...this.nodeData?.inputs?.analytics?.langSmith
                 }
                 const parentRun = new RunTree(parentRunConfig)
                 await parentRun.postRun()
@@ -390,8 +404,9 @@ export class AnalyticHandler {
                 const langfuse: Langfuse = this.handlers['langFuse'].client
                 langfuseTraceClient = langfuse.trace({
                     name,
-                    userId: this.options.chatId,
-                    metadata: { tags: ['openai-assistant'] }
+                    sessionId: this.options.chatId,
+                    metadata: { tags: ['openai-assistant'] },
+                    ...this.nodeData?.inputs?.analytics?.langFuse
                 })
             } else {
                 langfuseTraceClient = this.handlers['langFuse'].trace[parentIds['langFuse']]
@@ -420,7 +435,8 @@ export class AnalyticHandler {
                     runId,
                     name,
                     userId: this.options.chatId,
-                    input
+                    input,
+                    ...this.nodeData?.inputs?.analytics?.llmonitor
                 })
                 this.handlers['llmonitor'].chainEvent = { [runId]: runId }
                 returnIds['llmonitor'].chainEvent = runId

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -237,6 +237,7 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
 
                     let langSmithField: LangChainTracerFields = {
                         projectName: langSmithProject ?? 'default',
+                        //@ts-ignore
                         client
                     }
 


### PR DESCRIPTION
- Add sessionId tracking on Langfuse.
- User can also add additional configs like:
```
{
    "question": "hi there",
    "overrideConfig": {
        "analytics": {
            "langFuse": {
                "userId": "user1"
            }
        }
    }
}
```
