### PR TITLE
Bugfix/Web Scraper Limit

### DIFF
--- a/packages/components/nodes/documentloaders/Cheerio/Cheerio.ts
+++ b/packages/components/nodes/documentloaders/Cheerio/Cheerio.ts
@@ -132,7 +132,7 @@ class Cheerio_DocumentLoaders implements INode {
             else if (limit < 0) throw new Error('Limit cannot be less than 0')
             const pages: string[] =
                 selectedLinks && selectedLinks.length > 0
-                    ? selectedLinks.slice(0, limit)
+                    ? selectedLinks.slice(0, limit === 0 ? undefined : limit)
                     : relativeLinksMethod === 'webCrawl'
                     ? await webCrawl(url, limit)
                     : await xmlScrape(url, limit)

--- a/packages/components/nodes/documentloaders/Playwright/Playwright.ts
+++ b/packages/components/nodes/documentloaders/Playwright/Playwright.ts
@@ -173,7 +173,7 @@ class Playwright_DocumentLoaders implements INode {
             else if (limit < 0) throw new Error('Limit cannot be less than 0')
             const pages: string[] =
                 selectedLinks && selectedLinks.length > 0
-                    ? selectedLinks.slice(0, limit)
+                    ? selectedLinks.slice(0, limit === 0 ? undefined : limit)
                     : relativeLinksMethod === 'webCrawl'
                     ? await webCrawl(url, limit)
                     : await xmlScrape(url, limit)

--- a/packages/components/nodes/documentloaders/Puppeteer/Puppeteer.ts
+++ b/packages/components/nodes/documentloaders/Puppeteer/Puppeteer.ts
@@ -174,7 +174,7 @@ class Puppeteer_DocumentLoaders implements INode {
             else if (limit < 0) throw new Error('Limit cannot be less than 0')
             const pages: string[] =
                 selectedLinks && selectedLinks.length > 0
-                    ? selectedLinks.slice(0, limit)
+                    ? selectedLinks.slice(0, limit === 0 ? undefined : limit)
                     : relativeLinksMethod === 'webCrawl'
                     ? await webCrawl(url, limit)
                     : await xmlScrape(url, limit)


### PR DESCRIPTION
Bug: when `limit` set to 0, `selectedLinks` sliced to become empty
Expected: if `selectedLinks` is not empty AND `limit` is 0, `pages` == `selectedLinks`