### PR TITLE
fix bug settings.json not found on upsert

### DIFF
--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata'
 import path from 'path'
+import * as fs from 'fs'
 import { DataSource } from 'typeorm'
 import { getUserHome } from './utils'
 import { entities } from './database/entities'
@@ -10,10 +11,14 @@ import { postgresMigrations } from './database/migrations/postgres'
 let appDataSource: DataSource
 
 export const init = async (): Promise<void> => {
-    let homePath
+    let homePath;
+    let flowisePath = path.join(getUserHome(), '.flowise');
+    if (!fs.existsSync(flowisePath)) {
+        fs.mkdirSync(flowisePath);
+    }
     switch (process.env.DATABASE_TYPE) {
         case 'sqlite':
-            homePath = process.env.DATABASE_PATH ?? path.join(getUserHome(), '.flowise')
+            homePath = process.env.DATABASE_PATH ?? flowisePath;
             appDataSource = new DataSource({
                 type: 'sqlite',
                 database: path.resolve(homePath, 'database.sqlite'),
@@ -54,7 +59,7 @@ export const init = async (): Promise<void> => {
             })
             break
         default:
-            homePath = process.env.DATABASE_PATH ?? path.join(getUserHome(), '.flowise')
+            homePath = process.env.DATABASE_PATH ?? flowisePath;
             appDataSource = new DataSource({
                 type: 'sqlite',
                 database: path.resolve(homePath, 'database.sqlite'),

--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -11,14 +11,14 @@ import { postgresMigrations } from './database/migrations/postgres'
 let appDataSource: DataSource
 
 export const init = async (): Promise<void> => {
-    let homePath;
-    let flowisePath = path.join(getUserHome(), '.flowise');
+    let homePath
+    let flowisePath = path.join(getUserHome(), '.flowise')
     if (!fs.existsSync(flowisePath)) {
-        fs.mkdirSync(flowisePath);
+        fs.mkdirSync(flowisePath)
     }
     switch (process.env.DATABASE_TYPE) {
         case 'sqlite':
-            homePath = process.env.DATABASE_PATH ?? flowisePath;
+            homePath = process.env.DATABASE_PATH ?? flowisePath
             appDataSource = new DataSource({
                 type: 'sqlite',
                 database: path.resolve(homePath, 'database.sqlite'),
@@ -59,7 +59,7 @@ export const init = async (): Promise<void> => {
             })
             break
         default:
-            homePath = process.env.DATABASE_PATH ?? flowisePath;
+            homePath = process.env.DATABASE_PATH ?? flowisePath
             appDataSource = new DataSource({
                 type: 'sqlite',
                 database: path.resolve(homePath, 'database.sqlite'),


### PR DESCRIPTION
fixing issue related to bug https://github.com/FlowiseAI/Flowise/issues/1582

While using DB of 'mysql' (and I believe others which are not 'sqlite') there's an error saying:

**ENOENT: no such file or directory, open '/root/.flowise/settings.json** 

![image](https://github.com/FlowiseAI/Flowise/assets/19833797/3055e897-4013-4c13-b4d2-519ec596a9d7)

It happens since the root/.flowise directory wasn't exist before trying to write the 'settings.json' file over
https://github.com/FlowiseAI/Flowise/blob/5d25c35a1ac4250bb79b21bc22243576a18b2e36/packages/server/src/utils/telemetry.ts#L31

@HenryHengZJ please review

Thanks
