### PR TITLE
Add new openai model (GPT-4o ) in the assistant and models.json

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -403,6 +403,10 @@
             "name": "chatOpenAI",
             "models": [
                 {
+                    "label": "gpt-4o",
+                    "name": "gpt-4o"
+                },
+                {
                     "label": "gpt-4",
                     "name": "gpt-4"
                 },

--- a/packages/ui/src/views/assistants/AssistantDialog.jsx
+++ b/packages/ui/src/views/assistants/AssistantDialog.jsx
@@ -47,6 +47,10 @@ import { maxScroll } from '@/store/constant'
 
 const assistantAvailableModels = [
     {
+        label: 'gpt-4o',
+        name: 'gpt-4o'
+    },
+    {
         label: 'gpt-4-turbo',
         name: 'gpt-4-turbo'
     },
@@ -69,6 +73,10 @@ const assistantAvailableModels = [
     {
         label: 'gpt-3.5-turbo',
         name: 'gpt-3.5-turbo'
+    },
+    {
+        label: 'gpt-3.5-turbo-0125',
+        name: 'gpt-3.5-turbo-0125'
     },
     {
         label: 'gpt-3.5-turbo-1106',


### PR DESCRIPTION
OpenAI announced GPT-4o, their new flagship model that can reason across audio, vision, and text in real-time.

**Reference:** [Hello GPT-4o](https://openai.com/index/hello-gpt-4o/)