### PR TITLE
Adding pnpm-store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 **/logs
 **/*.log
 
+## pnpm
+.pnpm-store/
+
 ## build
 **/dist
 **/build


### PR DESCRIPTION
Nothing big but those files generated by pnpm usage are not yet in the .gitignore