### PR TITLE
Fix: Faiss vector store throws error when using pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "packageManager": "pnpm@8.14.0",
     "pnpm": {
         "onlyBuiltDependencies": [
+            "faiss-node",
             "sqlite3"
         ]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 onlyBuiltDependencies:
+  - faiss-node
   - sqlite3
 
 overrides:
@@ -14430,6 +14431,7 @@ packages:
   /faiss-node@0.2.3:
     resolution: {integrity: sha512-HfGhKFjyXPIyAlatcBNjv66q5ZQ43xfIpv8Uc17mIbEye7gbrmzVqAy+OxdlRy0usuLni+Dk1vSXf/z2yyr1Dg==}
     engines: {node: '>= 14.0.0'}
+    requiresBuild: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 6.1.0


### PR DESCRIPTION
Fixes an error thrown by the Faiss node when using pnpm to install packages.