### PR TITLE
Fix `observation?.includes is not a function`

### DIFF
--- a/packages/components/nodes/tools/CustomTool/core.ts
+++ b/packages/components/nodes/tools/CustomTool/core.ts
@@ -96,6 +96,9 @@ export class DynamicStructuredTool<
             await runManager?.handleToolError(e)
             throw e
         }
+        if (result && typeof result !== 'string') {
+            result = JSON.stringify(result)
+        }
         await runManager?.handleToolEnd(result)
         return result
     }


### PR DESCRIPTION
This error occurs when the result returned by CustomTool is of type number.