### PR TITLE
Send valid JSON to autosync workflows for multi-line commit messages

### DIFF
--- a/.github/workflows/autoSyncMergedPullRequest.yml
+++ b/.github/workflows/autoSyncMergedPullRequest.yml
@@ -28,6 +28,6 @@ jobs:
                         "ref": "${{ github.ref }}",
                         "prNumber": "${{ github.event.pull_request.number }}",
                         "prTitle": "${{ github.event.pull_request.title }}",
-                        "prDescription": "${{ github.event.pull_request.description }}",
+                        "prDescription": "${{ toJSON(github.event.pull_request.description) }}",
                         "sha": "${{ github.sha }}"
                       }

--- a/.github/workflows/autoSyncSingleCommit.yml
+++ b/.github/workflows/autoSyncSingleCommit.yml
@@ -32,5 +32,5 @@ jobs:
                       {
                         "ref": "${{ github.ref }}",
                         "sha": "${{ github.sha }}",
-                        "commitMessage": "${{ github.event.commits[0].message }}"
+                        "commitMessage": "${{ toJSON(github.event.commits[0].message) }}"
                       }


### PR DESCRIPTION
Allow multi-line commit message to be used in autosync workflows using the [toJSON context function](https://docs.github.com/en/actions/learn-github-actions/expressions#tojson)