### PR TITLE
Fixing Postgres so that similaritySearchVectorWithScore actually connects via TLS/SSL when specified

### DIFF
--- a/packages/components/nodes/vectorstores/Postgres/Postgres.ts
+++ b/packages/components/nodes/vectorstores/Postgres/Postgres.ts
@@ -253,7 +253,8 @@ const similaritySearchVectorWithScore = async (
         port: postgresConnectionOptions.port,
         user: postgresConnectionOptions.username,
         password: postgresConnectionOptions.password,
-        database: postgresConnectionOptions.database
+        database: postgresConnectionOptions.database,
+        ssl: postgresConnectionOptions.extra?.ssl
     }
     const pool = new Pool(poolOptions)
     const conn = await pool.connect()

--- a/packages/components/nodes/vectorstores/Postgres/Postgres.ts
+++ b/packages/components/nodes/vectorstores/Postgres/Postgres.ts
@@ -189,7 +189,8 @@ class Postgres_VectorStores implements INode {
             type: 'postgres',
             host: nodeData.inputs?.host as string,
             port: nodeData.inputs?.port as number,
-            username: user,
+            username: user, // Required by TypeORMVectorStore
+            user: user, // Required by Pool in similaritySearchVectorWithScore
             password: password,
             database: nodeData.inputs?.database as string
         }

--- a/packages/components/nodes/vectorstores/Postgres/Postgres.ts
+++ b/packages/components/nodes/vectorstores/Postgres/Postgres.ts
@@ -134,7 +134,7 @@ class Postgres_VectorStores implements INode {
                 port: nodeData.inputs?.port as number,
                 username: user,
                 password: password,
-                database: nodeData.inputs?.database as string,
+                database: nodeData.inputs?.database as string
             }
 
             const args = {

--- a/packages/components/nodes/vectorstores/Postgres/Postgres.ts
+++ b/packages/components/nodes/vectorstores/Postgres/Postgres.ts
@@ -61,13 +61,6 @@ class Postgres_VectorStores implements INode {
                 type: 'string'
             },
             {
-                label: 'SSL Connection',
-                name: 'sslConnection',
-                type: 'boolean',
-                default: false,
-                optional: false
-            },
-            {
                 label: 'Port',
                 name: 'port',
                 type: 'number',
@@ -124,7 +117,6 @@ class Postgres_VectorStores implements INode {
             const docs = nodeData.inputs?.document as Document[]
             const embeddings = nodeData.inputs?.embeddings as Embeddings
             const additionalConfig = nodeData.inputs?.additionalConfig as string
-            const sslConnection = nodeData.inputs?.sslConnection as boolean
 
             let additionalConfiguration = {}
             if (additionalConfig) {
@@ -143,7 +135,6 @@ class Postgres_VectorStores implements INode {
                 username: user,
                 password: password,
                 database: nodeData.inputs?.database as string,
-                ssl: sslConnection
             }
 
             const args = {
@@ -248,15 +239,7 @@ const similaritySearchVectorWithScore = async (
         ORDER BY "_distance" ASC
         LIMIT $3;`
 
-    const poolOptions = {
-        host: postgresConnectionOptions.host,
-        port: postgresConnectionOptions.port,
-        user: postgresConnectionOptions.username,
-        password: postgresConnectionOptions.password,
-        database: postgresConnectionOptions.database,
-        ssl: postgresConnectionOptions.extra?.ssl
-    }
-    const pool = new Pool(poolOptions)
+    const pool = new Pool(postgresConnectionOptions)
     const conn = await pool.connect()
 
     const documents = await conn.query(queryString, [embeddingString, _filter, k])

--- a/packages/components/nodes/vectorstores/Postgres/Postgres.ts
+++ b/packages/components/nodes/vectorstores/Postgres/Postgres.ts
@@ -24,7 +24,7 @@ class Postgres_VectorStores implements INode {
     constructor() {
         this.label = 'Postgres'
         this.name = 'postgres'
-        this.version = 2.0
+        this.version = 3.0
         this.type = 'Postgres'
         this.icon = 'postgres.svg'
         this.category = 'Vector Stores'


### PR DESCRIPTION
Hey @HenryHengZJ, as a follow up to this comment:
https://github.com/FlowiseAI/Flowise/pull/1107#issuecomment-1925593846

The core bug currently is:
- If you configure a Postgres DB to *ONLY* accept remote TLS/SSL connections
- You specify similar `additionalConfig` settings (see below)
- Then the node *will* successfully upsert documents into Postgres via TLS/SSL
- BUT, when you attempt to use the node's `similaritySearchVectorWithScore` function for comparisons, those connections will *fail* because the node attempts to connect to the Postgres DB in the clear (not using TLS/SSL) -- even though the settings were specified in `additionalConfig`

Here's a PR that covers the bugfix for getting the Postgres vectorstore node to actually talk to the DB via TLS/SSL all the time.  Previously, if you specified the `additionalConfig` of:

```
{  
  "ssl": true,  
  "extra": {  
    "ssl": {  
      "rejectUnauthorized": false,  
      "ca": "<your_self_signed_cert_name>"  
    }  
  }  
}  
```

While those settings *were* getting correctly used by the `postgresConnectionOptions` for record upserts, *NONE* of the TLS/SSL settings were actually getting propagated down to the `poolOptions` parameter in the `similaritySearchVectorWithScore` function.

This PR fixes that mismatch.  I've been testing this for a couple of days now and it seems to work for me.  Let me know if you have any additional questions.