### PR TITLE
Fix for Whisper Error: 'File is not defined' when using Speech to Text

### DIFF
--- a/packages/components/src/speechToText.ts
+++ b/packages/components/src/speechToText.ts
@@ -1,6 +1,6 @@
 import { ICommonObject, IFileUpload } from './Interface'
 import { getCredentialData } from './utils'
-import { type ClientOptions, OpenAIClient } from '@langchain/openai'
+import { type ClientOptions, OpenAIClient, toFile } from '@langchain/openai'
 import { AssemblyAI } from 'assemblyai'
 import { getFileFromStorage } from './storageUtils'
 
@@ -22,8 +22,9 @@ export const convertSpeechToText = async (upload: IFileUpload, speechToTextConfi
                     apiKey: credentialData.openAIApiKey
                 }
                 const openAIClient = new OpenAIClient(openAIClientOptions)
+                const file = await toFile(audio_file, upload.name)
                 const openAITranscription = await openAIClient.audio.transcriptions.create({
-                    file: new File([new Blob([audio_file])], upload.name),
+                    file: file,
                     model: 'whisper-1',
                     language: speechToTextConfig?.language,
                     temperature: speechToTextConfig?.temperature ? parseFloat(speechToTextConfig.temperature) : undefined,

--- a/packages/components/src/speechToText.ts
+++ b/packages/components/src/speechToText.ts
@@ -57,8 +57,9 @@ export const convertSpeechToText = async (upload: IFileUpload, speechToTextConfi
                     baseURL: speechToTextConfig?.baseUrl
                 }
                 const localAIClient = new OpenAIClient(LocalAIClientOptions)
+                const file = await toFile(audio_file, upload.name)
                 const localAITranscription = await localAIClient.audio.transcriptions.create({
-                    file: new File([new Blob([audio_file])], upload.name),
+                    file: file,
                     model: speechToTextConfig?.model || 'whisper-1',
                     language: speechToTextConfig?.language,
                     temperature: speechToTextConfig?.temperature ? parseFloat(speechToTextConfig.temperature) : undefined,

--- a/packages/server/src/services/openai-assistants-vector-store/index.ts
+++ b/packages/server/src/services/openai-assistants-vector-store/index.ts
@@ -178,8 +178,9 @@ const uploadFilesToAssistantVectorStore = async (
         const openai = new OpenAI({ apiKey: openAIApiKey })
         const uploadedFiles = []
         for (const file of files) {
+            const toFile = await OpenAI.toFile(fs.readFileSync(file.filePath), file.fileName)
             const createdFile = await openai.files.create({
-                file: new File([new Blob([fs.readFileSync(file.filePath)])], file.fileName),
+                file: toFile,
                 purpose: 'assistants'
             })
             uploadedFiles.push(createdFile)

--- a/packages/server/src/services/openai-assistants/index.ts
+++ b/packages/server/src/services/openai-assistants/index.ts
@@ -101,8 +101,9 @@ const uploadFilesToAssistant = async (credentialId: string, files: { filePath: s
     const uploadedFiles = []
 
     for (const file of files) {
+        const toFile = await OpenAI.toFile(fs.readFileSync(file.filePath), file.fileName)
         const createdFile = await openai.files.create({
-            file: new File([new Blob([fs.readFileSync(file.filePath)])], file.fileName),
+            file: toFile,
             purpose: 'assistants'
         })
         uploadedFiles.push(createdFile)


### PR DESCRIPTION
Fix for error reported on Discord:

![image](https://github.com/FlowiseAI/Flowise/assets/4365623/8ce5613f-e4df-4373-8d3c-124f638a7f10)


toFile() is a helper by openai to create the correct data to send to whisper.

Below is after the fix (disconsider the pt-br thing, I used the wrong ISO):

![image](https://github.com/FlowiseAI/Flowise/assets/4365623/59e7d6f5-10cf-4de2-96ed-b8d11248a27d)
