### PR TITLE
Fix CustomFunction receiving excaped inputs

### DIFF
--- a/packages/components/nodes/utilities/CustomFunction/CustomFunction.ts
+++ b/packages/components/nodes/utilities/CustomFunction/CustomFunction.ts
@@ -73,7 +73,11 @@ class CustomFunction_Utilities implements INode {
 
         if (Object.keys(inputVars).length) {
             for (const item in inputVars) {
-                sandbox[`$${item}`] = inputVars[item]
+                let value = inputVars[item]
+                if (typeof value === 'string') {
+                    value = handleEscapeCharacters(value, true)
+                }
+                sandbox[`$${item}`] = value
             }
         }
 


### PR DESCRIPTION
When the input contains FLOWISE_DOUBLE_QUOTE, it will not be parsed using JSON.parse.