### PR TITLE
Add Perplexity AI Search Tool to Marketplaces/Tools

### DIFF
--- a/packages/server/marketplaces/tools/Perplexity AI Search.json
+++ b/packages/server/marketplaces/tools/Perplexity AI Search.json
@@ -1,0 +1,9 @@
+{
+    "name": "perplexity_ai_search",
+    "framework": "Langchain",
+    "description": "Useful when conducting research using Perplexity AI online model.",
+    "color": "linear-gradient(rgb(155,190,84), rgb(176,69,245))",
+    "iconSrc": "https://raw.githubusercontent.com/AsharibAli/project-images/main/perplexity-ai-icon.svg",
+    "schema": "[{\"id\":1,\"property\":\"query\",\"description\":\"Query for research\",\"type\":\"string\",\"required\":true}]",
+    "func": "const fetch = require('node-fetch');\nconst apiKey = 'YOUR_PERPLEXITY_API_KEY';  // Put Your Perplexity AI API key here\n\nconst query = $query;\n\nconst options = {\n\tmethod: 'POST',\n\theaders: {\n\t\t'Content-Type': 'application/json',\n\t\t'Authorization': 'Bearer <YOUR_PERPLEXITY_API_KEY>'\n\t},\n\tbody: JSON.stringify({\n\t\tmodel: 'llama-3-sonar-small-32k-online',  // Model\n\t\tmessages: [\n\t\t\t{\n\t\t\t\trole: 'system',\n\t\t\t\tcontent: 'You are a research assistant.'\n\t\t\t},\n\t\t\t{\n\t\t\t\trole: 'user',\n\t\t\t\tcontent: query\n\t\t\t}\n\t\t]\n\t})\n};\n\ntry {\n\tconst response = await fetch('https://api.perplexity.ai/chat/completions', options);\n\tconst data = await response.json();\n\treturn JSON.stringify(data);\n} catch (error) {\n\tconsole.error(error);\n\treturn 'Error occurred while fetching data from Perplexity AI';\n}\n\n// For more details: https://docs.perplexity.ai/docs/getting-started"
+}


### PR DESCRIPTION
This pull request adds a new tool named **perplexity_ai_search** to the marketplaces/tools directory. The tool utilizes the Perplexity AI online model for conducting research. The tool is built using the Langchain framework and includes the necessary configurations and a function to interact with the Perplexity AI API.

**Code Added:**
```
{
    "name": "perplexity_ai_search",
    "framework": "Langchain",
    "description": "Useful when conducting research using Perplexity AI online model.",
    "color": "linear-gradient(rgb(155,190,84), rgb(176,69,245))",
    "iconSrc": "https://raw.githubusercontent.com/AsharibAli/project-images/main/perplexity-ai-icon.svg",
    "schema": "[{\"id\":1,\"property\":\"query\",\"description\":\"Query for research\",\"type\":\"string\",\"required\":true}]",
    "func": "const fetch = require('node-fetch');\nconst apiKey = 'YOUR_PERPLEXITY_API_KEY';  // Put Your Perplexity AI API key here\n\nconst query = $query;\n\nconst options = {\n\tmethod: 'POST',\n\theaders: {\n\t\t'Content-Type': 'application/json',\n\t\t'Authorization': 'Bearer <YOUR_PERPLEXITY_API_KEY>'\n\t},\n\tbody: JSON.stringify({\n\t\tmodel: 'llama-3-sonar-small-32k-online',  // Model\n\t\tmessages: [\n\t\t\t{\n\t\t\t\trole: 'system',\n\t\t\t\tcontent: 'You are a research assistant.'\n\t\t\t},\n\t\t\t{\n\t\t\t\trole: 'user',\n\t\t\t\tcontent: query\n\t\t\t}\n\t\t]\n\t})\n};\n\ntry {\n\tconst response = await fetch('https://api.perplexity.ai/chat/completions', options);\n\tconst data = await response.json();\n\treturn JSON.stringify(data);\n} catch (error) {\n\tconsole.error(error);\n\treturn 'Error occurred while fetching data from Perplexity AI';\n}\n\n// For more details: https://docs.perplexity.ai/docs/getting-started"
}
```

For more details about the Perplexity API: [Perplexity API Getting Started Guide](https://docs.perplexity.ai/docs/getting-started).

**LeadUp Guru** on Flowise Discord: [Orignal Tool](https://discordapp.com/channels/1087698854775881778/1126304629043511468/1258389696481071184) 