### PR TITLE
fixes bug where querying by chatId results in no records

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1453,7 +1453,7 @@ export class App {
                 chatflowid,
                 chatType,
                 chatId,
-                memoryType: memoryType ?? (chatId ? IsNull() : undefined),
+                memoryType: memoryType ?? undefined,
                 sessionId: sessionId ?? undefined,
                 createdDate: toDate && fromDate ? Between(fromDate, toDate) : undefined
             },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,7 +10,7 @@ import logger from './utils/logger'
 import { expressRequestLogger } from './utils/logger'
 import { v4 as uuidv4 } from 'uuid'
 import OpenAI from 'openai'
-import { Between, IsNull, FindOptionsWhere } from 'typeorm'
+import { FindOptionsWhere, MoreThanOrEqual, LessThanOrEqual } from 'typeorm'
 import {
     IChatFlow,
     IncomingInput,
@@ -1464,7 +1464,8 @@ export class App {
                 chatId,
                 memoryType: memoryType ?? undefined,
                 sessionId: sessionId ?? undefined,
-                createdDate: toDate && fromDate ? Between(fromDate, toDate) : undefined
+                ...(fromDate && { createdDate: MoreThanOrEqual(fromDate) }),
+                ...(toDate && { createdDate: LessThanOrEqual(toDate) })
             },
             order: {
                 createdDate: sortOrder === 'DESC' ? 'DESC' : 'ASC'

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1442,11 +1442,20 @@ export class App {
         startDate?: string,
         endDate?: string
     ): Promise<ChatMessage[]> {
+        const setDateToStartOrEndOfDay = (dateTimeStr: string, setHours: 'start' | 'end') => {
+            const date = new Date(dateTimeStr)
+            if (isNaN(date.getTime())) {
+                return undefined
+            }
+            setHours === 'start' ? date.setHours(0, 0, 0, 0) : date.setHours(23, 59, 59, 999)
+            return date
+        }
+
         let fromDate
-        if (startDate) fromDate = new Date(startDate)
+        if (startDate) fromDate = setDateToStartOrEndOfDay(startDate, 'start')
 
         let toDate
-        if (endDate) toDate = new Date(endDate)
+        if (endDate) toDate = setDateToStartOrEndOfDay(endDate, 'end')
 
         return await this.AppDataSource.getRepository(ChatMessage).find({
             where: {


### PR DESCRIPTION
previous logic for where clause of memoryType checked for existence of chatId and would query for memoryType is null This where clause logic results in an empty result for any request to the endpoint that filters by chatId

Getting messages without any filters
<img width="1060" alt="Screenshot 2024-02-12 at 8 14 32 PM" src="https://github.com/FlowiseAI/Flowise/assets/10228950/1f9bc36b-a934-403d-8838-41d030142f4d">

filtering by known chatId value using existing where clause
<img width="1070" alt="Screenshot 2024-02-12 at 8 16 09 PM" src="https://github.com/FlowiseAI/Flowise/assets/10228950/15c9d571-afd6-4d49-854b-b986d2fb9cde">

filtering by known chatId value using new where clause logic for memoryType
<img width="1052" alt="Screenshot 2024-02-12 at 8 15 09 PM" src="https://github.com/FlowiseAI/Flowise/assets/10228950/ef90fec8-23df-468b-bcad-1e1b994af3c3">
