### PR TITLE
Fix: starter prompts exceeds chat window and cannot be scrolled

### DIFF
--- a/packages/ui/src/ui-component/cards/StarterPromptsCard.css
+++ b/packages/ui/src/ui-component/cards/StarterPromptsCard.css
@@ -1,7 +1,9 @@
 .button-container {
     display: flex;
+    flex-wrap: wrap;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch; /* For momentum scroll on mobile devices */
+    scrollbar-width: none; /* For Firefox */
 }
 
 .button {

--- a/packages/ui/src/ui-component/cards/StarterPromptsCard.css
+++ b/packages/ui/src/ui-component/cards/StarterPromptsCard.css
@@ -2,7 +2,6 @@
     display: flex;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch; /* For momentum scroll on mobile devices */
-    scrollbar-width: none; /* For Firefox */
 }
 
 .button {


### PR DESCRIPTION
When starter prompts are long or when we have more than 3, the prompts exceed the chat window. It's only scrollable with a trackpad and doesn't show a scrollbar. Now prompts will wrap, which is the behavior in embed.

![Flowise-Low-code-LLM-apps-builder (10)](https://github.com/FlowiseAI/Flowise/assets/4386534/ef056fa3-f352-4e81-9589-569887432e3a)
