### PR TITLE
Update ChatOpenAI.ts to include new openai's Chat models

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -48,6 +48,14 @@ class ChatOpenAI_ChatModels implements INode {
                         name: 'gpt-4'
                     },
                     {
+                        label: 'gpt-4-turbo-preview',
+                        name: 'gpt-4-turbo-preview'
+                    },
+                    {
+                        label: 'gpt-4-0125-preview',
+                        name: 'gpt-4-0125-preview'
+                    },
+                    {
                         label: 'gpt-4-1106-preview',
                         name: 'gpt-4-1106-preview'
                     },


### PR DESCRIPTION
[OpenAI Blog notice](https://openai.com/blog/new-embedding-models-and-api-updates)

- added the new gpt-4-0125-preview
- added the latest model alias: gpt-4-turbo-preview