### PR TITLE
Add data source adapter of MariaDB

### DIFF
--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -6,6 +6,7 @@ import { getUserHome } from './utils'
 import { entities } from './database/entities'
 import { sqliteMigrations } from './database/migrations/sqlite'
 import { mysqlMigrations } from './database/migrations/mysql'
+import { mariadbMigrations } from './database/migrations/mariadb'
 import { postgresMigrations } from './database/migrations/postgres'
 
 let appDataSource: DataSource
@@ -41,6 +42,22 @@ export const init = async (): Promise<void> => {
                 migrationsRun: false,
                 entities: Object.values(entities),
                 migrations: mysqlMigrations,
+                ssl: getDatabaseSSLFromEnv()
+            })
+            break
+        case 'mariadb':
+            appDataSource = new DataSource({
+                type: 'mariadb',
+                host: process.env.DATABASE_HOST,
+                port: parseInt(process.env.DATABASE_PORT || '3306'),
+                username: process.env.DATABASE_USER,
+                password: process.env.DATABASE_PASSWORD,
+                database: process.env.DATABASE_NAME,
+                charset: 'utf8mb4',
+                synchronize: false,
+                migrationsRun: false,
+                entities: Object.values(entities),
+                migrations: mariadbMigrations,
                 ssl: getDatabaseSSLFromEnv()
             })
             break

