### PR TITLE
CONSTRAINT ID already in use - in postgresql migration - 1707213601923-AddFeedback.ts

### DIFF
--- a/packages/server/src/database/migrations/postgres/1707213601923-AddFeedback.ts
+++ b/packages/server/src/database/migrations/postgres/1707213601923-AddFeedback.ts
@@ -11,7 +11,7 @@ export class AddFeedback1707213601923 implements MigrationInterface {
                 "messageId" varchar NOT NULL,
                 "rating" varchar NOT NULL,
                 "createdDate" timestamp NOT NULL DEFAULT now(),
-                CONSTRAINT "PK_98419043dd704f54-9830ab78f8" PRIMARY KEY (id)
+                CONSTRAINT "PK_chat_message_feedback_id" PRIMARY KEY (id)
             );`
         )
     }


### PR DESCRIPTION
There is a conflict with AddVariableEntity1699325775451 which is using the same CONSTRAINT ID

I manually changed it. But there may be a better way to fix this (directly in the /entities/..) or when creating these migrations.