### PR TITLE
support pinecone serverless indexes

### DIFF
--- a/packages/components/credentials/PineconeApi.credential.ts
+++ b/packages/components/credentials/PineconeApi.credential.ts
@@ -16,11 +16,6 @@ class PineconeApi implements INodeCredential {
                 label: 'Pinecone Api Key',
                 name: 'pineconeApiKey',
                 type: 'password'
-            },
-            {
-                label: 'Pinecone Environment',
-                name: 'pineconeEnv',
-                type: 'string'
             }
         ]
     }

--- a/packages/components/nodes/vectorstores/Pinecone/Pinecone.ts
+++ b/packages/components/nodes/vectorstores/Pinecone/Pinecone.ts
@@ -108,8 +108,7 @@ class Pinecone_VectorStores implements INode {
             const pineconeEnv = getCredentialParam('pineconeEnv', credentialData, nodeData)
 
             const client = new Pinecone({
-                apiKey: pineconeApiKey,
-                environment: pineconeEnv
+                apiKey: pineconeApiKey
             })
 
             const pineconeIndex = client.Index(index)
@@ -148,8 +147,7 @@ class Pinecone_VectorStores implements INode {
         const pineconeEnv = getCredentialParam('pineconeEnv', credentialData, nodeData)
 
         const client = new Pinecone({
-            apiKey: pineconeApiKey,
-            environment: pineconeEnv
+            apiKey: pineconeApiKey
         })
 
         const pineconeIndex = client.Index(index)

--- a/packages/components/nodes/vectorstores/Pinecone/Pinecone_Existing.ts
+++ b/packages/components/nodes/vectorstores/Pinecone/Pinecone_Existing.ts
@@ -95,11 +95,9 @@ class Pinecone_Existing_VectorStores implements INode {
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const pineconeApiKey = getCredentialParam('pineconeApiKey', credentialData, nodeData)
-        const pineconeEnv = getCredentialParam('pineconeEnv', credentialData, nodeData)
 
         const client = new Pinecone({
-            apiKey: pineconeApiKey,
-            environment: pineconeEnv
+            apiKey: pineconeApiKey
         })
 
         const pineconeIndex = client.Index(index)

--- a/packages/components/nodes/vectorstores/Pinecone/Pinecone_Upsert.ts
+++ b/packages/components/nodes/vectorstores/Pinecone/Pinecone_Upsert.ts
@@ -96,11 +96,9 @@ class PineconeUpsert_VectorStores implements INode {
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const pineconeApiKey = getCredentialParam('pineconeApiKey', credentialData, nodeData)
-        const pineconeEnv = getCredentialParam('pineconeEnv', credentialData, nodeData)
 
         const client = new Pinecone({
-            apiKey: pineconeApiKey,
-            environment: pineconeEnv
+            apiKey: pineconeApiKey
         })
 
         const pineconeIndex = client.Index(index)

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,7 +33,7 @@
         "@langchain/mistralai": "^0.0.6",
         "@notionhq/client": "^2.2.8",
         "@opensearch-project/opensearch": "^1.2.0",
-        "@pinecone-database/pinecone": "^1.1.1",
+        "@pinecone-database/pinecone": "^2.0.1",
         "@qdrant/js-client-rest": "^1.2.2",
         "@supabase/supabase-js": "^2.29.0",
         "@types/js-yaml": "^4.0.5",


### PR DESCRIPTION
Pinecone has released a new type of index (serverless) that according to their documentation aim to reduce by **"Up to 50x lower costs"** and improve performance (see documentation --> https://www.pinecone.io/blog/serverless/)

**Attention**
After this change you won't need to put the pinecone's index environment param as part of pinecone's credentials.
The only parameter you need to provide is the pinecone's API-KEY.

@HenryHengZJ 

![3735c2c9d291430cbbc1df872d775e19680b70d1-1043x834](https://github.com/FlowiseAI/Flowise/assets/19833797/a20202f2-8f9f-453f-85b5-0f26e2cccead)
![693154d31b3b6814eb67d74aa3f3a9ccbb99167e-1036x684](https://github.com/FlowiseAI/Flowise/assets/19833797/465d6605-197d-40e8-8ef0-690681627c2a)
