### PR TITLE
Implementing CORS and CSP headers from config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,8 @@ Flowise support different environment variables to configure your instance. You 
 | Variable                    | Description                                                                  | Type                                             | Default                             |
 | --------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
 | PORT                        | The HTTP port Flowise runs on                                                | Number                                           | 3000                                |
+| CORS_ORIGINS                | The allowed origins for all cross-origin HTTP calls                          | String                                           |                                     |
+| IFRAME_ORIGINS              | The allowed origins for iframe src embedding                                 | String                                           |                                     |
 | FLOWISE_USERNAME            | Username to login                                                            | String                                           |                                     |
 | FLOWISE_PASSWORD            | Password to login                                                            | String                                           |                                     |
 | DEBUG                       | Print logs from components                                                   | Boolean                                          |                                     |

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -4,6 +4,9 @@ APIKEY_PATH=/root/.flowise
 SECRETKEY_PATH=/root/.flowise
 LOG_PATH=/root/.flowise/logs
 
+# CORS_ORIGINS="*"
+# IFRAME_ORIGINS="*"
+
 # NUMBER_OF_PROXIES= 1
 
 # DATABASE_TYPE=postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         restart: always
         environment:
             - PORT=${PORT}
+            - CORS_ORIGINS=${CORS_ORIGINS}
+            - IFRAME_ORIGINS=${IFRAME_ORIGINS}
             - FLOWISE_USERNAME=${FLOWISE_USERNAME}
             - FLOWISE_PASSWORD=${FLOWISE_PASSWORD}
             - DEBUG=${DEBUG}

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,4 +1,6 @@
 PORT=3000
+# CORS_ORIGINS="*"
+# EMBEDDING_ORIGINS="*"
 # DATABASE_PATH=/your_database_path/.flowise
 # APIKEY_PATH=/your_api_key_path/.flowise
 # SECRETKEY_PATH=/your_api_key_path/.flowise

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,6 +1,6 @@
 PORT=3000
 # CORS_ORIGINS="*"
-# EMBEDDING_ORIGINS="*"
+# IFRAME_ORIGINS="*"
 # DATABASE_PATH=/your_database_path/.flowise
 # APIKEY_PATH=/your_api_key_path/.flowise
 # SECRETKEY_PATH=/your_api_key_path/.flowise

