### PR TITLE
fix: update streaming how-to url

### DIFF
--- a/packages/ui/src/views/chatflows/APICodeDialog.jsx
+++ b/packages/ui/src/views/chatflows/APICodeDialog.jsx
@@ -709,7 +709,7 @@ formData.append("openAIApiKey[openAIEmbeddings_0]", "sk-my-openai-2nd-key")`
                                 {getIsChatflowStreamingApi.data?.isStreaming && (
                                     <p>
                                         Read&nbsp;
-                                        <a rel='noreferrer' target='_blank' href='https://docs.flowiseai.com/how-to-use#streaming'>
+                                        <a rel='noreferrer' target='_blank' href='https://docs.flowiseai.com/using-flowise/streaming'>
                                             here
                                         </a>
                                         &nbsp;on how to stream response back to application


### PR DESCRIPTION
The current url takes you to 404. Updated the href.

<img width="458" alt="image" src="https://github.com/FlowiseAI/Flowise/assets/6112201/5e109a3e-e14d-4fa9-ab98-8ae04622d158">

