### PR TITLE
FIX: Upstash redis error causing deployment and adding credentials error

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,7 @@
         "@supabase/supabase-js": "^2.29.0",
         "@types/js-yaml": "^4.0.5",
         "@types/jsdom": "^21.1.1",
-        "@upstash/redis": "^1.22.1",
+        "@upstash/redis": "1.22.1",
         "@zilliz/milvus2-sdk-node": "^2.2.24",
         "apify-client": "^2.7.1",
         "axios": "1.6.2",


### PR DESCRIPTION
- Locks the `@upstash/redis` version in `components/package.json`. This was causing issues with deployments and when adding credentials.