### PR TITLE
[Bufix] Modify the default value of sessionId when fetching history chat messages.

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1440,7 +1440,7 @@ export class App {
                 chatType,
                 chatId,
                 memoryType: memoryType ?? (chatId ? IsNull() : undefined),
-                sessionId: sessionId ?? (chatId ? IsNull() : undefined),
+                sessionId: sessionId ?? undefined,
                 createdDate: toDate && fromDate ? Between(fromDate, toDate) : undefined
             },
             order: {


### PR DESCRIPTION
# 

## Background

I used OpenAI's Assistant in ChatFlow and differentiated users based on their chatId.

Then, when I wanted to retrieve the user's chat message history based on the unique `chatId`, I had to first call `/chatmessage/${chatflowid}` to get all the historical chat messages. Then, I filtered the chat message based on `chatId` and obtained the `sessionId`. After that, I called `/chatmessage/${chatflowid}?chatId=${chatId}&sessionId=${sessionId}` to retrieve the user's chat message.

> 💡 Flowise internal `sessionId` is the `threadId` returned by Assistant and cannot be overwritten.


> ⚠️ Calling `/chatmessage/${chatflowid}` will retrieve all chat messages, which is not ideal.


## Reason

The reason for needing to retrieve the chat history of a single user is because when querying the database, if only the chatId is passed, the sessionId will be null.

![Untitled1](https://github.com/FlowiseAI/Flowise/assets/35761035/798c3984-7fd7-47e6-80a7-1d9ac6d112cd)

[Code address](https://github.com/FlowiseAI/Flowise/blob/37828de66414a1dd35e6e479a9af7f1627db5610/packages/server/src/index.ts#L1443)



## Solution

The value of `sessionId` is no longer related to `chatId`. This means that when retrieving the history messages of the current chatId, you only need to call the `/chatmessage/${chatflowid}?chatId=${chatId}` API once.
<img width="894" alt="Untitled" src="https://github.com/FlowiseAI/Flowise/assets/35761035/00ca34d6-3f46-4f81-914c-8c29661d0b0b">