### PR TITLE
Feature - Add option to start a new session with each interaction with the Chatflow tool

### DIFF
--- a/packages/components/nodes/tools/ChatflowTool/ChatflowTool.ts
+++ b/packages/components/nodes/tools/ChatflowTool/ChatflowTool.ts
@@ -258,7 +258,7 @@ class ChatflowTool extends StructuredTool {
 
         const body = {
             question: inputQuestion,
-            chatId: flowConfig?.chatId,
+            chatId: this.startNewSession ? uuidv4() : flowConfig?.chatId,
             overrideConfig: {
                 sessionId: this.startNewSession ? uuidv4() : flowConfig?.sessionId
             }

--- a/packages/components/nodes/tools/ChatflowTool/ChatflowTool.ts
+++ b/packages/components/nodes/tools/ChatflowTool/ChatflowTool.ts
@@ -6,6 +6,7 @@ import { CallbackManagerForToolRun, Callbacks, CallbackManager, parseCallbackCon
 import { StructuredTool } from '@langchain/core/tools'
 import { ICommonObject, IDatabaseEntity, INode, INodeData, INodeOptionsValue, INodeParams } from '../../../src/Interface'
 import { availableDependencies, defaultAllowBuiltInDep, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { v4 as uuidv4 } from 'uuid'
 
 class ChatflowTool_Tools implements INode {
     label: string
@@ -22,7 +23,7 @@ class ChatflowTool_Tools implements INode {
     constructor() {
         this.label = 'Chatflow Tool'
         this.name = 'ChatflowTool'
-        this.version = 2.0
+        this.version = 3.0
         this.type = 'ChatflowTool'
         this.icon = 'chatflowTool.svg'
         this.category = 'Tools'
@@ -63,6 +64,16 @@ class ChatflowTool_Tools implements INode {
                 description:
                     'Base URL to Flowise. By default, it is the URL of the incoming request. Useful when you need to execute the Chatflow through an alternative route.',
                 placeholder: 'http://localhost:3000',
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Start new session per message',
+                name: 'startNewSession',
+                type: 'boolean',
+                description:
+                    'Whether to continue the session with the Chatflow tool or start a new one with each interaction. Useful for Chatflows with memory if you want to avoid it.',
+                default: false,
                 optional: true,
                 additionalParams: true
             },
@@ -117,6 +128,8 @@ class ChatflowTool_Tools implements INode {
         const useQuestionFromChat = nodeData.inputs?.useQuestionFromChat as boolean
         const customInput = nodeData.inputs?.customInput as string
 
+        const startNewSession = nodeData.inputs?.startNewSession as boolean
+
         const baseURL = (nodeData.inputs?.baseURL as string) || (options.baseURL as string)
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
@@ -136,7 +149,7 @@ class ChatflowTool_Tools implements INode {
 
         let name = _name || 'chatflow_tool'
 
-        return new ChatflowTool({ name, baseURL, description, chatflowid: selectedChatflowId, headers, input: toolInput })
+        return new ChatflowTool({ name, baseURL, description, chatflowid: selectedChatflowId, startNewSession, headers, input: toolInput })
     }
 }
 
@@ -153,6 +166,8 @@ class ChatflowTool extends StructuredTool {
 
     chatflowid = ''
 
+    startNewSession = false
+
     baseURL = 'http://localhost:3000'
 
     headers = {}
@@ -166,6 +181,7 @@ class ChatflowTool extends StructuredTool {
         description,
         input,
         chatflowid,
+        startNewSession,
         baseURL,
         headers
     }: {
@@ -173,6 +189,7 @@ class ChatflowTool extends StructuredTool {
         description: string
         input: string
         chatflowid: string
+        startNewSession: boolean
         baseURL: string
         headers: ICommonObject
     }) {
@@ -181,6 +198,7 @@ class ChatflowTool extends StructuredTool {
         this.description = description
         this.input = input
         this.baseURL = baseURL
+        this.startNewSession = startNewSession
         this.headers = headers
         this.chatflowid = chatflowid
     }
@@ -242,7 +260,7 @@ class ChatflowTool extends StructuredTool {
             question: inputQuestion,
             chatId: flowConfig?.chatId,
             overrideConfig: {
-                sessionId: flowConfig?.sessionId
+                sessionId: this.startNewSession ? uuidv4() : flowConfig?.sessionId
             }
         }
 


### PR DESCRIPTION
This PR adds an option to the Chatflow Tool to decide if the conversation with the Chatflow keeps the same session or is independent with each interaction. This is very useful when using it with a Chatflow that has memory, to avoid it.

My use case is the following:
- Chatflow 1: Is a chat bot that answers questions based on RAG, with memory.
- Chatflow 2: Is an agent that uses the Chatflow 1 as a tool and it's instructed to, based on a list of questions and expected answers, ask them to the Chatflow 1 and evaluate each response.

In scenarios like this where repeated independent tasks are executed, memory is not desirable. Chatflow 1 might get confused about what is being asked in each independent task.