### PR TITLE
Fix for #1535

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "pretty-quick": "^3.1.3",
         "rimraf": "^3.0.2",
         "run-script-os": "^1.1.6",
-        "turbo": "1.7.4",
+        "turbo": "^1.7.4",
         "typescript": "^4.8.4"
     },
     "engines": {


### PR DESCRIPTION
The cause of #1535 is the older version of turbo, as per https://github.com/vercel/turbo/issues/5650.

This PR updates turbo to the latest compatible version to fix a bug with GitHub actions not able to build arm64 docker images.

Fixes #1535.