### PR TITLE
Feature: Add support for accessing NodeData via json path

### DIFF
--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -541,7 +541,7 @@ export const getVariableValue = (
                 if (variableFullPathParts.length > 3) {
                     let variableObj = null
                     switch (typeof variableValue) {
-                        case 'string':
+                        case 'string': {
                             const unEscapedVariableValue = handleEscapeCharacters(variableValue, true)
                             if (unEscapedVariableValue.startsWith('{') && unEscapedVariableValue.endsWith('}')) {
                                 try {
@@ -551,9 +551,11 @@ export const getVariableValue = (
                                 }
                             }
                             break
-                        case 'object':
+                        }
+                        case 'object': {
                             variableObj = variableValue
                             break
+                        }
                         default:
                             break
                     }

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -561,7 +561,10 @@ export const getVariableValue = (
                     }
                     if (variableObj) {
                         variableObj = get(variableObj, variableFullPathParts.slice(3))
-                        variableValue = handleEscapeCharacters(JSON.stringify(variableObj), false)
+                        variableValue = handleEscapeCharacters(
+                            typeof variableObj === 'object' ? JSON.stringify(variableObj) : variableObj,
+                            false
+                        )
                     }
                 }
                 if (isAcceptVariable) {

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -528,11 +528,40 @@ export const getVariableValue = (
                 variableDict[`{{${variableFullPath}}}`] = handleEscapeCharacters(convertChatHistoryToText(chatHistory), false)
             }
 
-            // Split by first occurrence of '.' to get just nodeId
-            const [variableNodeId, _] = variableFullPath.split('.')
+            // Resolve values with following case.
+            // 1: <variableNodeId>.data.instance
+            // 2: <variableNodeId>.data.instance.pathtokey
+            const variableFullPathParts = variableFullPath.split('.')
+            const variableNodeId = variableFullPathParts[0]
             const executedNode = reactFlowNodes.find((nd) => nd.id === variableNodeId)
             if (executedNode) {
-                const variableValue = get(executedNode.data, 'instance')
+                let variableValue = get(executedNode.data, 'instance')
+
+                // Handle path such as `<variableNodeId>.data.instance.key`
+                if (variableFullPathParts.length > 3) {
+                    let variableObj = null
+                    switch (typeof variableValue) {
+                        case 'string':
+                            const unEscapedVariableValue = handleEscapeCharacters(variableValue, true)
+                            if (unEscapedVariableValue.startsWith('{') && unEscapedVariableValue.endsWith('}')) {
+                                try {
+                                    variableObj = JSON.parse(unEscapedVariableValue)
+                                } catch (e) {
+                                    // ignore
+                                }
+                            }
+                            break
+                        case 'object':
+                            variableObj = variableValue
+                            break
+                        default:
+                            break
+                    }
+                    if (variableObj) {
+                        variableObj = get(variableObj, variableFullPathParts.slice(3))
+                        variableValue = handleEscapeCharacters(JSON.stringify(variableObj), false)
+                    }
+                }
                 if (isAcceptVariable) {
                     variableDict[`{{${variableFullPath}}}`] = variableValue
                 } else {


### PR DESCRIPTION
This PR supports `{{<variableNodeId>.data.instance.pathtokey}}`.

<img width="505" alt="图片" src="https://github.com/FlowiseAI/Flowise/assets/16131917/d3f76aaa-5f89-4c75-91fa-6f4064d3d158">


---

This is useful for PromptTemplate to get the value of one of its fields from the previous node json value output.