--- a/packages/server/src/database/migrations/mariadb/1693840429259-Init.ts
+++ b/packages/server/src/database/migrations/mariadb/1693840429259-Init.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Init1693840429259 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`chat_flow\` (
+                \`id\` varchar(36) NOT NULL,
+                \`name\` varchar(255) NOT NULL,
+                \`flowData\` text NOT NULL,
+                \`deployed\` tinyint DEFAULT NULL,
+                \`isPublic\` tinyint DEFAULT NULL,
+                \`apikeyid\` varchar(255) DEFAULT NULL,
+                \`chatbotConfig\` varchar(255) DEFAULT NULL,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`chat_message\` (
+                \`id\` varchar(36) NOT NULL,
+                \`role\` varchar(255) NOT NULL,
+                \`chatflowid\` varchar(255) NOT NULL,
+                \`content\` text NOT NULL,
+                \`sourceDocuments\` varchar(255) DEFAULT NULL,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`),
+                KEY \`IDX_e574527322272fd838f4f0f3d3\` (\`chatflowid\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`credential\` (
+                \`id\` varchar(36) NOT NULL,
+                \`name\` varchar(255) NOT NULL,
+                \`credentialName\` varchar(255) NOT NULL,
+                \`encryptedData\` varchar(255) NOT NULL,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`tool\` (
+                \`id\` varchar(36) NOT NULL,
+                \`name\` varchar(255) NOT NULL,
+                \`description\` text NOT NULL,
+                \`color\` varchar(255) NOT NULL,
+                \`iconSrc\` varchar(255) DEFAULT NULL,
+                \`schema\` varchar(255) DEFAULT NULL,
+                \`func\` varchar(255) DEFAULT NULL,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE chat_flow`)
+        await queryRunner.query(`DROP TABLE chat_message`)
+        await queryRunner.query(`DROP TABLE credential`)
+        await queryRunner.query(`DROP TABLE tool`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1693997791471-ModifyChatFlow.ts
+++ b/packages/server/src/database/migrations/mariadb/1693997791471-ModifyChatFlow.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ModifyChatFlow1693997791471 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` MODIFY \`chatbotConfig\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` MODIFY \`chatbotConfig\` VARCHAR;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1693999022236-ModifyChatMessage.ts
+++ b/packages/server/src/database/migrations/mariadb/1693999022236-ModifyChatMessage.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ModifyChatMessage1693999022236 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` MODIFY \`sourceDocuments\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` MODIFY \`sourceDocuments\` VARCHAR;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1693999261583-ModifyCredential.ts
+++ b/packages/server/src/database/migrations/mariadb/1693999261583-ModifyCredential.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ModifyCredential1693999261583 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`credential\` MODIFY \`encryptedData\` TEXT NOT NULL;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`credential\` MODIFY \`encryptedData\` VARCHAR NOT NULL;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1694001465232-ModifyTool.ts
+++ b/packages/server/src/database/migrations/mariadb/1694001465232-ModifyTool.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ModifyTool1694001465232 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`tool\` MODIFY \`schema\` TEXT, MODIFY \`func\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`tool\` MODIFY \`schema\` VARCHAR, MODIFY \`func\` VARCHAR;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1694099200729-AddApiConfig.ts
+++ b/packages/server/src/database/migrations/mariadb/1694099200729-AddApiConfig.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddApiConfig1694099200729 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'apiConfig')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`apiConfig\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`apiConfig\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1694432361423-AddAnalytic.ts
+++ b/packages/server/src/database/migrations/mariadb/1694432361423-AddAnalytic.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddAnalytic1694432361423 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'analytic')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`analytic\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`analytic\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1694658767766-AddChatHistory.ts
+++ b/packages/server/src/database/migrations/mariadb/1694658767766-AddChatHistory.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddChatHistory1694658767766 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const chatTypeColumnExists = await queryRunner.hasColumn('chat_message', 'chatType')
+        if (!chatTypeColumnExists)
+            await queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`chatType\` VARCHAR(255) NOT NULL DEFAULT 'INTERNAL';`)
+
+        const chatIdColumnExists = await queryRunner.hasColumn('chat_message', 'chatId')
+        if (!chatIdColumnExists) await queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`chatId\` VARCHAR(255);`)
+        const results: { id: string; chatflowid: string }[] = await queryRunner.query(`WITH RankedMessages AS (
+                SELECT
+                    \`chatflowid\`,
+                    \`id\`,
+                    \`createdDate\`,
+                    ROW_NUMBER() OVER (PARTITION BY \`chatflowid\` ORDER BY \`createdDate\`) AS row_num
+                FROM \`chat_message\`
+            )
+            SELECT \`chatflowid\`, \`id\`
+            FROM RankedMessages
+            WHERE row_num = 1;`)
+        for (const chatMessage of results) {
+            await queryRunner.query(
+                `UPDATE \`chat_message\` SET \`chatId\` = '${chatMessage.id}' WHERE \`chatflowid\` = '${chatMessage.chatflowid}'`
+            )
+        }
+        await queryRunner.query(`ALTER TABLE \`chat_message\` MODIFY \`chatId\` VARCHAR(255) NOT NULL;`)
+
+        const memoryTypeColumnExists = await queryRunner.hasColumn('chat_message', 'memoryType')
+        if (!memoryTypeColumnExists) await queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`memoryType\` VARCHAR(255);`)
+
+        const sessionIdColumnExists = await queryRunner.hasColumn('chat_message', 'sessionId')
+        if (!sessionIdColumnExists) await queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`sessionId\` VARCHAR(255);`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE \`chat_message\` DROP COLUMN \`chatType\`, DROP COLUMN \`chatId\`, DROP COLUMN \`memoryType\`, DROP COLUMN \`sessionId\`;`
+        )
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1699325775451-AddAssistantEntity.ts
+++ b/packages/server/src/database/migrations/mariadb/1699325775451-AddAssistantEntity.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddAssistantEntity1699325775451 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`assistant\` (
+                \`id\` varchar(36) NOT NULL,
+                \`credential\` varchar(255) NOT NULL,
+                \`details\` text NOT NULL,
+                \`iconSrc\` varchar(255) DEFAULT NULL,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE assistant`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1699481607341-AddUsedToolsToChatMessage.ts
+++ b/packages/server/src/database/migrations/mariadb/1699481607341-AddUsedToolsToChatMessage.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddUsedToolsToChatMessage1699481607341 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_message', 'usedTools')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`usedTools\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`usedTools\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1699900910291-AddCategoryToChatFlow.ts
+++ b/packages/server/src/database/migrations/mariadb/1699900910291-AddCategoryToChatFlow.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddCategoryToChatFlow1699900910291 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'category')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`category\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`category\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1700271021237-AddFileAnnotationsToChatMessage.ts
+++ b/packages/server/src/database/migrations/mariadb/1700271021237-AddFileAnnotationsToChatMessage.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddFileAnnotationsToChatMessage1700271021237 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_message', 'fileAnnotations')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`fileAnnotations\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`fileAnnotations\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1701788586491-AddFileUploadsToChatMessage.ts
+++ b/packages/server/src/database/migrations/mariadb/1701788586491-AddFileUploadsToChatMessage.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddFileUploadsToChatMessage1701788586491 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_message', 'fileUploads')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`fileUploads\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`fileUploads\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1702200925471-AddVariableEntity.ts
+++ b/packages/server/src/database/migrations/mariadb/1702200925471-AddVariableEntity.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddVariableEntity1699325775451 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`variable\` (
+                \`id\` varchar(36) NOT NULL,
+                \`name\` varchar(255) NOT NULL,
+                \`value\` text NOT NULL,
+                \`type\` varchar(255) DEFAULT NULL,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE variable`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1706364937060-AddSpeechToText.ts
+++ b/packages/server/src/database/migrations/mariadb/1706364937060-AddSpeechToText.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddSpeechToText1706364937060 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'speechToText')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`speechToText\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`speechToText\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1707213626553-AddFeedback.ts
+++ b/packages/server/src/database/migrations/mariadb/1707213626553-AddFeedback.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddFeedback1707213626553 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`chat_message_feedback\` (
+                \`id\` varchar(36) NOT NULL,
+                \`chatflowid\` varchar(255) NOT NULL,
+                \`content\` text,
+                \`chatId\` varchar(255) NOT NULL,
+                \`messageId\` varchar(255) NOT NULL,
+                \`rating\` varchar(255) NOT NULL,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE chat_message_feedback`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1709814301358-AddUpsertHistoryEntity.ts
+++ b/packages/server/src/database/migrations/mariadb/1709814301358-AddUpsertHistoryEntity.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddUpsertHistoryEntity1709814301358 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`upsert_history\` (
+                \`id\` varchar(36) NOT NULL,
+                \`chatflowid\` varchar(255) NOT NULL,
+                \`result\` text NOT NULL,
+                \`flowData\` text NOT NULL,
+                \`date\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`),
+                KEY \`IDX_a0b59fd66f6e48d2b198123cb6\` (\`chatflowid\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE upsert_history`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1710832127079-AddLead.ts
+++ b/packages/server/src/database/migrations/mariadb/1710832127079-AddLead.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddLead1710832127079 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`lead\` (
+                \`id\` varchar(36) NOT NULL,
+                \`chatflowid\` varchar(255) NOT NULL,
+                \`chatId\` varchar(255) NOT NULL,
+                \`name\` text,
+                \`email\` text,
+                \`phone\` text,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE lead`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1711538023578-AddLeadToChatMessage.ts
+++ b/packages/server/src/database/migrations/mariadb/1711538023578-AddLeadToChatMessage.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddLeadToChatMessage1711538023578 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_message', 'leadEmail')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`leadEmail\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`leadEmail\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1711637331047-AddDocumentStore.ts
+++ b/packages/server/src/database/migrations/mariadb/1711637331047-AddDocumentStore.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddDocumentStore1711637331047 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`document_store\` (
+                \`id\` varchar(36) NOT NULL,
+                \`name\` varchar(255) NOT NULL,
+                \`description\` varchar(255),
+                \`loaders\` text,
+                \`whereUsed\` text,
+                \`status\` varchar(20) NOT NULL,
+                \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`id\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+        await queryRunner.query(
+            `CREATE TABLE IF NOT EXISTS \`document_store_file_chunk\` (
+                \`id\` varchar(36) NOT NULL,
+                \`docId\` varchar(36) NOT NULL,
+                \`storeId\` varchar(36) NOT NULL,
+                \`chunkNo\` INT NOT NULL,
+                \`pageContent\` text,
+                \`metadata\` text,
+                PRIMARY KEY (\`id\`),
+                KEY \`IDX_e76bae1780b77e56aab1h2asd4\` (\`docId\`),
+                KEY \`IDX_e213b811b01405a42309a6a410\` (\`storeId\`)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE document_store`)
+        await queryRunner.query(`DROP TABLE document_store_file_chunk`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1714679514451-AddAgentReasoningToChatMessage.ts
+++ b/packages/server/src/database/migrations/mariadb/1714679514451-AddAgentReasoningToChatMessage.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddAgentReasoningToChatMessage1714679514451 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_message', 'agentReasoning')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_message\` ADD COLUMN \`agentReasoning\` LONGTEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_message\` DROP COLUMN \`agentReasoning\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/1766759476232-AddTypeToChatFlow.ts
+++ b/packages/server/src/database/migrations/mariadb/1766759476232-AddTypeToChatFlow.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddTypeToChatFlow1766759476232 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'type')
+        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`type\` TEXT;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`chat_flow\` DROP COLUMN \`type\`;`)
+    }
+}

