### PR TITLE
Bugfix/Default file size limit

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -81,7 +81,7 @@ export class App {
 
     async config(socketIO?: Server) {
         // Limit is needed to allow sending/receiving base64 encoded string
-        const flowise_file_size_limit = process.env.FLOWISE_FILE_SIZE_LIMIT ?? '50mb'
+        const flowise_file_size_limit = process.env.FLOWISE_FILE_SIZE_LIMIT || '50mb'
         this.app.use(express.json({ limit: flowise_file_size_limit }))
         this.app.use(express.urlencoded({ limit: flowise_file_size_limit, extended: true }))
         if (process.env.NUMBER_OF_PROXIES && parseInt(process.env.NUMBER_OF_PROXIES) > 0)


### PR DESCRIPTION
Bug: when deploying on docker, `flowise_file_size_limit` becomes empty if not specified in `.env` file.
Expected: it should be `50mb` by default
Fix: uses `||` instead of `??`