### PR TITLE
bugfix: depreciating chatgpt plugin

### DIFF
--- a/packages/components/nodes/tools/AIPlugin/AIPlugin.ts
+++ b/packages/components/nodes/tools/AIPlugin/AIPlugin.ts
@@ -12,6 +12,7 @@ class AIPlugin implements INode {
     category: string
     baseClasses: string[]
     inputs?: INodeParams[]
+    badge: string
 
     constructor() {
         this.label = 'AI Plugin'
@@ -22,6 +23,7 @@ class AIPlugin implements INode {
         this.category = 'Tools'
         this.description = 'Execute actions using ChatGPT Plugin Url'
         this.baseClasses = [this.type, ...getBaseClasses(AIPluginTool)]
+        this.badge = 'DEPRECATING'
         this.inputs = [
             {
                 label: 'Plugin Url',


### PR DESCRIPTION
**I have noticed that we don't have to use the AIPlugin in nodes under the tools section because the ChatGPT Plugin is winding down on March 19. This means the endpoints will no longer function, which could lead to bugs. Users who are already using the AIPlugin tool should be notified via the Badge (DEPRECATING) so they are aware that they should not use this tool in production.**

### Depreciating ChatGPT Plugins:
[https://help.openai.com/en/articles/8988022-winding-down-the-chatgpt-plugins-beta](https://help.openai.com/en/articles/8988022-winding-down-the-chatgpt-plugins-beta
)
