### PR TITLE
fix missing comma upon sql migration query

### DIFF
--- a/packages/server/src/database/migrations/mysql/1709814301358-AddUpsertHistoryEntity.ts
+++ b/packages/server/src/database/migrations/mysql/1709814301358-AddUpsertHistoryEntity.ts
@@ -10,7 +10,7 @@ export class AddUpsertHistoryEntity1709814301358 implements MigrationInterface {
                 \`flowData\` text NOT NULL,
                 \`date\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
                 PRIMARY KEY (\`id\`)
-                KEY \`IDX_a0b59fd66f6e48d2b198123cb6\` (\`chatflowid\`)
+                KEY \`IDX_a0b59fd66f6e48d2b198123cb6\` (\`chatflowid\`),
               ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`
         )
     }

--- a/packages/server/src/database/migrations/mysql/1709814301358-AddUpsertHistoryEntity.ts
+++ b/packages/server/src/database/migrations/mysql/1709814301358-AddUpsertHistoryEntity.ts
@@ -9,8 +9,8 @@ export class AddUpsertHistoryEntity1709814301358 implements MigrationInterface {
                 \`result\` text NOT NULL,
                 \`flowData\` text NOT NULL,
                 \`date\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-                PRIMARY KEY (\`id\`)
-                KEY \`IDX_a0b59fd66f6e48d2b198123cb6\` (\`chatflowid\`),
+                PRIMARY KEY (\`id\`),
+                KEY \`IDX_a0b59fd66f6e48d2b198123cb6\` (\`chatflowid\`)
               ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`
         )
     }


### PR DESCRIPTION
while running latest deployment I'm getting the following syntax error for mysql db:

Migration "AddUpsertHistoryEntity1709814301358" failed, error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'KEY `IDX_a0b59fd66f6e48d2b198123cb6` (`chatflowid`)) ENGINE=InnoD' at line 8

There was missing comma which fixed that,

@HenryHengZJ please review