--- a/packages/server/src/database/migrations/mariadb/index.ts
+++ b/packages/server/src/database/migrations/mariadb/index.ts
@@ -1,0 +1,47 @@
+import { Init1693840429259 } from './1693840429259-Init'
+import { ModifyChatFlow1693997791471 } from './1693997791471-ModifyChatFlow'
+import { ModifyChatMessage1693999022236 } from './1693999022236-ModifyChatMessage'
+import { ModifyCredential1693999261583 } from './1693999261583-ModifyCredential'
+import { ModifyTool1694001465232 } from './1694001465232-ModifyTool'
+import { AddApiConfig1694099200729 } from './1694099200729-AddApiConfig'
+import { AddAnalytic1694432361423 } from './1694432361423-AddAnalytic'
+import { AddChatHistory1694658767766 } from './1694658767766-AddChatHistory'
+import { AddAssistantEntity1699325775451 } from './1699325775451-AddAssistantEntity'
+import { AddUsedToolsToChatMessage1699481607341 } from './1699481607341-AddUsedToolsToChatMessage'
+import { AddCategoryToChatFlow1699900910291 } from './1699900910291-AddCategoryToChatFlow'
+import { AddFileAnnotationsToChatMessage1700271021237 } from './1700271021237-AddFileAnnotationsToChatMessage'
+import { AddFileUploadsToChatMessage1701788586491 } from './1701788586491-AddFileUploadsToChatMessage'
+import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntity'
+import { AddSpeechToText1706364937060 } from './1706364937060-AddSpeechToText'
+import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
+import { AddFeedback1707213626553 } from './1707213626553-AddFeedback'
+import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
+import { AddLead1710832127079 } from './1710832127079-AddLead'
+import { AddLeadToChatMessage1711538023578 } from './1711538023578-AddLeadToChatMessage'
+import { AddAgentReasoningToChatMessage1714679514451 } from './1714679514451-AddAgentReasoningToChatMessage'
+import { AddTypeToChatFlow1766759476232 } from './1766759476232-AddTypeToChatFlow'
+
+export const mariadbMigrations = [
+    Init1693840429259,
+    ModifyChatFlow1693997791471,
+    ModifyChatMessage1693999022236,
+    ModifyCredential1693999261583,
+    ModifyTool1694001465232,
+    AddApiConfig1694099200729,
+    AddAnalytic1694432361423,
+    AddChatHistory1694658767766,
+    AddAssistantEntity1699325775451,
+    AddUsedToolsToChatMessage1699481607341,
+    AddCategoryToChatFlow1699900910291,
+    AddFileAnnotationsToChatMessage1700271021237,
+    AddVariableEntity1699325775451,
+    AddFileUploadsToChatMessage1701788586491,
+    AddSpeechToText1706364937060,
+    AddUpsertHistoryEntity1709814301358,
+    AddFeedback1707213626553,
+    AddDocumentStore1711637331047,
+    AddLead1710832127079,
+    AddLeadToChatMessage1711538023578,
+    AddAgentReasoningToChatMessage1714679514451,
+    AddTypeToChatFlow1766759476232
+]


### PR DESCRIPTION
I created the `mariadb` option to `DataSource.ts` for handling MariaDB.

MariaDB has no `utf8mb4_0900_ai_ci`, so I chosen `utf8mb4_unicode_520_ci` instead.

This is the new config for `MariaDB` as the data source:

```env
DATABASE_TYPE="mariadb"
DATABASE_PORT="3306"
DATABASE_HOST="localhost"
DATABASE_NAME="flowise"
DATABASE_USER="flowise"
DATABASE_PASSWORD="mypassword"
# ... etc
```

As result, the patch is working fine with MariaDB.