### PR TITLE
fix Dockerfile to actually start server

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,4 @@ RUN npm install -g flowise
 
 WORKDIR /data
 
-CMD "flowise"
+CMD flowise start


### PR DESCRIPTION
If you run the docker image built with current Dockerfile, container simply outputs the output of `flowise` command to its log and exit. This is due to `CMD` in Dockerfile just points `flowise` instead of `flowise start` which actually starts the server. Simple update on Dockerfile to make it actually start the server.