### PR TITLE
Improve OpenSearchURL credential storing user and password in separate fields from the URL

### DIFF
--- a/packages/components/credentials/OpenSearchUrl.credential.ts
+++ b/packages/components/credentials/OpenSearchUrl.credential.ts
@@ -10,12 +10,26 @@ class OpenSearchUrl implements INodeCredential {
     constructor() {
         this.label = 'OpenSearch'
         this.name = 'openSearchUrl'
-        this.version = 1.0
+        this.version = 2.0
         this.inputs = [
             {
                 label: 'OpenSearch Url',
                 name: 'openSearchUrl',
                 type: 'string'
+            },
+            {
+                label: 'User',
+                name: 'user',
+                type: 'string',
+                placeholder: '<OPENSEARCH_USERNAME>',
+                optional: true
+            },
+            {
+                label: 'Password',
+                name: 'password',
+                type: 'password',
+                placeholder: '<OPENSEARCH_PASSWORD>',
+                optional: true
             }
         ]
     }


### PR DESCRIPTION
Version 1.8.1 included the new OpenSearch credentials with the URL field. This allows to save in a central and secure way the connection credentials for OpenSearch.

But it requires the user to save the username and password hardcoded inside the URL field in the form: `https://user:password@url.com`.

This approach has a few downsides:
- Password is in plan text in the UI, which could lead to security issues if there is an unauthorized access.
- Some people might not know that OpenSearch allows to put the username and password as part of the URL.

My proposal in this PR is to change the OpenSearch credential to have 3 fields:
- URL
- User (optional)
- Password (optional)

and build the final URL inside the OpenSearch component.