### PR TITLE
Optimize `getEndingNodes`

### DIFF
--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -178,50 +178,35 @@ export const utilBuildChatflow = async (req: Request, socketIO?: Server, isInter
             /*** Get Ending Node with Directed Graph  ***/
             const { graph, nodeDependencies } = constructGraphs(nodes, edges)
             const directedGraph = graph
-            const endingNodeIds = getEndingNodes(nodeDependencies, directedGraph)
-            if (!endingNodeIds.length) {
-                throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, `Ending nodes not found`)
-            }
 
-            const endingNodes = nodes.filter((nd) => endingNodeIds.includes(nd.id))
+            const endingNodes = getEndingNodes(nodeDependencies, directedGraph, nodes)
 
-            let isEndingNodeExists = endingNodes.find((node) => node.data?.outputs?.output === 'EndingNode')
+            let isCustomFunctionEndingNode = endingNodes.some((node) => node.data?.outputs?.output === 'EndingNode')
 
             for (const endingNode of endingNodes) {
                 const endingNodeData = endingNode.data
-                if (!endingNodeData) {
-                    throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, `Ending node ${endingNode.id} data not found`)
-                }
 
                 const isEndingNode = endingNodeData?.outputs?.output === 'EndingNode'
 
-                if (!isEndingNode) {
-                    if (
-                        endingNodeData &&
-                        endingNodeData.category !== 'Chains' &&
-                        endingNodeData.category !== 'Agents' &&
-                        endingNodeData.category !== 'Engine'
-                    ) {
-                        throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, `Ending node must be either a Chain or Agent`)
-                    }
+                // Once custom function ending node exists, no need to do follow-up checks.
+                if (isEndingNode) continue
 
-                    if (
-                        endingNodeData.outputs &&
-                        Object.keys(endingNodeData.outputs).length &&
-                        !Object.values(endingNodeData.outputs ?? {}).includes(endingNodeData.name)
-                    ) {
-                        throw new InternalFlowiseError(
-                            StatusCodes.INTERNAL_SERVER_ERROR,
-                            `Output of ${endingNodeData.label} (${endingNodeData.id}) must be ${endingNodeData.label}, can't be an Output Prediction`
-                        )
-                    }
+                if (
+                    endingNodeData.outputs &&
+                    Object.keys(endingNodeData.outputs).length &&
+                    !Object.values(endingNodeData.outputs ?? {}).includes(endingNodeData.name)
+                ) {
+                    throw new InternalFlowiseError(
+                        StatusCodes.INTERNAL_SERVER_ERROR,
+                        `Output of ${endingNodeData.label} (${endingNodeData.id}) must be ${endingNodeData.label}, can't be an Output Prediction`
+                    )
                 }
 
                 isStreamValid = isFlowValidForStream(nodes, endingNodeData)
             }
 
             // Once custom function ending node exists, flow is always unavailable to stream
-            isStreamValid = isEndingNodeExists ? false : isStreamValid
+            isStreamValid = isCustomFunctionEndingNode ? false : isStreamValid
 
             let chatHistory: IMessage[] = []
 
@@ -252,6 +237,7 @@ export const utilBuildChatflow = async (req: Request, socketIO?: Server, isInter
             const nonDirectedGraph = constructedObj.graph
             let startingNodeIds: string[] = []
             let depthQueue: IDepthQueue = {}
+            const endingNodeIds = endingNodes.map((n) => n.id)
             for (const endingNodeId of endingNodeIds) {
                 const resx = getStartingNodes(nonDirectedGraph, endingNodeId)
                 startingNodeIds.push(...resx.startingNodeIds)


### PR DESCRIPTION
If there are multiple end nodes, only one needs to pass verification, and the others are automatically ignored. 

This allows us to temporarily disconnect a node without deleting it.