### PR TITLE
Unstructured Upsert bug

### DIFF
--- a/packages/components/nodes/documentloaders/Unstructured/UnstructuredFile.ts
+++ b/packages/components/nodes/documentloaders/Unstructured/UnstructuredFile.ts
@@ -448,7 +448,16 @@ class UnstructuredFile_DocumentLoaders implements INode {
         if (_omitMetadataKeys) {
             omitMetadataKeys = _omitMetadataKeys.split(',').map((key) => key.trim())
         }
-        const fileBase64 = nodeData.inputs?.fileObject as string
+        // give priority to upload with upsert then to fileObject (upload from UI component)
+        const fileBase64 = 
+        nodeData.inputs?.pdfFile ||
+        nodeData.inputs?.txtFile ||
+        nodeData.inputs?.yamlFile ||
+        nodeData.inputs?.docxFile ||
+        nodeData.inputs?.jsonlinesFile ||
+        nodeData.inputs?.csvFile ||
+        nodeData.inputs?.jsonFile ||
+        nodeData.inputs?.fileObject as string;
 
         const obj: UnstructuredLoaderOptions = {
             apiUrl: unstructuredAPIUrl,

--- a/packages/components/nodes/documentloaders/Unstructured/UnstructuredFile.ts
+++ b/packages/components/nodes/documentloaders/Unstructured/UnstructuredFile.ts
@@ -449,15 +449,15 @@ class UnstructuredFile_DocumentLoaders implements INode {
             omitMetadataKeys = _omitMetadataKeys.split(',').map((key) => key.trim())
         }
         // give priority to upload with upsert then to fileObject (upload from UI component)
-        const fileBase64 = 
-        nodeData.inputs?.pdfFile ||
-        nodeData.inputs?.txtFile ||
-        nodeData.inputs?.yamlFile ||
-        nodeData.inputs?.docxFile ||
-        nodeData.inputs?.jsonlinesFile ||
-        nodeData.inputs?.csvFile ||
-        nodeData.inputs?.jsonFile ||
-        nodeData.inputs?.fileObject as string;
+        const fileBase64 =
+            nodeData.inputs?.pdfFile ||
+            nodeData.inputs?.txtFile ||
+            nodeData.inputs?.yamlFile ||
+            nodeData.inputs?.docxFile ||
+            nodeData.inputs?.jsonlinesFile ||
+            nodeData.inputs?.csvFile ||
+            nodeData.inputs?.jsonFile ||
+            (nodeData.inputs?.fileObject as string)
 
         const obj: UnstructuredLoaderOptions = {
             apiUrl: unstructuredAPIUrl,


### PR DESCRIPTION
When upserting with the API, the uploaded files are of type pdfFile, txtFile, etc. but the code reads only fileObject which is the uploaded file using the button