### PR TITLE
Feat/add puppeteer url

### DIFF
--- a/packages/server/src/Interface.DocumentStore.ts
+++ b/packages/server/src/Interface.DocumentStore.ts
@@ -124,6 +124,9 @@ export class DocumentStoreDTO {
                     case 'cheerioWebScraper':
                         loader.source = loader.loaderConfig.url
                         break
+                    case 'puppeteerWebScraper':
+                        loader.source = loader.loaderConfig.url
+                        break
                     case 'jsonFile':
                         loader.source = loader.loaderConfig.jsonFile.replace('FILE-STORAGE::', '')
                         break

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -180,7 +180,7 @@ const getDocumentStoreFileChunks = async (storeId: string, fileId: string, pageN
         })
         if (found) {
             found.totalChars = totalChars
-            found.id = entity.id
+            found.id = fileId
             found.status = entity.status
         }
         const PAGE_SIZE = 50


### PR DESCRIPTION
adds puppeteer URLs in the "sources" in document store

<img width="735" alt="image" src="https://github.com/FlowiseAI/Flowise/assets/3491953/ad83b536-b58a-4a46-aeb2-b7d785d9ab10">

puppeteer used to have "None" as the source.