### PR TITLE
Bugfix/Set Variable

### DIFF
--- a/packages/components/nodes/utilities/SetVariable/SetVariable.ts
+++ b/packages/components/nodes/utilities/SetVariable/SetVariable.ts
@@ -46,8 +46,12 @@ class SetVariable_Utilities implements INode {
     }
 
     async init(nodeData: INodeData): Promise<any> {
-        const inputRaw = nodeData.inputs?.input
+        let inputRaw = nodeData.inputs?.input
         const variableName = nodeData.inputs?.variableName as string
+
+        if (Array.isArray(inputRaw) && inputRaw.length === 1) {
+            inputRaw = inputRaw[0]
+        }
 
         return { output: inputRaw, dynamicVariables: { [variableName]: inputRaw } }
     }


### PR DESCRIPTION
Bug: Set Variable input always has an array like `['value']`, this causes error when Get Variable is called to retrieve the variable