### PR TITLE
Bugfix/AzureOpenAIEmbedding - Updated Default Batch Size from 1 to 100

### DIFF
--- a/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
@@ -35,7 +35,7 @@ class AzureOpenAIEmbedding_Embeddings implements INode {
                 label: 'Batch Size',
                 name: 'batchSize',
                 type: 'number',
-                default: '1',
+                default: '100',
                 optional: true,
                 additionalParams: true
             },


### PR DESCRIPTION
This fixes https://github.com/FlowiseAI/Flowise/issues/1626