### PR TITLE
Add newly-released gpt-3.5-turbo-0125 to ChatOpenAI

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -80,6 +80,10 @@ class ChatOpenAI_ChatModels implements INode {
                         name: 'gpt-3.5-turbo'
                     },
                     {
+                        label: 'gpt-3.5-turbo-0125',
+                        name: 'gpt-3.5-turbo-0125'
+                    },
+                    {
                         label: 'gpt-3.5-turbo-1106',
                         name: 'gpt-3.5-turbo-1106'
                     },


### PR DESCRIPTION
Include newly-released gpt-3.5-turbo-0125 to available models in Chat/OpenAI node