### PR TITLE
fix: add migration to modify chatflowconfig to longtext for mysql

### DIFF
--- a/packages/server/src/database/migrations/mysql/1712762777471-ExpandChatflowConfig.ts
+++ b/packages/server/src/database/migrations/mysql/1712762777471-ExpandChatflowConfig.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ExpandChatFlowConfig1712762777471 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` MODIFY \`chatbotConfig\` LONGTEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` MODIFY \`chatbotConfig\` TEXT;`)
+    }
+}

--- a/packages/server/src/database/migrations/mysql/index.ts
+++ b/packages/server/src/database/migrations/mysql/index.ts
@@ -15,6 +15,7 @@ import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntit
 import { AddSpeechToText1706364937060 } from './1706364937060-AddSpeechToText'
 import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { AddFeedback1707213626553 } from './1707213626553-AddFeedback'
+import { ExpandChatFlowConfig1712762777471 } from './1712762777471-ExpandChatflowConfig'
 
 export const mysqlMigrations = [
     Init1693840429259,
@@ -33,5 +34,6 @@ export const mysqlMigrations = [
     AddVariableEntity1699325775451,
     AddSpeechToText1706364937060,
     AddUpsertHistoryEntity1709814301358,
-    AddFeedback1707213626553
+    AddFeedback1707213626553,
+    ExpandChatFlowConfig1712762777471
 ]


### PR DESCRIPTION
Using big CSV files as document loaders my break mysql chat flow because of the TEXT size of the column and base64 conversion.

Here a migration has been added to change the column type from TEXT to LONGTEXT (4GB of max data)