### PR TITLE
add kotlin files to folder-loader

### DIFF
--- a/packages/components/nodes/documentloaders/Folder/Folder.ts
+++ b/packages/components/nodes/documentloaders/Folder/Folder.ts
@@ -70,6 +70,7 @@ class Folder_DocumentLoaders implements INode {
             '.css': (path) => new TextLoader(path),
             '.go': (path) => new TextLoader(path), // Go
             '.h': (path) => new TextLoader(path), // C++ Header files
+            '.kt': (path) => new TextLoader(path), // Kotlin
             '.java': (path) => new TextLoader(path), // Java
             '.js': (path) => new TextLoader(path), // JavaScript
             '.less': (path) => new TextLoader(path), // Less files


### PR DESCRIPTION
I noticed that Kotlin files were not loaded via the folder loader.
This PR now adds this file type.