### PR TITLE
FIX #2617 Cherio Web Crawler doesn't work with large sites

### DIFF
--- a/packages/components/nodes/documentloaders/Cheerio/Cheerio.ts
+++ b/packages/components/nodes/documentloaders/Cheerio/Cheerio.ts
@@ -145,6 +145,7 @@ class Cheerio_DocumentLoaders implements INode {
                 return docs
             } catch (err) {
                 if (process.env.DEBUG === 'true') options.logger.error(`error in CheerioWebBaseLoader: ${err.message}, on page: ${url}`)
+                return []
             }
         }
 
@@ -165,17 +166,17 @@ class Cheerio_DocumentLoaders implements INode {
             if (process.env.DEBUG === 'true') options.logger.info(`pages: ${JSON.stringify(pages)}, length: ${pages.length}`)
             if (!pages || pages.length === 0) throw new Error('No relative links found')
             for (const page of pages) {
-                docs.push(...((await cheerioLoader(page)) || []))
+                docs.push(...(await cheerioLoader(page)))
             }
             if (process.env.DEBUG === 'true') options.logger.info(`Finish ${relativeLinksMethod}`)
         } else if (selectedLinks && selectedLinks.length > 0) {
             if (process.env.DEBUG === 'true')
                 options.logger.info(`pages: ${JSON.stringify(selectedLinks)}, length: ${selectedLinks.length}`)
             for (const page of selectedLinks.slice(0, limit)) {
-                docs.push(...((await cheerioLoader(page)) || []))
+                docs.push(...(await cheerioLoader(page)))
             }
         } else {
-            docs = (await cheerioLoader(url)) || []
+            docs = await cheerioLoader(url)
         }
 
         if (metadata) {

--- a/packages/components/nodes/documentloaders/Cheerio/Cheerio.ts
+++ b/packages/components/nodes/documentloaders/Cheerio/Cheerio.ts
@@ -131,7 +131,11 @@ class Cheerio_DocumentLoaders implements INode {
 
         async function cheerioLoader(url: string): Promise<any> {
             try {
-                let docs = []
+                let docs: IDocument[] = []
+                if (url.endsWith('.pdf')) {
+                    if (process.env.DEBUG === 'true') options.logger.info(`CheerioWebBaseLoader does not support PDF files: ${url}`)
+                    return docs
+                }
                 const loader = new CheerioWebBaseLoader(url, params)
                 if (textSplitter) {
                     docs = await loader.loadAndSplit(textSplitter)
@@ -161,17 +165,17 @@ class Cheerio_DocumentLoaders implements INode {
             if (process.env.DEBUG === 'true') options.logger.info(`pages: ${JSON.stringify(pages)}, length: ${pages.length}`)
             if (!pages || pages.length === 0) throw new Error('No relative links found')
             for (const page of pages) {
-                docs.push(...(await cheerioLoader(page)))
+                docs.push(...((await cheerioLoader(page)) || []))
             }
             if (process.env.DEBUG === 'true') options.logger.info(`Finish ${relativeLinksMethod}`)
         } else if (selectedLinks && selectedLinks.length > 0) {
             if (process.env.DEBUG === 'true')
                 options.logger.info(`pages: ${JSON.stringify(selectedLinks)}, length: ${selectedLinks.length}`)
             for (const page of selectedLinks.slice(0, limit)) {
-                docs.push(...(await cheerioLoader(page)))
+                docs.push(...((await cheerioLoader(page)) || []))
             }
         } else {
-            docs = await cheerioLoader(url)
+            docs = (await cheerioLoader(url)) || []
         }
 
         if (metadata) {


### PR DESCRIPTION
Hi,

There is a fix for issue https://github.com/FlowiseAI/Flowise/issues/2617. There were two problems. 

Firstly, sometimes cheerioLoader fails to download contnent of page and it returns undefined, so I added assignment of empty arrays if there is undefined. 

Secondly, CheerioWebBaseLoader doesn’t support loading PDF files. It takes a lot to load PDF file and the content is encoded so I believe it shouldn’t be downloaded as Document. So I added condition to avoid downloading PDF files.

I’ve tried it on the same Chatflow as in the issue.