### PR TITLE
Bugfix/Correctly throw 401 error when unauthorized

### DIFF
--- a/packages/server/src/services/apikey/index.ts
+++ b/packages/server/src/services/apikey/index.ts
@@ -55,7 +55,14 @@ const verifyApiKey = async (paramApiKey: string): Promise<string> => {
         const dbResponse = 'OK'
         return dbResponse
     } catch (error) {
-        throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, `Error: apikeyService.verifyApiKey - ${getErrorMessage(error)}`)
+        if (error instanceof InternalFlowiseError && error.statusCode === StatusCodes.UNAUTHORIZED) {
+            throw error
+        } else {
+            throw new InternalFlowiseError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: apikeyService.verifyApiKey - ${getErrorMessage(error)}`
+            )
+        }
     }
 }
 

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -236,10 +236,14 @@ const getSinglePublicChatflow = async (chatflowId: string): Promise<any> => {
         }
         throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found`)
     } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: chatflowsService.getSinglePublicChatflow - ${getErrorMessage(error)}`
-        )
+        if (error instanceof InternalFlowiseError && error.statusCode === StatusCodes.UNAUTHORIZED) {
+            throw error
+        } else {
+            throw new InternalFlowiseError(
+                StatusCodes.INTERNAL_SERVER_ERROR,
+                `Error: chatflowsService.getSinglePublicChatflow - ${getErrorMessage(error)}`
+            )
+        }
     }
 }
 

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -417,7 +417,11 @@ export const utilBuildChatflow = async (req: Request, socketIO?: Server, isInter
         return result
     } catch (e) {
         logger.error('[server]: Error:', e)
-        throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, getErrorMessage(e))
+        if (e instanceof InternalFlowiseError && e.statusCode === StatusCodes.UNAUTHORIZED) {
+            throw e
+        } else {
+            throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, getErrorMessage(e))
+        }
     }
 }
 

--- a/packages/server/src/utils/upsertVector.ts
+++ b/packages/server/src/utils/upsertVector.ts
@@ -22,6 +22,7 @@ import { getRunningExpressApp } from '../utils/getRunningExpressApp'
 import { UpsertHistory } from '../database/entities/UpsertHistory'
 import { InternalFlowiseError } from '../errors/internalFlowiseError'
 import { StatusCodes } from 'http-status-codes'
+import { getErrorMessage } from '../errors/utils'
 
 /**
  * Upsert documents
@@ -163,10 +164,12 @@ export const upsertVector = async (req: Request, isInternal: boolean = false) =>
         })
 
         return upsertedResult['result'] ?? { result: 'Successfully Upserted' }
-    } catch (error) {
-        logger.error('[server]: Error:', error)
-        if (error instanceof Error) {
-            throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, error.message)
+    } catch (e) {
+        logger.error('[server]: Error:', e)
+        if (e instanceof InternalFlowiseError && e.statusCode === StatusCodes.UNAUTHORIZED) {
+            throw e
+        } else {
+            throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, getErrorMessage(e))
         }
     }
 }


### PR DESCRIPTION
Bug: UI doesnt catch the 401 error, hence not showing login prompt as below when opening share chatbot:
![image](https://github.com/FlowiseAI/Flowise/assets/26460777/7350e8ac-22f7-4f9e-9de3-11348a930d11)
