### PR TITLE
Fix JSON escaping

### DIFF
--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -780,7 +780,7 @@ export const getVariableValue = (
             const variableValue = variableDict[path]
             // Replace all occurrence
             if (typeof variableValue === 'object') {
-                returnVal = returnVal.split(path).join(JSON.stringify(variableValue).replace(/"/g, '\\"'))
+                returnVal = returnVal.split(path).join(JSON.stringify(variableValue).replaceAll('"', '\\"').replaceAll('\\n', '\\\\n'))
             } else {
                 returnVal = returnVal.split(path).join(variableValue)
             }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "lib": ["es2017"],
-        "target": "es2017" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+        "lib": ["es2021"],
+        "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
         "experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
         "emitDecoratorMetadata": true /* Emit design-type metadata for decorated declarations in source files. */,
         "module": "commonjs" /* Specify what module code is generated. */,


### PR DESCRIPTION
This PR fixes the JSON parssing error that `variableValue` contains newlines

```json
{
    "text": "a\\nb" 
}
```