### PR TITLE
add deploy to Zeabur as another self host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ Deploy Flowise self-hosted in your existing infrastructure, we support various [
 
         [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=29)
 
+    -   [Zeabur](https://zeabur.com/templates/2JYZTR)
+       
+        [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/2JYZTR)
+
       </details>
 
 ## 💻 Cloud Hosted


### PR DESCRIPTION
<img width="1427" alt="image" src="https://github.com/FlowiseAI/Flowise/assets/63531512/18d7cdce-4538-435f-a87f-68feca0524c9">
Zeabur is a platform for developers to deploy their services easily. Now Zeabur supports for deploying Flowise with one click in there templates and official prebuilt marketplace