### PR TITLE
Fix retry mechanism for API call

### DIFF
--- a/packages/server/src/controllers/predictions/index.ts
+++ b/packages/server/src/controllers/predictions/index.ts
@@ -8,52 +8,63 @@ import { StatusCodes } from 'http-status-codes'
 
 // Send input message and get prediction result (External)
 const createPrediction = async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        if (typeof req.params === 'undefined' || !req.params.id) {
-            throw new InternalFlowiseError(
-                StatusCodes.PRECONDITION_FAILED,
-                `Error: predictionsController.createPrediction - id not provided!`
-            )
-        }
-        if (!req.body) {
-            throw new InternalFlowiseError(
-                StatusCodes.PRECONDITION_FAILED,
-                `Error: predictionsController.createPrediction - body not provided!`
-            )
-        }
-        const chatflow = await chatflowsService.getChatflowById(req.params.id)
-        if (!chatflow) {
-            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${req.params.id} not found`)
-        }
-        let isDomainAllowed = true
-        logger.info(`[server]: Request originated from ${req.headers.origin}`)
-        if (chatflow.chatbotConfig) {
-            const parsedConfig = JSON.parse(chatflow.chatbotConfig)
-            // check whether the first one is not empty. if it is empty that means the user set a value and then removed it.
-            const isValidAllowedOrigins = parsedConfig.allowedOrigins?.length && parsedConfig.allowedOrigins[0] !== ''
-            if (isValidAllowedOrigins) {
-                const originHeader = req.headers.origin as string
-                const origin = new URL(originHeader).host
-                isDomainAllowed =
-                    parsedConfig.allowedOrigins.filter((domain: string) => {
-                        try {
-                            const allowedOrigin = new URL(domain).host
-                            return origin === allowedOrigin
-                        } catch (e) {
-                            return false
-                        }
-                    }).length > 0
+    const retryLimit = 3;
+    const retryDelay = 2000; // 2 seconds
+
+    for (let attempt = 1; attempt <= retryLimit; attempt++) {
+        try {
+            if (typeof req.params === 'undefined' || !req.params.id) {
+                throw new InternalFlowiseError(
+                    StatusCodes.PRECONDITION_FAILED,
+                    `Error: predictionsController.createPrediction - id not provided!`
+                )
+            }
+            if (!req.body) {
+                throw new InternalFlowiseError(
+                    StatusCodes.PRECONDITION_FAILED,
+                    `Error: predictionsController.createPrediction - body not provided!`
+                )
+            }
+            const chatflow = await chatflowsService.getChatflowById(req.params.id)
+            if (!chatflow) {
+                throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${req.params.id} not found`)
+            }
+            let isDomainAllowed = true
+            logger.info(`[server]: Request originated from ${req.headers.origin}`)
+            if (chatflow.chatbotConfig) {
+                const parsedConfig = JSON.parse(chatflow.chatbotConfig)
+                // check whether the first one is not empty. if it is empty that means the user set a value and then removed it.
+                const isValidAllowedOrigins = parsedConfig.allowedOrigins?.length && parsedConfig.allowedOrigins[0] !== ''
+                if (isValidAllowedOrigins) {
+                    const originHeader = req.headers.origin as string
+                    const origin = new URL(originHeader).host
+                    isDomainAllowed =
+                        parsedConfig.allowedOrigins.filter((domain: string) => {
+                            try {
+                                const allowedOrigin = new URL(domain).host
+                                return origin === allowedOrigin
+                            } catch (e) {
+                                return false
+                            }
+                        }).length > 0
+                }
+            }
+            if (isDomainAllowed) {
+                //@ts-ignore
+                const apiResponse = await predictionsServices.buildChatflow(req, req?.io)
+                return res.json(apiResponse)
+            } else {
+                throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, `This site is not allowed to access this chatbot`)
+            }
+        } catch (error) {
+            logger.error(`[server]: Error on attempt ${attempt}:`, error)
+            if (attempt < retryLimit && (error.code === 'ECONNRESET' || error.message.includes('Socket timeout'))) {
+                logger.info(`[server]: Retrying attempt ${attempt + 1} after ${retryDelay}ms...`)
+                await new Promise(resolve => setTimeout(resolve, retryDelay))
+            } else {
+                next(error)
             }
         }
-        if (isDomainAllowed) {
-            //@ts-ignore
-            const apiResponse = await predictionsServices.buildChatflow(req, req?.io)
-            return res.json(apiResponse)
-        } else {
-            throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, `This site is not allowed to access this chatbot`)
-        }
-    } catch (error) {
-        next(error)
     }
 }
 


### PR DESCRIPTION
Related to #2755

Add retry logic to handle ECONNRESET and Socket timeout errors in API calls.

* **Retry Logic in `utilBuildChatflow`**:
  - Add retry mechanism in `utilBuildChatflow` function in `packages/server/src/utils/buildChatflow.ts`.
  - Attempt API call up to 3 times with a delay of 2 seconds between each attempt.
  - Log errors and retry attempts.
  - Throw `InternalFlowiseError` if retries are exhausted.

* **Retry Logic in `createPrediction`**:
  - Add retry mechanism in `createPrediction` function in `packages/server/src/controllers/predictions/index.ts`.
  - Attempt API call up to 3 times with a delay of 2 seconds between each attempt.
  - Log errors and retry attempts.
  - Pass error to next middleware if retries are exhausted.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FlowiseAI/Flowise/issues/2755?shareId=ac019ece-5c99-4770-9c36-d855ab322b27).