### PR TITLE
fix: Autofocus on the add node search input field

### DIFF
--- a/packages/ui/src/views/canvas/AddNodes.jsx
+++ b/packages/ui/src/views/canvas/AddNodes.jsx
@@ -296,6 +296,8 @@ const AddNodes = ({ nodesData, node, isAgentCanvas }) => {
                                             <Typography variant='h4'>Add Nodes</Typography>
                                         </Stack>
                                         <OutlinedInput
+                                            // eslint-disable-next-line
+                                            autoFocus
                                             sx={{ width: '100%', pr: 2, pl: 2, my: 2 }}
                                             id='input-search-node'
                                             value={searchValue}


### PR DESCRIPTION
This PR is for adding an `autoFocus` on the search field in the `AddNodes` component, so that the input loads focused, and the user can start typing right away.

<img width="404" alt="image" src="https://github.com/user-attachments/assets/ab43d7e7-b2f5-4a9e-9299-f967468d3155">

Fixes #2881