### PR TITLE
FIX: ES module import issue in Qdrant package

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     },
     "engines": {
         "node": ">=18.15.0"
+    },
+    "resolutions": {
+        "@qdrant/openapi-typescript-fetch": "1.2.1"
     }
 }


### PR DESCRIPTION
The latest version of a dependency (`@qdrant/openapi-typescript-fetch`) in the `@qdrant/js-client-rest` package causes an error when starting the Flowise server. This also caused an issue with adding credentials. Pinning the previous version of the dependency in the root `package.json` fixes the issue.

Before:
![flowise-dev-errors](https://github.com/FlowiseAI/Flowise/assets/4386534/82b3ca51-f16e-44f8-b8f1-5d0583c5a58c)

After:
![flowise-dev-errors-2](https://github.com/FlowiseAI/Flowise/assets/4386534/2b99bff0-a341-4e95-981a-ee2a4364d5eb)

