### PR TITLE
Added support for gpt-4 and gpt-4-32k models

### DIFF
--- a/packages/components/nodes/llms/Azure OpenAI/AzureOpenAI.ts
+++ b/packages/components/nodes/llms/Azure OpenAI/AzureOpenAI.ts
@@ -18,7 +18,7 @@ class AzureOpenAI_LLMs implements INode {
     constructor() {
         this.label = 'Azure OpenAI'
         this.name = 'azureOpenAI'
-        this.version = 2.0
+        this.version = 2.1
         this.type = 'AzureOpenAI'
         this.icon = 'Azure.svg'
         this.category = 'LLMs'
@@ -89,6 +89,14 @@ class AzureOpenAI_LLMs implements INode {
                     {
                         label: 'gpt-35-turbo',
                         name: 'gpt-35-turbo'
+                    },
+                    {
+                        label: 'gpt-4',
+                        name: 'gpt-4'
+                    },
+                    {
+                        label: 'gpt-4-32k',
+                        name: 'gpt-4-32k'
                     }
                 ],
                 default: 'text-davinci-003',


### PR DESCRIPTION
Hey @HenryHengZJ , I've updated the AzureOpenAI LLM node to support gpt-4 and gpt-4-32k models, since those were missing from the dropdown selectors.  Let me know if you have any questions. Thanks!