### PR TITLE
Updated bedrock model list

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -5,47 +5,68 @@
             "models": [
                 {
                     "label": "anthropic.claude-3-haiku",
-                    "name": "anthropic.claude-3-haiku-20240307-v1:0"
+                    "name": "anthropic.claude-3-haiku-20240307-v1:0",
+                    "description": "Image to text, conversation, chat optimized"
                 },
                 {
                     "label": "anthropic.claude-3-sonnet",
-                    "name": "anthropic.claude-3-sonnet-20240229-v1:0"
+                    "name": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "description": "Image to text and code, multilingual conversation, complex reasoning and analysis"
+                },
+                {
+                    "label": "anthropic.claude-3-opus",
+                    "name": "anthropic.claude-3-opus-20240229-v1:0",
+                    "description": "Image to text and code, multilingual conversation, complex reasoning and analysis"
                 },
                 {
                     "label": "anthropic.claude-instant-v1",
-                    "name": "anthropic.claude-instant-v1"
+                    "name": "anthropic.claude-instant-v1",
+                    "description": "Text generation, conversation"
                 },
                 {
                     "label": "anthropic.claude-v2:1",
-                    "name": "anthropic.claude-v2:1"
+                    "name": "anthropic.claude-v2:1",
+                    "description": "Text generation, conversation, complex reasoning and analysis"
                 },
                 {
                     "label": "anthropic.claude-v2",
-                    "name": "anthropic.claude-v2"
+                    "name": "anthropic.claude-v2",
+                    "description": "Text generation, conversation, complex reasoning and analysis"
                 },
                 {
                     "label": "meta.llama2-13b-chat-v1",
-                    "name": "meta.llama2-13b-chat-v1"
+                    "name": "meta.llama2-13b-chat-v1",
+                    "description": "Text generation, conversation"
                 },
                 {
                     "label": "meta.llama2-70b-chat-v1",
-                    "name": "meta.llama2-70b-chat-v1"
+                    "name": "meta.llama2-70b-chat-v1",
+                    "description": "Text generation, conversation"
                 },
                 {
                     "label": "meta.llama3-8b-instruct-v1:0",
-                    "name": "meta.llama3-8b-instruct-v1:0"
+                    "name": "meta.llama3-8b-instruct-v1:0",
+                    "description": "Text summarization, text classification, sentiment analysis"
                 },
                 {
                     "label": "meta.llama3-70b-instruct-v1:0",
-                    "name": "meta.llama3-70b-instruct-v1:0"
+                    "name": "meta.llama3-70b-instruct-v1:0",
+                    "description": "Language modeling, dialog systems, code generation, text summarization, text classification, sentiment analysis"
                 },
                 {
                     "label": "mistral.mistral-7b-instruct-v0:2",
-                    "name": "mistral.mistral-7b-instruct-v0:2"
+                    "name": "mistral.mistral-7b-instruct-v0:2",
+                    "description": "Classification, text generation, code generation"
                 },
                 {
                     "label": "mistral.mixtral-8x7b-instruct-v0:1",
-                    "name": "mistral.mixtral-8x7b-instruct-v0:1"
+                    "name": "mistral.mixtral-8x7b-instruct-v0:1",
+                    "description": "Complex reasoning and analysis, text generation, code generation"
+                },
+                {
+                    "label": "mistral.mistral-large-2402-v1:0",
+                    "name": "mistral.mistral-large-2402-v1:0",
+                    "description": "Complex reasoning and analysis, text generation, code generation, RAG, agents"
                 }
             ],
             "regions": [
@@ -1082,19 +1103,28 @@
             "models": [
                 {
                     "label": "amazon.titan-embed-text-v1",
-                    "name": "amazon.titan-embed-text-v1"
+                    "name": "amazon.titan-embed-text-v1",
+                    "description": "Embedding Dimensions: 1536"
+                },
+                {
+                    "label": "amazon.titan-embed-text-v2",
+                    "name": "amazon.titan-embed-text-v2:0",
+                    "description": "Embedding Dimensions: 1024"
                 },
                 {
                     "label": "amazon.titan-embed-g1-text-02",
-                    "name": "amazon.titan-embed-g1-text-02"
+                    "name": "amazon.titan-embed-g1-text-02",
+                    "description": "Embedding Dimensions: 1536"
                 },
                 {
                     "label": "cohere.embed-english-v3",
-                    "name": "cohere.embed-english-v3"
+                    "name": "cohere.embed-english-v3",
+                    "description": "Embedding Dimensions: 1024"
                 },
                 {
                     "label": "cohere.embed-multilingual-v3",
-                    "name": "cohere.embed-multilingual-v3"
+                    "name": "cohere.embed-multilingual-v3",
+                    "description": "Embedding Dimensions: 1024"
                 }
             ],
             "regions": [


### PR DESCRIPTION
**Description:**

In the "models" array:
- Added a "description" field for each bedrock model, providing a brief overview of the model's capabilities.
- Updated the "name" field for some models by appending a version number (e.g., ":0", ":1", ":2") to the model name.
- Added new models:
    - "anthropic.claude-3-opus"
    - "mistral.mistral-large-2402-v1:0"
- Note: I didn't add the cohere command R models as langchain doesn't have support for their needed parameters (plus they rank low, so is it a loss?)


In the embeddings section:
- Added a new model "amazon.titan-embed-text-v2:0" with an embedding dimension of 1024.
- Added a "description" field for each embedding model, specifying the embedding dimensions.

Each model has been tested on my local with success. 