### PR TITLE
persist overrideConfig in chat_message table to support multi tenancy

### DIFF
--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -36,6 +36,7 @@ export interface IChatMessage {
     memoryType?: string
     sessionId?: string
     createdDate: Date
+    overrideConfig?: string
 }
 
 export interface ITool {

--- a/packages/server/src/database/entities/ChatMessage.ts
+++ b/packages/server/src/database/entities/ChatMessage.ts
@@ -40,4 +40,7 @@ export class ChatMessage implements IChatMessage {
 
     @CreateDateColumn()
     createdDate: Date
+
+    @Column({ nullable: true })
+    overrideConfig?: string
 }

--- a/packages/server/src/database/migrations/mysql/1702200925471-AddVariableEntity.ts
+++ b/packages/server/src/database/migrations/mysql/1702200925471-AddVariableEntity.ts
@@ -2,7 +2,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm'
 
 export class AddVariableEntity1699325775451 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(
+                await queryRunner.query(
             `CREATE TABLE IF NOT EXISTS \`variable\` (
                 \`id\` varchar(36) NOT NULL,
                 \`name\` varchar(255) NOT NULL,

--- a/packages/server/src/database/migrations/mysql/1707656902630-AddOverrideConfigToChatMessage.ts
+++ b/packages/server/src/database/migrations/mysql/1707656902630-AddOverrideConfigToChatMessage.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddOverrideConfigToChatMessage1707656902630 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        console.log('hey');
+        const columnExists = await queryRunner.hasColumn('chat_message', 'overrideConfig')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`overrideConfig\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`overrideConfig\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mysql/index.ts
+++ b/packages/server/src/database/migrations/mysql/index.ts
@@ -11,6 +11,7 @@ import { AddUsedToolsToChatMessage1699481607341 } from './1699481607341-AddUsedT
 import { AddCategoryToChatFlow1699900910291 } from './1699900910291-AddCategoryToChatFlow'
 import { AddFileAnnotationsToChatMessage1700271021237 } from './1700271021237-AddFileAnnotationsToChatMessage'
 import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntity'
+import { AddOverrideConfigToChatMessage1707656902630 } from './1707656902630-AddOverrideConfigToChatMessage';
 
 export const mysqlMigrations = [
     Init1693840429259,
@@ -25,5 +26,6 @@ export const mysqlMigrations = [
     AddUsedToolsToChatMessage1699481607341,
     AddCategoryToChatFlow1699900910291,
     AddFileAnnotationsToChatMessage1700271021237,
-    AddVariableEntity1699325775451
+    AddVariableEntity1699325775451,
+    AddOverrideConfigToChatMessage1707656902630
 ]

--- a/packages/server/src/database/migrations/postgres/1707656902630-AddOverrideConfigToChatMessage.ts
+++ b/packages/server/src/database/migrations/postgres/1707656902630-AddOverrideConfigToChatMessage.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddOverrideConfigToChatMessage1707656902630 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_message" ADD COLUMN IF NOT EXISTS "overrideConfig" TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_message" DROP COLUMN "overrideConfig";`)
+    }
+}

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -11,6 +11,7 @@ import { AddUsedToolsToChatMessage1699481607341 } from './1699481607341-AddUsedT
 import { AddCategoryToChatFlow1699900910291 } from './1699900910291-AddCategoryToChatFlow'
 import { AddFileAnnotationsToChatMessage1700271021237 } from './1700271021237-AddFileAnnotationsToChatMessage'
 import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntity'
