### PR TITLE
Feature - Env variable to disable ChatFlow reuse

### DIFF
--- a/CONTRIBUTING-ZH.md
+++ b/CONTRIBUTING-ZH.md
@@ -124,6 +124,7 @@ Flowise 支持不同的环境变量来配置您的实例。您可以在 `package
 | FLOWISE_USERNAME             | 登录用户名                                              | 字符串                                          |                                     |
 | FLOWISE_PASSWORD             | 登录密码                                                | 字符串                                          |                                     |
 | FLOWISE_FILE_SIZE_LIMIT      | 上传文件大小限制                                        | 字符串                                          | 50mb                                |
+| DISABLE_CHATFLOW_REUSE       | 强制为每次调用创建一个新的ChatFlow，而不是重用缓存中的现有ChatFlow	| 布尔值	                                 |                                 |
 | DEBUG                        | 打印组件的日志                                          | 布尔值                                          |                                     |
 | LOG_PATH                     | 存储日志文件的位置                                      | 字符串                                          | `your-path/Flowise/logs`            |
 | LOG_LEVEL                    | 日志的不同级别                                          | 枚举字符串: `error`, `info`, `verbose`, `debug` | `info`                              |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ Flowise support different environment variables to configure your instance. You 
 | FLOWISE_USERNAME             | Username to login                                                                | String                                           |                                     |
 | FLOWISE_PASSWORD             | Password to login                                                                | String                                           |                                     |
 | FLOWISE_FILE_SIZE_LIMIT      | Upload File Size Limit                                                           | String                                           | 50mb                                |
+| DISABLE_CHATFLOW_REUSE       | Forces the creation of a new ChatFlow for each call instead of reusing existing ones from cache  | Boolean                  |                                |
 | DEBUG                        | Print logs from components                                                       | Boolean                                          |                                     |
 | LOG_PATH                     | Location where log files are stored                                              | String                                           | `your-path/Flowise/logs`            |
 | LOG_LEVEL                    | Different levels of logs                                                         | Enum String: `error`, `info`, `verbose`, `debug` | `info`                              |

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -23,6 +23,8 @@ BLOB_STORAGE_PATH=/root/.flowise/storage
 # FLOWISE_SECRETKEY_OVERWRITE=myencryptionkey
 # FLOWISE_FILE_SIZE_LIMIT=50mb
 
+# DISABLE_CHATFLOW_REUSE=true
+
 # DEBUG=true
 # LOG_LEVEL=debug (error | warn | info | verbose | debug)
 # TOOL_FUNCTION_BUILTIN_DEP=crypto,fs

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -22,6 +22,8 @@ PORT=3000
 # FLOWISE_SECRETKEY_OVERWRITE=myencryptionkey
 # FLOWISE_FILE_SIZE_LIMIT=50mb
 
+# DISABLE_CHATFLOW_REUSE=true
+
 # DEBUG=true
 # LOG_PATH=/your_log_path/.flowise/logs
 # LOG_LEVEL=debug (error | warn | info | verbose | debug)

--- a/packages/server/src/commands/start.ts
+++ b/packages/server/src/commands/start.ts
@@ -32,6 +32,7 @@ export default class Start extends Command {
         TOOL_FUNCTION_BUILTIN_DEP: Flags.string(),
         TOOL_FUNCTION_EXTERNAL_DEP: Flags.string(),
         NUMBER_OF_PROXIES: Flags.string(),
+        DISABLE_CHATFLOW_REUSE: Flags.string(),
         DATABASE_TYPE: Flags.string(),
         DATABASE_PATH: Flags.string(),
         DATABASE_PORT: Flags.string(),
@@ -93,6 +94,7 @@ export default class Start extends Command {
         if (flags.IFRAME_ORIGINS) process.env.IFRAME_ORIGINS = flags.IFRAME_ORIGINS
         if (flags.DEBUG) process.env.DEBUG = flags.DEBUG
         if (flags.NUMBER_OF_PROXIES) process.env.NUMBER_OF_PROXIES = flags.NUMBER_OF_PROXIES
+        if (flags.DISABLE_CHATFLOW_REUSE) process.env.DISABLE_CHATFLOW_REUSE = flags.DISABLE_CHATFLOW_REUSE
 
         // Authorization
         if (flags.FLOWISE_USERNAME) process.env.FLOWISE_USERNAME = flags.FLOWISE_USERNAME

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -187,6 +187,7 @@ export const utilBuildChatflow = async (req: Request, socketIO?: Server, isInter
         const prependMessages = incomingInput.history
 
         /*   Reuse the flow without having to rebuild (to avoid duplicated upsert, recomputation, reinitialization of memory) when all these conditions met:
+         * - Reuse of flows is not disabled
          * - Node Data already exists in pool
          * - Still in sync (i.e the flow has not been modified since)
          * - Existing overrideConfig and new overrideConfig are the same
@@ -194,6 +195,7 @@ export const utilBuildChatflow = async (req: Request, socketIO?: Server, isInter
          ***/
         const isFlowReusable = () => {
             return (
+                process.env.DISABLE_CHATFLOW_REUSE !== 'true' &&
                 Object.prototype.hasOwnProperty.call(appServer.chatflowPool.activeChatflows, chatflowid) &&
                 appServer.chatflowPool.activeChatflows[chatflowid].inSync &&
                 appServer.chatflowPool.activeChatflows[chatflowid].endingNodeData &&


### PR DESCRIPTION
Discussed in #2533, this PR adds a new env variable `DISABLE_CHATFLOW_REUSE` to allow users to decide if they want to create a new ChatFlow in each interaction or reuse current one when possible.

This is useful for a few reasons:
- Debugging purposes: If a user sees an issue and we think it might be related to caching, we can ask to disable it temporarily and try again.
- Avoid issues with unsupported flows: Flows like the one described in #2533 are not supported by current logic and users might decide to disable the reuse of ChatFlows.

### Implementation
Current implementation adds a new condition to the `ifFlowReusable` function to check for the new env variable `DISABLE_CHATFLOW_REUSE`.

This approach is simple and keeps the `chatflowPool` active for other use cases, like AgentFlow abortion.

### Alternative implementation
Another possible solution is to make the `chatflowPool` creation optional. At first this was my preferred approach because I think it's cleaner, but it would break the AgentFlow abortion logic. With the PR implementation regular ChatFlows are still stored in the pool but never used.