### PR TITLE
Bugfix - JS function "execute" from node crashing the frontend and response is hidden

### DIFF
--- a/packages/ui/src/ui-component/dialog/ExpandTextDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ExpandTextDialog.jsx
@@ -152,7 +152,7 @@ const ExpandTextDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
                     <div style={{ marginTop: '15px' }}>
                         <CodeEditor
                             disabled={true}
-                            value={codeExecutedResult}
+                            value={codeExecutedResult.toString()}
                             height='max-content'
                             theme={customization.isDarkMode ? 'dark' : 'light'}
                             lang={'js'}

--- a/packages/ui/src/ui-component/dialog/ExpandTextDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ExpandTextDialog.jsx
@@ -78,7 +78,7 @@ const ExpandTextDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
     useEffect(() => {
         if (executeCustomFunctionNodeApi.error) {
             if (typeof executeCustomFunctionNodeApi.error === 'object' && executeCustomFunctionNodeApi.error?.response?.data) {
-                setCodeExecutedResult(executeCustomFunctionNodeApi.error?.response?.data)
+                setCodeExecutedResult(JSON.stringify(executeCustomFunctionNodeApi.error?.response?.data, null, 2))
             } else if (typeof executeCustomFunctionNodeApi.error === 'string') {
                 setCodeExecutedResult(executeCustomFunctionNodeApi.error)
             }
@@ -100,7 +100,7 @@ const ExpandTextDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
                                     borderColor: theme.palette.grey['500'],
                                     borderRadius: '12px',
                                     height: '100%',
-                                    maxHeight: languageType === 'js' ? 'calc(100vh - 250px)' : 'calc(100vh - 220px)',
+                                    maxHeight: languageType === 'js' ? 'calc(100vh - 430px)' : 'calc(100vh - 400px)',
                                     overflowX: 'hidden',
                                     backgroundColor: 'white'
                                 }}
@@ -108,7 +108,7 @@ const ExpandTextDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
                                 <CodeEditor
                                     disabled={dialogProps.disabled}
                                     value={inputValue}
-                                    height={languageType === 'js' ? 'calc(100vh - 250px)' : 'calc(100vh - 220px)'}
+                                    height={languageType === 'js' ? 'calc(100vh - 430px)' : 'calc(100vh - 400px)'}
                                     theme={customization.isDarkMode ? 'dark' : 'light'}
                                     lang={languageType}
                                     placeholder={inputParam.placeholder}

--- a/packages/ui/src/ui-component/dialog/ExpandTextDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ExpandTextDialog.jsx
@@ -100,7 +100,7 @@ const ExpandTextDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
                                     borderColor: theme.palette.grey['500'],
                                     borderRadius: '12px',
                                     height: '100%',
-                                    maxHeight: languageType === 'js' ? 'calc(100vh - 430px)' : 'calc(100vh - 400px)',
+                                    maxHeight: languageType === 'js' ? 'calc(100vh - 330px)' : 'calc(100vh - 220px)',
                                     overflowX: 'hidden',
                                     backgroundColor: 'white'
                                 }}
@@ -108,7 +108,7 @@ const ExpandTextDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
                                 <CodeEditor
                                     disabled={dialogProps.disabled}
                                     value={inputValue}
-                                    height={languageType === 'js' ? 'calc(100vh - 430px)' : 'calc(100vh - 400px)'}
+                                    height={languageType === 'js' ? 'calc(100vh - 330px)' : 'calc(100vh - 220px)'}
                                     theme={customization.isDarkMode ? 'dark' : 'light'}
                                     lang={languageType}
                                     placeholder={inputParam.placeholder}


### PR DESCRIPTION
When testing a JS function from the node, a message with the results should appear below the code view.

Currently there are two issues:
- When JS execution throws an error, the frontend is crashing leading to a full white screen and losing the progress if not saved.
- Code view has a fixed size that doesn't give enough room for the error message to show. User has to scroll to view it. This makes it hard for users to know that there is actually a message with the response being shown and generates confusion even knowing that this happens. 

This PR tackles both issues:
- Fixes crash by transforming the response object to string to be printed on screen.
- Reduces heigh of code view by 180px to give room to response message. Screenshots below show the before and after.

**Before:**
Code view before execution
<img width="1720" alt="Before" src="https://github.com/FlowiseAI/Flowise/assets/2080953/3c328b10-9880-495c-b482-66ef69416c6d">
Code view after execution
<img width="1728" alt="Before - Error" src="https://github.com/FlowiseAI/Flowise/assets/2080953/3dc48e5e-89c0-46cd-a24c-89affc2b3578">

**After:**
Code view before execution
<img width="1716" alt="After" src="https://github.com/FlowiseAI/Flowise/assets/2080953/b06390a5-7cd0-4ea0-8fe7-5fcc54486cde">
Code view after execution
<img width="1714" alt="After - Error" src="https://github.com/FlowiseAI/Flowise/assets/2080953/de08741f-aad9-4bf9-af7b-f3c3c883590b">

