### PR TITLE
models.json support for Groq

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -366,6 +366,27 @@
             ]
         },
         {
+            "name": "groqChat",
+            "models": [
+                {
+                    "label": "gemma-7b-it",
+                    "name": "gemma-7b-it"
+                },
+                {
+                    "label": "llama3-70b-8192",
+                    "name": "llama3-70b-8192"
+                },
+                {
+                    "label": "llama3-8b-8192",
+                    "name": "llama3-8b-8192"
+                },
+                {
+                    "label": "mixtral-8x7b-32768",
+                    "name": "mixtral-8x7b-32768"
+                }
+            ]
+        },
+        {
             "name": "chatCohere",
             "models": [
                 {

--- a/packages/components/nodes/chatmodels/Groq/Groq.ts
+++ b/packages/components/nodes/chatmodels/Groq/Groq.ts
@@ -56,7 +56,7 @@ class Groq_ChatModels implements INode {
             }
         ]
     }
-    
+
     //@ts-ignore
     loadMethods = {
         async listModels(): Promise<INodeOptionsValue[]> {

--- a/packages/components/nodes/chatmodels/Groq/Groq.ts
+++ b/packages/components/nodes/chatmodels/Groq/Groq.ts
@@ -19,7 +19,7 @@ class Groq_ChatModels implements INode {
     constructor() {
         this.label = 'GroqChat'
         this.name = 'groqChat'
-        this.version = 2.0
+        this.version = 3.0
         this.type = 'GroqChat'
         this.icon = 'groq.png'
         this.category = 'Chat Models'

--- a/packages/components/nodes/chatmodels/Groq/Groq.ts
+++ b/packages/components/nodes/chatmodels/Groq/Groq.ts
@@ -1,6 +1,7 @@
 import { BaseCache } from '@langchain/core/caches'
 import { ChatGroq, ChatGroqInput } from '@langchain/groq'
-import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { ICommonObject, INode, INodeData, INodeOptionsValue, INodeParams } from '../../../src/Interface'
+import { getModels, MODEL_TYPE } from '../../../src/modelLoader'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 
 class Groq_ChatModels implements INode {
@@ -41,8 +42,9 @@ class Groq_ChatModels implements INode {
             {
                 label: 'Model Name',
                 name: 'modelName',
-                type: 'string',
-                placeholder: 'mixtral-8x7b-32768'
+                type: 'asyncOptions',
+                loadMethod: 'listModels',
+                placeholder: 'llama3-70b-8192'
             },
             {
                 label: 'Temperature',
@@ -53,6 +55,13 @@ class Groq_ChatModels implements INode {
                 optional: true
             }
         ]
+    }
+    
+    //@ts-ignore
+    loadMethods = {
+        async listModels(): Promise<INodeOptionsValue[]> {
+            return await getModels(MODEL_TYPE.CHAT, 'groqChat')
+        }
     }
 
     async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {


### PR DESCRIPTION
Added support for `models.json` with GroqChat and included the current models in the list.