+import { AddOverrideConfigToChatMessage1707656902630 } from './1707656902630-AddOverrideConfigToChatMessage';
 
 export const postgresMigrations = [
     Init1693891895163,
@@ -25,5 +26,6 @@ export const postgresMigrations = [
     AddUsedToolsToChatMessage1699481607341,
     AddCategoryToChatFlow1699900910291,
     AddFileAnnotationsToChatMessage1700271021237,
-    AddVariableEntity1699325775451
+    AddVariableEntity1699325775451,
+    AddOverrideConfigToChatMessage1707656902630
 ]

--- a/packages/server/src/database/migrations/sqlite/1707656902630-AddOverrideConfigToChatMessage.ts
+++ b/packages/server/src/database/migrations/sqlite/1707656902630-AddOverrideConfigToChatMessage.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddOverrideConfigToChatMessage1707656902630 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE "temp_chat_message" ("id" varchar PRIMARY KEY NOT NULL, "role" varchar NOT NULL, "chatflowid" varchar NOT NULL, "content" text NOT NULL, "sourceDocuments" text, "usedTools" text, "fileAnnotations" text, "createdDate" datetime NOT NULL DEFAULT (datetime('now')), "chatType" VARCHAR NOT NULL DEFAULT 'INTERNAL', "chatId" VARCHAR NOT NULL, "memoryType" VARCHAR, "sessionId" VARCHAR, "overrideConfig" text);`
+        )
+        await queryRunner.query(
+            `INSERT INTO "temp_chat_message" ("id", "role", "chatflowid", "content", "sourceDocuments", "usedTools", "createdDate", "chatType", "chatId", "memoryType", "sessionId", "overrideConfig") SELECT "id", "role", "chatflowid", "content", "sourceDocuments", "usedTools", "createdDate", "chatType", "chatId", "memoryType", "sessionId", "overrideConfig" FROM "chat_message";`
+        )
+        await queryRunner.query(`DROP TABLE "chat_message";`)
+        await queryRunner.query(`ALTER TABLE "temp_chat_message" RENAME TO "chat_message";`)
+        await queryRunner.query(`CREATE INDEX "IDX_e574527322272fd838f4f0f3d3" ON "chat_message" ("chatflowid") ;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE IF EXISTS "temp_chat_message";`)
+        await queryRunner.query(`ALTER TABLE "chat_message" DROP COLUMN "overrideConfig";`)
+    }
+}

--- a/packages/server/src/database/migrations/sqlite/index.ts
+++ b/packages/server/src/database/migrations/sqlite/index.ts
@@ -11,6 +11,7 @@ import { AddUsedToolsToChatMessage1699481607341 } from './1699481607341-AddUsedT
 import { AddCategoryToChatFlow1699900910291 } from './1699900910291-AddCategoryToChatFlow'
 import { AddFileAnnotationsToChatMessage1700271021237 } from './1700271021237-AddFileAnnotationsToChatMessage'
 import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntity'
+import { AddOverrideConfigToChatMessage1707656902630 } from './1707656902630-AddOverrideConfigToChatMessage';
 
 export const sqliteMigrations = [
     Init1693835579790,
@@ -25,5 +26,6 @@ export const sqliteMigrations = [
     AddUsedToolsToChatMessage1699481607341,
     AddCategoryToChatFlow1699900910291,
     AddFileAnnotationsToChatMessage1700271021237,
-    AddVariableEntity1699325775451
+    AddVariableEntity1699325775451,
+    AddOverrideConfigToChatMessage1707656902630
 ]

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1847,7 +1847,8 @@ export class App {
                 chatId,
                 memoryType,
                 sessionId,
-                createdDate: userMessageDateTime
+                createdDate: userMessageDateTime,
+                overrideConfig: incomingInput?.overrideConfig ? JSON.stringify(incomingInput?.overrideConfig) : undefined
             }
             await this.addChatMessage(userMessage)
 
@@ -1863,12 +1864,13 @@ export class App {
                 chatType: isInternal ? chatType.INTERNAL : chatType.EXTERNAL,
                 chatId,
                 memoryType,
-                sessionId
+                sessionId,
+                overrideConfig: incomingInput?.overrideConfig ? JSON.stringify(incomingInput?.overrideConfig) : undefined
             }
             if (result?.sourceDocuments) apiMessage.sourceDocuments = JSON.stringify(result.sourceDocuments)
             if (result?.usedTools) apiMessage.usedTools = JSON.stringify(result.usedTools)
             if (result?.fileAnnotations) apiMessage.fileAnnotations = JSON.stringify(result.fileAnnotations)
-            const chatMessage = await this.addChatMessage(apiMessage)
+                        const chatMessage = await this.addChatMessage(apiMessage)
             result.chatMessageId = chatMessage.id
 
             logger.debug(`[server]: Finished running ${nodeToExecuteData.label} (${nodeToExecuteData.id})`)


### PR DESCRIPTION
In order to support multi tenancy in flowise, meaning that a single flow may server multiple customers we can deliver the `overrideConfig` parameter to the `prediction`/`internal-prediction` APIs, so you can overload additional `variable` of `customer_id` (for example, or you can give whatever alias you would like to).


But with the current implementation and in order to support the predictions analytics/logs you won't be able to differ such `chat_message`s among your different tenants/customers.

Hence, I added this overrideConfig to be persisted which will bring us the ability to QUERY by your given `variable` (e.g. `customer_id`)

So for example, if your API would called with such `overrideConfig`:

![image](https://github.com/FlowiseAI/Flowise/assets/19833797/66e9a9c7-d019-4404-bbb5-4a5ed8a0eb21)

You can later query that watching the final result persisted on DB:

![image](https://github.com/FlowiseAI/Flowise/assets/19833797/8b3fe930-a052-4642-8595-713743c817bf)

