### PR TITLE
mysql-ssl

### DIFF
--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -89,5 +89,5 @@ const getDatabaseSSLFromEnv = () => {
     } else if (process.env.DATABASE_SSL === 'true') {
         return true
     }
-    return {}
+    return undefined
 }

--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -40,7 +40,19 @@ export const init = async (): Promise<void> => {
                 synchronize: false,
                 migrationsRun: false,
                 entities: Object.values(entities),
-                migrations: mysqlMigrations
+                migrations: mysqlMigrations,
+                ...(process.env.DATABASE_SSL_KEY_BASE64
+                    ? {
+                        ssl: {
+                            rejectUnauthorized: false,
+                            ca: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
+                        }
+                    }
+                    : process.env.DATABASE_SSL === 'true'
+                        ? {
+                            ssl: true
+                        }
+                        : {}),
             })
             break
         case 'postgres':
@@ -53,16 +65,16 @@ export const init = async (): Promise<void> => {
                 database: process.env.DATABASE_NAME,
                 ...(process.env.DATABASE_SSL_KEY_BASE64
                     ? {
-                          ssl: {
-                              rejectUnauthorized: false,
-                              cert: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
-                          }
-                      }
+                        ssl: {
+                            rejectUnauthorized: false,
+                            cert: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
+                        }
+                    }
                     : process.env.DATABASE_SSL === 'true'
-                    ? {
-                          ssl: true
-                      }
-                    : {}),
+                        ? {
+                            ssl: true
+                        }
+                        : {}),
                 synchronize: false,
                 migrationsRun: false,
                 entities: Object.values(entities),

--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -43,16 +43,16 @@ export const init = async (): Promise<void> => {
                 migrations: mysqlMigrations,
                 ...(process.env.DATABASE_SSL_KEY_BASE64
                     ? {
-                        ssl: {
-                            rejectUnauthorized: false,
-                            ca: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
-                        }
-                    }
+                          ssl: {
+                              rejectUnauthorized: false,
+                              ca: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
+                          }
+                      }
                     : process.env.DATABASE_SSL === 'true'
-                        ? {
-                            ssl: true
-                        }
-                        : {}),
+                    ? {
+                          ssl: true
+                      }
+                    : {})
             })
             break
         case 'postgres':
@@ -65,16 +65,16 @@ export const init = async (): Promise<void> => {
                 database: process.env.DATABASE_NAME,
                 ...(process.env.DATABASE_SSL_KEY_BASE64
                     ? {
-                        ssl: {
-                            rejectUnauthorized: false,
-                            cert: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
-                        }
-                    }
+                          ssl: {
+                              rejectUnauthorized: false,
+                              cert: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
+                          }
+                      }
                     : process.env.DATABASE_SSL === 'true'
-                        ? {
-                            ssl: true
-                        }
-                        : {}),
+                    ? {
+                          ssl: true
+                      }
+                    : {}),
                 synchronize: false,
                 migrationsRun: false,
                 entities: Object.values(entities),

--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -41,7 +41,7 @@ export const init = async (): Promise<void> => {
                 migrationsRun: false,
                 entities: Object.values(entities),
                 migrations: mysqlMigrations,
-                ssl: getDatabaseSSLFromEnv(),
+                ssl: getDatabaseSSLFromEnv()
             })
             break
         case 'postgres':
@@ -85,9 +85,9 @@ const getDatabaseSSLFromEnv = () => {
         return {
             rejectUnauthorized: false,
             ca: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
-        };
+        }
     } else if (process.env.DATABASE_SSL === 'true') {
-        return true;
+        return true
     }
-    return {};
+    return {}
 }

--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -41,18 +41,7 @@ export const init = async (): Promise<void> => {
                 migrationsRun: false,
                 entities: Object.values(entities),
                 migrations: mysqlMigrations,
-                ...(process.env.DATABASE_SSL_KEY_BASE64
-                    ? {
-                          ssl: {
-                              rejectUnauthorized: false,
-                              ca: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
-                          }
-                      }
-                    : process.env.DATABASE_SSL === 'true'
-                    ? {
-                          ssl: true
-                      }
-                    : {})
+                ssl: getDatabaseSSLFromEnv(),
             })
             break
         case 'postgres':
@@ -63,18 +52,7 @@ export const init = async (): Promise<void> => {
                 username: process.env.DATABASE_USER,
                 password: process.env.DATABASE_PASSWORD,
                 database: process.env.DATABASE_NAME,
-                ...(process.env.DATABASE_SSL_KEY_BASE64
-                    ? {
-                          ssl: {
-                              rejectUnauthorized: false,
-                              cert: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
-                          }
-                      }
-                    : process.env.DATABASE_SSL === 'true'
-                    ? {
-                          ssl: true
-                      }
-                    : {}),
+                ssl: getDatabaseSSLFromEnv(),
                 synchronize: false,
                 migrationsRun: false,
                 entities: Object.values(entities),
@@ -100,4 +78,16 @@ export function getDataSource(): DataSource {
         init()
     }
     return appDataSource
+}
+
+const getDatabaseSSLFromEnv = () => {
+    if (process.env.DATABASE_SSL_KEY_BASE64) {
+        return {
+            rejectUnauthorized: false,
+            ca: Buffer.from(process.env.DATABASE_SSL_KEY_BASE64, 'base64')
+        };
+    } else if (process.env.DATABASE_SSL === 'true') {
+        return true;
+    }
+    return {};
 }


### PR DESCRIPTION
In order to increase the level of security for flowise users who are using **MYSQL** DB, I've added the SSL support.

This PR based on similar PR done for postgres https://github.com/FlowiseAI/Flowise/pull/1613

In order to use this you need to setup **DATABASE_SSL=TRUE** env variable OR **DATABASE_SSL_KEY_BASE64**={YOUR_SSL_BASE64} which overrides the DATABASE_SSL env.

@Jaredude @HenryHengZJ please review

Thanks 🐉 

