### PR TITLE
Enable github workflow pnpm caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,16 @@ jobs:
         env:
             PUPPETEER_SKIP_DOWNLOAD: true
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v2
+              with:
+                  version: 6.32.9
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
+                  check-latest: false
+                  cache: 'pnpm'
 
             - run: npm i -g pnpm
 


### PR DESCRIPTION
The action follows [actions/cache](https://github.com/actions/cache/blob/main/examples.md#node---npm) guidelines, and caches global cache on the machine instead of node_modules, so cache can be reused between different Node.js versions.

Caching pnpm (v6.10+) dependencies

NOTES:
- pnpm caching support requires pnpm version >= 6.10.0
- By default --frozen-lockfile option is passed starting from pnpm 6.10.x. It will be automatically added if we run it on [CI](https://pnpm.io/cli/install#--frozen-lockfile). If the pnpm-lock.yaml file changes then we have to pass --frozen-lockfile option.