### PR TITLE
feat: add gpt-4-trubo (new updated model by OpenAI)

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -50,6 +50,10 @@ class ChatOpenAI_ChatModels implements INode {
                         name: 'gpt-4'
                     },
                     {
+                        label: 'gpt-4-turbo',
+                        name: 'gpt-4-turbo'
+                    },
+                    {
                         label: 'gpt-4-turbo-preview',
                         name: 'gpt-4-turbo-preview'
                     },


### PR DESCRIPTION
**Add: New "GPT-4-Turbo" with Vision Model in the ChatOpenAI Node.**

Yesterday, they have released a stable version of gpt-4-turbo series with a context window size of 128,000 tokens and updated training data up to December 2023.

**Official Release Reference:**
#[https://platform.openai.com/docs/models/continuous-model-upgrades](https://platform.openai.com/docs/models/continuous-model-upgrades)