### PR TITLE
Add LLM Chain in JSON single line

### DIFF
--- a/packages/components/nodes/chains/LLMChain/LLMChain.ts
+++ b/packages/components/nodes/chains/LLMChain/LLMChain.ts
@@ -141,9 +141,10 @@ class LLMChain_Chains implements INode {
         promptValues = injectOutputParser(this.outputParser, chain, promptValues)
         const res = await runPrediction(inputVariables, chain, input, promptValues, options, nodeData)
         // eslint-disable-next-line no-console
-        console.log('\x1b[93m\x1b[1m\n*****FINAL RESULT*****\n\x1b[0m\x1b[0m')
+        //console.log('\x1b[93m\x1b[1m\n*****FINAL RESULT*****\n\x1b[0m\x1b[0m')
         // eslint-disable-next-line no-console
-        console.log(res)
+        //console.log(res)
+        options.logger.info(JSON.stringify({ input, output: res }))
         return res
     }
 }


### PR DESCRIPTION
Add a single line json log with input and output of llm chain. It is very interesting to monitoring what is passing through LLM. It is single line because is a easy way to read these logs with a external log agent (fluentbit, fluentd, etc)