### PR TITLE
fix: Change the CMD flowise command in Dockerfile to be the same as in the document

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,4 @@ RUN npm install -g flowise
 
 WORKDIR /data
 
-ENTRYPOINT ["npx", "flowise", "start"]
+ENTRYPOINT ["flowise", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,4 @@ RUN npm install -g flowise
 
 WORKDIR /data
 
-CMD "flowise"
+ENTRYPOINT ["npx", "flowise", "start"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,4 +33,4 @@ services:
             - '${PORT}:${PORT}'
         volumes:
             - ~/.flowise:/root/.flowise
-        command: /bin/sh -c "sleep 3; flowise start"
+        entrypoint: /bin/sh -c "sleep 3; flowise start"


### PR DESCRIPTION
The Dockerfile wasn't working with the command:
`CMD flowise`

Based on the documentation, to start Flowise, you should use the command "start". In this case, the Dockerfile was updated to use:

ENTRYPOINT ["npx", "flowise", "start"]

Reference:
[get started | Flowise](https://docs.flowiseai.com/getting-started)