### PR TITLE
Feature: Support role-based authentication for AWS

### DIFF
--- a/packages/components/nodes/memory/DynamoDb/DynamoDb.ts
+++ b/packages/components/nodes/memory/DynamoDb/DynamoDb.ts
@@ -46,7 +46,8 @@ class DynamoDb_Memory implements INode {
             label: 'Connect Credential',
             name: 'credential',
             type: 'credential',
-            credentialNames: ['dynamodbMemoryApi']
+            credentialNames: ['dynamodbMemoryApi'],
+            optional: true
         }
         this.inputs = [
             {
@@ -102,13 +103,18 @@ const initializeDynamoDB = async (nodeData: INodeData, options: ICommonObject): 
     const accessKeyId = getCredentialParam('accessKey', credentialData, nodeData)
     const secretAccessKey = getCredentialParam('secretAccessKey', credentialData, nodeData)
 
-    const config: DynamoDBClientConfig = {
-        region,
-        credentials: {
+    let credentials: DynamoDBClientConfig['credentials'] | undefined;
+    if (accessKeyId && secretAccessKey) {
+        credentials = {
             accessKeyId,
             secretAccessKey
-        }
+        };
     }
+    
+    const config: DynamoDBClientConfig = {
+        region,
+        credentials
+    };
 
     const client = new DynamoDBClient(config ?? {})
 

--- a/packages/components/nodes/memory/DynamoDb/DynamoDb.ts
+++ b/packages/components/nodes/memory/DynamoDb/DynamoDb.ts
@@ -103,18 +103,18 @@ const initializeDynamoDB = async (nodeData: INodeData, options: ICommonObject): 
     const accessKeyId = getCredentialParam('accessKey', credentialData, nodeData)
     const secretAccessKey = getCredentialParam('secretAccessKey', credentialData, nodeData)
 
-    let credentials: DynamoDBClientConfig['credentials'] | undefined;
+    let credentials: DynamoDBClientConfig['credentials'] | undefined
     if (accessKeyId && secretAccessKey) {
         credentials = {
             accessKeyId,
             secretAccessKey
-        };
+        }
     }
-    
+
     const config: DynamoDBClientConfig = {
         region,
         credentials
-    };
+    }
 
     const client = new DynamoDBClient(config ?? {})
 

--- a/packages/components/src/storageUtils.ts
+++ b/packages/components/src/storageUtils.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs'
-import { DeleteObjectsCommand, GetObjectCommand, ListObjectsV2Command, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { DeleteObjectsCommand, GetObjectCommand, ListObjectsV2Command, PutObjectCommand, S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
 import { Readable } from 'node:stream'
 import { getUserHome } from './utils'
 
@@ -311,14 +311,20 @@ export const getS3Config = () => {
     const secretAccessKey = process.env.S3_STORAGE_SECRET_ACCESS_KEY
     const region = process.env.S3_STORAGE_REGION
     const Bucket = process.env.S3_STORAGE_BUCKET_NAME
-    if (!accessKeyId || !secretAccessKey || !region || !Bucket) {
+    if (!region || !Bucket) {
         throw new Error('S3 storage configuration is missing')
     }
-    const s3Client = new S3Client({
-        credentials: {
+
+    let credentials: S3ClientConfig['credentials'] | undefined
+    if (accessKeyId && secretAccessKey) {
+        credentials = {
             accessKeyId,
             secretAccessKey
-        },
+        }
+    }
+    
+    const s3Client = new S3Client({
+        credentials,
         region
     })
     return { s3Client, Bucket }

--- a/packages/components/src/storageUtils.ts
+++ b/packages/components/src/storageUtils.ts
@@ -1,6 +1,13 @@
 import path from 'path'
 import fs from 'fs'
-import { DeleteObjectsCommand, GetObjectCommand, ListObjectsV2Command, PutObjectCommand, S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
+import {
+    DeleteObjectsCommand,
+    GetObjectCommand,
+    ListObjectsV2Command,
+    PutObjectCommand,
+    S3Client,
+    S3ClientConfig
+} from '@aws-sdk/client-s3'
 import { Readable } from 'node:stream'
 import { getUserHome } from './utils'
 
@@ -322,7 +329,7 @@ export const getS3Config = () => {
             secretAccessKey
         }
     }
-    
+
     const s3Client = new S3Client({
         credentials,
         region


### PR DESCRIPTION
This pull request addresses issue #2466.

### Context
Currently, Flowise has four features or components that use AWS services:
- Flowise Storage
- DynamoDB Chat Memory
- AWS Bedrock
- S3 file

However, only AWS Bedrock and S3 file support AWS role-based authentication by making access keys optional. Since the AWS SDK supports seeking credentials from multiple sources, if access keys are not provided during client initialization, it will search for other authentication methods.

### What does this pull request do?
This PR makes credentials optional for Flowise Storage and DynamoDB Chat Memory, allowing for role-based authentication.

### Why is this useful?
Role-based authentication is particularly useful when deploying to K8S, as roles can be assumed by pods (Flowise) by configuring a ServiceAccount. It is also one of the preferred methods for granting access to applications, as AWS advises against generating access keys that are not regularly rotated. Additionally, many companies mandate the use of role-based authentication, prohibiting the creation of access keys.

### Was it tested?
Yes, it was tested in K8S with a ServiceAccount attached, and it works for both Flowise Storage and DynamoDB Chat Memory.