### PR TITLE
Unable to view upsert history dialog, when InMemoryVector Store is used

### DIFF
--- a/packages/ui/src/views/vectorstore/UpsertHistoryDialog.jsx
+++ b/packages/ui/src/views/vectorstore/UpsertHistoryDialog.jsx
@@ -157,11 +157,13 @@ function UpsertHistoryRow(props) {
                                                 </div>
                                             </AccordionSummary>
                                             <AccordionDetails>
-                                                <TableViewOnly
-                                                    sx={{ minWidth: 150 }}
-                                                    rows={node.paramValues}
-                                                    columns={Object.keys(node.paramValues[0])}
-                                                />
+                                                {node.paramValues[0] && (
+                                                    <TableViewOnly
+                                                        sx={{ minWidth: 150 }}
+                                                        rows={node.paramValues}
+                                                        columns={Object.keys(node.paramValues[0])}
+                                                    />
+                                                )}
                                             </AccordionDetails>
                                         </Accordion>
                                     )


### PR DESCRIPTION
Steps to reproduce:
1) Create a new chatflow with InMemory VectorStore and do an upsert.
2) Click on Upsert History Dialog from settings
3) Expand Accordion - Details 
4) Expand the InMemory Accordion
