### PR TITLE
Fix #2000

### DIFF
--- a/packages/server/src/database/entities/ChatMessage.ts
+++ b/packages/server/src/database/entities/ChatMessage.ts
@@ -32,13 +32,13 @@ export class ChatMessage implements IChatMessage {
     @Column()
     chatType: string
 
-    @Column({ type: 'uuid' })
+    @Column({ type: 'varchar' })
     chatId: string
 
     @Column({ nullable: true })
     memoryType?: string
 
-    @Column({ type: 'uuid', nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     sessionId?: string
 
     @Column({type:'timestamp'})

--- a/packages/server/src/database/entities/ChatMessageFeedback.ts
+++ b/packages/server/src/database/entities/ChatMessageFeedback.ts
@@ -13,7 +13,7 @@ export class ChatMessageFeedback implements IChatMessageFeedback {
     chatflowid: string
 
     @Index()
-    @Column({ type: 'uuid' })
+    @Column({ type: 'varchar' })
     chatId: string
 
     @Column({ type: 'uuid' })

--- a/packages/server/src/database/migrations/postgres/1710497452584-FieldTypes.ts
+++ b/packages/server/src/database/migrations/postgres/1710497452584-FieldTypes.ts
@@ -5,13 +5,10 @@ export class FieldTypes1710497452584 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "chatflowid" type uuid USING "chatflowid"::uuid`)
-        await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "chatId" type uuid USING "chatId"::uuid`)
-        await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "sessionId" type uuid USING "sessionId"::uuid`)
 
         await queryRunner.query(`ALTER TABLE "assistant" ALTER COLUMN "credential" type uuid USING "credential"::uuid`)
 
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "chatflowid" type uuid USING "chatflowid"::uuid`)
-        await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "chatId" type uuid USING "chatId"::uuid`)
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "messageId" type uuid USING "messageId"::uuid`)
 
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ADD CONSTRAINT "UQ_6352078b5a294f2d22179ea7955" UNIQUE ("messageId")`)
@@ -29,13 +26,10 @@ export class FieldTypes1710497452584 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" DROP CONSTRAINT "UQ_6352078b5a294f2d22179ea7955"`)
 
         await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "chatflowid" type varchar USING "chatflowid"::varchar`)
-        await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "chatId" type varchar USING "chatId"::varchar`)
-        await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "sessionId" type varchar USING "sessionId"::varchar`)
 
         await queryRunner.query(`ALTER TABLE "assistant" ALTER COLUMN "credential" type varchar USING "credential"::varchar`)
 
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "chatflowid" type varchar USING "chatflowid"::varchar`)
-        await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "chatId" type varchar USING "chatId"::varchar`)
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "messageId" type varchar USING "messageId"::varchar`)
     }
 }

--- a/packages/server/src/database/migrations/postgres/1710497452584-FieldTypes.ts
+++ b/packages/server/src/database/migrations/postgres/1710497452584-FieldTypes.ts
@@ -5,10 +5,13 @@ export class FieldTypes1710497452584 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "chatflowid" type uuid USING "chatflowid"::uuid`)
+        await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "chatId" type varchar USING "chatId"::varchar`)
+        await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "sessionId" varchar uuid USING "sessionId"::varchar`)
 
         await queryRunner.query(`ALTER TABLE "assistant" ALTER COLUMN "credential" type uuid USING "credential"::uuid`)
 
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "chatflowid" type uuid USING "chatflowid"::uuid`)
+        await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "chatId" type varchar USING "chatId"::varchar`)
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "messageId" type uuid USING "messageId"::uuid`)
 
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ADD CONSTRAINT "UQ_6352078b5a294f2d22179ea7955" UNIQUE ("messageId")`)
@@ -26,10 +29,13 @@ export class FieldTypes1710497452584 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" DROP CONSTRAINT "UQ_6352078b5a294f2d22179ea7955"`)
 
         await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "chatflowid" type varchar USING "chatflowid"::varchar`)
+        await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "chatId" type varchar USING "chatId"::varchar`)
+        await queryRunner.query(`ALTER TABLE "chat_message" ALTER COLUMN "sessionId" type varchar USING "sessionId"::varchar`)
 
         await queryRunner.query(`ALTER TABLE "assistant" ALTER COLUMN "credential" type varchar USING "credential"::varchar`)
 
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "chatflowid" type varchar USING "chatflowid"::varchar`)
+        await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "chatId" type varchar USING "chatId"::varchar`)
         await queryRunner.query(`ALTER TABLE "chat_message_feedback" ALTER COLUMN "messageId" type varchar USING "messageId"::varchar`)
     }
 }


### PR DESCRIPTION
This PR fixes #2000 

Sorry for the inconvenience, The Last PR was to change chatId and sessionId types into UUID types. The problem is both the chatId and the sessionId fields are user-defined variables. Therefore they must stay in varchar type in the database.

Note : This PR also handles the users who already migrated to 1.6.2