### PR TITLE
update Dockerfile to fix broken build (increase node js memory limit)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN npm install -g pnpm
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
+ENV NODE_OPTIONS=--max-old-space-size=8192
+
 WORKDIR /usr/src
 
 # Copy app source


### PR DESCRIPTION
Fixes the following memory error when building:

`93.14 flowise-components:build: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
93.14 flowise-components:build: ----- Native stack trace -----
93.14 flowise-components:build:
93.26 flowise-components:build: Aborted
93.26 flowise-components:build:  ELIFECYCLE  Command failed with exit code 134.
93.27 flowise-components:build: ERROR: command finished with error: command (/usr/src/packages/components) pnpm run build exited (134)
93.27 flowise-components#build: command (/usr/src/packages/components) pnpm run build exited (134)`