### PR TITLE
Improvement - Reduce size of final docker image with multistage build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM node:20-alpine as build
 
 USER root
 
+# Skip downloading Chrome for Puppeteer (saves build time)
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
 # Install latest Flowise globally (specific version can be set: flowise@1.0.0)
 RUN npm install -g flowise
 
@@ -12,12 +15,11 @@ FROM node:20-alpine
 # Install runtime dependencies
 RUN apk add --no-cache chromium git python3 py3-pip make g++ build-base cairo-dev pango-dev
 
+# Set the environment variable for Puppeteer to find Chromium
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
 # Copy Flowise from the build stage
 COPY --from=build /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=build /usr/local/bin /usr/local/bin
-
-# Set the environment variable for Puppeteer to find Chromium
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
-ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 ENTRYPOINT ["flowise", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,23 @@
-FROM node:20-alpine
+# Stage 1: Build stage
+FROM node:20-alpine as build
 
 USER root
 
-RUN apk add --no-cache git
-RUN apk add --no-cache python3 py3-pip make g++
-# needed for pdfjs-dist
-RUN apk add --no-cache build-base cairo-dev pango-dev
-
-# Install Chromium
-RUN apk add --no-cache chromium
-
-ENV PUPPETEER_SKIP_DOWNLOAD=true
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
-
-# You can install a specific version like: flowise@1.0.0
+# Install latest Flowise globally (specific version can be set: flowise@1.0.0)
 RUN npm install -g flowise
 
-WORKDIR /data
+# Stage 2: Runtime stage
+FROM node:20-alpine
+
+# Install runtime dependencies
+RUN apk add --no-cache chromium git python3 py3-pip make g++ build-base cairo-dev pango-dev
+
+# Copy Flowise from the build stage
+COPY --from=build /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=build /usr/local/bin /usr/local/bin
+
+# Set the environment variable for Puppeteer to find Chromium
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 ENTRYPOINT ["flowise", "start"]


### PR DESCRIPTION
This draft PR transforms the main Dockerfile to a multistage build. The multistage build allows for any unnecessary files, like npm cache files, to be left outside of the runtime image reducing the final size significantly.

I calculated the following sizes before and after the changes (numbers are approximates):

**Before**
Uncompressed: `~3.2GB`
Compressed: `~0.98GB`

**After**
Uncompressed: `~2.3GB`
Compressed: `~0.67GB`

But this could be optimised even more if we review the packages that are being installed with APK:
`git 
python3 
py3-pip 
make 
g++ 
build-base 
cairo-dev 
pango-dev`

These packages do not seem to be necessary when installing Flowise through npm and I doubt they are actually needed in runtime. I'm not a node expert, but I'd think that any dependencies needed are installed with npm. Chrome is definitely needed for Puppeteer, so we need to keep it.

If those APK packages are not installed final image sizes are:
Uncompressed: `~2.0GB`
Compressed: `~0.57GB`

Any thoughts and insights on why those packages are installed is welcome. 