### PR TITLE
adding url to source for all web scrapers

### DIFF
--- a/packages/server/src/Interface.DocumentStore.ts
+++ b/packages/server/src/Interface.DocumentStore.ts
@@ -124,6 +124,12 @@ export class DocumentStoreDTO {
                     case 'cheerioWebScraper':
                         loader.source = loader.loaderConfig.url
                         break
+                    case 'playwrightWebScraper':
+                        loader.source = loader.loaderConfig.url
+                        break
+                    case 'puppeteerWebScraper':
+                        loader.source = loader.loaderConfig.url
+                        break
                     case 'jsonFile':
                         loader.source = loader.loaderConfig.jsonFile.replace('FILE-STORAGE::', '')
                         break


### PR DESCRIPTION
this allows a URL to appear in the document store listing when using web scrapers.

added puppeteer and playwright
fixes https://github.com/FlowiseAI/Flowise/issues/2520