### PR TITLE
feat: add driverInfo to mongodb component

### DIFF
--- a/packages/components/nodes/vectorstores/MongoDBAtlas/MongoDBAtlas.ts
+++ b/packages/components/nodes/vectorstores/MongoDBAtlas/MongoDBAtlas.ts
@@ -191,16 +191,21 @@ class MongoDBAtlas_VectorStores implements INode {
 let mongoClientSingleton: MongoClient
 let mongoUrl: string
 
+const driverInfo = {
+    name: 'Flowise',
+    version: 'todo, 1.8.5'
+}
+
 const getMongoClient = async (newMongoUrl: string) => {
     if (!mongoClientSingleton) {
         // if client does not exist
-        mongoClientSingleton = new MongoClient(newMongoUrl)
+        mongoClientSingleton = new MongoClient(newMongoUrl, { driverInfo })
         mongoUrl = newMongoUrl
         return mongoClientSingleton
     } else if (mongoClientSingleton && newMongoUrl !== mongoUrl) {
         // if client exists but url changed
         mongoClientSingleton.close()
-        mongoClientSingleton = new MongoClient(newMongoUrl)
+        mongoClientSingleton = new MongoClient(newMongoUrl, { driverInfo })
         mongoUrl = newMongoUrl
         return mongoClientSingleton
     }

--- a/packages/components/nodes/vectorstores/MongoDBAtlas/MongoDBAtlas.ts
+++ b/packages/components/nodes/vectorstores/MongoDBAtlas/MongoDBAtlas.ts
@@ -4,7 +4,7 @@ import { MongoDBAtlasVectorSearch } from '@langchain/mongodb'
 import { Embeddings } from '@langchain/core/embeddings'
 import { Document } from '@langchain/core/documents'
 import { ICommonObject, INode, INodeData, INodeOutputsValue, INodeParams, IndexingResult } from '../../../src/Interface'
-import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { getBaseClasses, getCredentialData, getCredentialParam, getVersion } from '../../../src/utils'
 import { addMMRInputParams, resolveVectorStoreOrRetriever } from '../VectorStoreUtils'
 
 class MongoDBAtlas_VectorStores implements INode {
@@ -191,12 +191,9 @@ class MongoDBAtlas_VectorStores implements INode {
 let mongoClientSingleton: MongoClient
 let mongoUrl: string
 
-const driverInfo = {
-    name: 'Flowise',
-    version: 'todo, 1.8.5'
-}
-
 const getMongoClient = async (newMongoUrl: string) => {
+    const driverInfo = { name: 'Flowise', version: (await getVersion()).version }
+
     if (!mongoClientSingleton) {
         // if client does not exist
         mongoClientSingleton = new MongoClient(newMongoUrl, { driverInfo })

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -772,3 +772,28 @@ export const prepareSandboxVars = (variables: IVariable[]) => {
     }
     return vars
 }
+
+let version: string
+export const getVersion: () => Promise<{ version: string }> = async () => {
+    if (version != null) return { version }
+
+    const checkPaths = [
+        path.join(__dirname, '..', 'package.json'),
+        path.join(__dirname, '..', '..', 'package.json'),
+        path.join(__dirname, '..', '..', '..', 'package.json'),
+        path.join(__dirname, '..', '..', '..', '..', 'package.json'),
+        path.join(__dirname, '..', '..', '..', '..', '..', 'package.json')
+    ]
+    for (const checkPath of checkPaths) {
+        try {
+            const content = await fs.promises.readFile(checkPath, 'utf8')
+            const parsedContent = JSON.parse(content)
+            version = parsedContent.version
+            return { version }
+        } catch {
+            continue
+        }
+    }
+
+    throw new Error('None of the package.json paths could be parsed')
+}


### PR DESCRIPTION
### Description

#### What is changing?

[NODE-6240](https://jira.mongodb.org/browse/NODE-6240)

Hello! 👋🏻 I am adding [`driverInfo`](https://mongodb.github.io/node-mongodb-native/6.8/interfaces/DriverInfo.html) to the MongoClient construction in the MongoDBAtlas component. 

#### What is the motivation for this change?

This field is intended for libraries wrapping the driver to push relevant information to the client metadata sent along with the initial handshake during connection creation. This information can be viewed in server logs to assist with debugging the source of a connection issue. It also provides data for determining what combined use cases the driver is supporting ([ex. mongoose](https://github.com/Automattic/mongoose/blob/2d4b8c2995251b8ece99da72a0fe1ba4481c8d18/lib/drivers/node-mongodb-native/connection.js#L295-L298)).

Ideally, I would like to set the Flowise version in addition to the name, I found a getVersion helper in `server/` but not something similar in `components/`, could I port that over? or is there a preferred way to obtain the version? 