--- a/packages/server/src/commands/start.ts
+++ b/packages/server/src/commands/start.ts
@@ -19,6 +19,8 @@ export default class Start extends Command {
         FLOWISE_USERNAME: Flags.string(),
         FLOWISE_PASSWORD: Flags.string(),
         PORT: Flags.string(),
+        CORS_ORIGINS: Flags.string(),
+        IFRAME_ORIGINS: Flags.string(),
         DEBUG: Flags.string(),
         APIKEY_PATH: Flags.string(),
         SECRETKEY_PATH: Flags.string(),
@@ -78,6 +80,8 @@ export default class Start extends Command {
         const { flags } = await this.parse(Start)
 
         if (flags.PORT) process.env.PORT = flags.PORT
+        if (flags.CORS_ORIGINS) process.env.CORS_ORIGINS = flags.CORS_ORIGINS
+        if (flags.IFRAME_ORIGINS) process.env.IFRAME_ORIGINS = flags.IFRAME_ORIGINS
         if (flags.DEBUG) process.env.DEBUG = flags.DEBUG
         if (flags.NUMBER_OF_PROXIES) process.env.NUMBER_OF_PROXIES = flags.NUMBER_OF_PROXIES
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -62,7 +62,7 @@ import { CachePool } from './CachePool'
 import { ICommonObject, IMessage, INodeOptionsValue, handleEscapeCharacters } from 'flowise-components'
 import { createRateLimiter, getRateLimiter, initializeRateLimiter } from './utils/rateLimit'
 import { addAPIKey, compareKeys, deleteAPIKey, getApiKey, getAPIKeys, updateAPIKey } from './utils/apiKey'
-import { sanitizeMiddleware, getAllowedCorsOrigins, getAllowedEmbeddingOrigins } from './utils/XSS'
+import { sanitizeMiddleware, getCorsOptions, getAllowedIframeOrigins } from './utils/XSS'
 import axios from 'axios'
 import { Client } from 'langchainhub'
 import { parsePrompt } from './utils/hub'
@@ -127,21 +127,11 @@ export class App {
             this.app.set('trust proxy', parseInt(process.env.NUMBER_OF_PROXIES))
 
         // Allow access from specified domains
-        const corsOptions = {
-            origin: function (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) {
-                const allowedOrigins = getAllowedCorsOrigins()
-                if (!origin || allowedOrigins == '*' || allowedOrigins.indexOf(origin) !== -1) {
-                    callback(null, true)
-                } else {
-                    callback(new Error('Not allowed by CORS'))
-                }
-            }
-        }
-        this.app.use(cors(corsOptions))
+        this.app.use(cors(getCorsOptions()))
 
         // Allow embedding from specified domains.
         this.app.use((req, res, next) => {
-            const allowedOrigins = getAllowedEmbeddingOrigins()
+            const allowedOrigins = getAllowedIframeOrigins()
             if (allowedOrigins == '*') {
                 next()
             } else {
@@ -1884,16 +1874,7 @@ export async function start(): Promise<void> {
     const server = http.createServer(serverApp.app)
 
     const io = new Server(server, {
-        cors: {
-            origin: function (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) {
-                const allowedOrigins = getAllowedCorsOrigins()
-                if (!origin || allowedOrigins == '*' || allowedOrigins.indexOf(origin) !== -1) {
-                    callback(null, true)
-                } else {
-                    callback(new Error('Not allowed by CORS'))
-                }
-            }
-        }
+        cors: getCorsOptions()
     })
 
     await serverApp.initDatabase()

--- a/packages/server/src/utils/XSS.ts
+++ b/packages/server/src/utils/XSS.ts
@@ -24,8 +24,22 @@ export function getAllowedCorsOrigins(): string {
     return process.env.CORS_ORIGINS ?? '*'
 }
 
-export function getAllowedEmbeddingOrigins(): string {
+export function getCorsOptions(): any {
+    const corsOptions = {
+        origin: function (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) {
+            const allowedOrigins = getAllowedCorsOrigins()
+            if (!origin || allowedOrigins == '*' || allowedOrigins.indexOf(origin) !== -1) {
+                callback(null, true)
+            } else {
+                callback(new Error('Not allowed by CORS'))
+            }
+        }
+    }
+    return corsOptions
+}
+
+export function getAllowedIframeOrigins(): string {
     // Expects FQDN separated by commas, otherwise nothing or * for all.
     // Also CSP allowed values: self or none
-    return process.env.EMBEDDING_ORIGINS ?? '*'
+    return process.env.IFRAME_ORIGINS ?? '*'
 }

--- a/packages/server/src/utils/XSS.ts
+++ b/packages/server/src/utils/XSS.ts
@@ -18,3 +18,14 @@ export function sanitizeMiddleware(req: Request, res: Response, next: NextFuncti
     }
     next()
 }
+
+export function getAllowedCorsOrigins(): string {
+    // Expects FQDN separated by commas, otherwise nothing or * for all.
+    return process.env.CORS_ORIGINS ?? '*'
+}
+
+export function getAllowedEmbeddingOrigins(): string {
+    // Expects FQDN separated by commas, otherwise nothing or * for all.
+    // Also CSP allowed values: self or none
+    return process.env.EMBEDDING_ORIGINS ?? '*'
+}

--- a/packages/server/src/utils/XSS.ts
+++ b/packages/server/src/utils/XSS.ts
@@ -31,7 +31,7 @@ export function getCorsOptions(): any {
             if (!origin || allowedOrigins == '*' || allowedOrigins.indexOf(origin) !== -1) {
                 callback(null, true)
             } else {
-                callback(new Error('Not allowed by CORS'))
+                callback(null, false)
             }
         }
     }


### PR DESCRIPTION
This PR implements both [Cross Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) and [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) frame ancestors headers.

Both are very important from a security standpoint, with CSP specifically stopping XSS attacks (iframe embedding).

These new options use two new _optional_ env variables:
```
# CORS_ORIGINS="*"
# EMBEDDING_ORIGINS="*"
```

By default both are not set and backwards compatible. If they are not set, we do not emit CSP headers (as before), and CORS sends the origin domain (also as before).

Here's an example that allows CORS requests and embedding from a specific domain:
```
CORS_ORIGINS="https://www.testme.com"
EMBEDDING_ORIGINS="https://www.testme.com"
```

Here's an example that allows CORS, but not iframe embedding except by itself:
```
CORS_ORIGINS="https://www.testme.com"
EMBEDDING_ORIGINS="self"
```

Here's an example that allows multiple CORS domains, but no embedding at all:
```
CORS_ORIGINS="https://www.testme.com, https://www.testmeagain.com"
EMBEDDING_ORIGINS="none"
```

Here's an example that allows multiple CORS domains and embedding domains:
```
CORS_ORIGINS="https://www.testme.com, https://www.testmeagain.com"
EMBEDDING_ORIGINS="https://www.testme.com, https://www.testmeagain.com"
```
This applies the same CORS headers to both websockets and node backend.