### PR TITLE
Fixes 2343 CSV error with no text splitter

### DIFF
--- a/packages/components/nodes/documentloaders/Csv/Csv.ts
+++ b/packages/components/nodes/documentloaders/Csv/Csv.ts
@@ -99,7 +99,7 @@ class Csv_DocumentLoaders implements INode {
                 if (textSplitter) {
                     docs.push(...(await loader.loadAndSplit(textSplitter)))
                 } else {
-                    docs.push(...(await loader.loadAndSplit(textSplitter)))
+                    docs.push(...(await loader.load()))
                 }
             }
         } else {


### PR DESCRIPTION
This fixes the typo where the CSV document loader doesn't work if a text splitter isn't specified.