### PR TITLE
feat: additional metadata added to Spider tool

### DIFF
--- a/packages/components/nodes/documentloaders/Spider/Spider.ts
+++ b/packages/components/nodes/documentloaders/Spider/Spider.ts
@@ -172,7 +172,7 @@ class Spider_DocumentLoaders implements INode {
             try {
                 params = JSON.parse(params)
             } catch (e) {
-                throw new Error('Invalid JSON string provided for params')
+                console.error('Invalid JSON string provided for params')
             }
         }
 
@@ -181,10 +181,10 @@ class Spider_DocumentLoaders implements INode {
                 try {
                     additionalMetadata = JSON.parse(additionalMetadata)
                 } catch (e) {
-                    throw new Error('Invalid JSON string provided for additional metadata')
+                    console.error('Invalid JSON string provided for additional metadata')
                 }
             } else if (typeof additionalMetadata !== 'object') {
-                throw new Error('Additional metadata must be a valid JSON object')
+                console.error('Additional metadata must be a valid JSON object')
             }
         } else {
             additionalMetadata = {}

--- a/packages/components/nodes/documentloaders/Spider/Spider.ts
+++ b/packages/components/nodes/documentloaders/Spider/Spider.ts
@@ -236,12 +236,12 @@ class Spider_DocumentLoaders implements INode {
                 _omitMetadataKeys === '*'
                     ? additionalMetadata
                     : omit(
-                        {
-                            ...doc.metadata,
-                            ...additionalMetadata
-                        },
-                        omitMetadataKeys
-                    )
+                          {
+                              ...doc.metadata,
+                              ...additionalMetadata
+                          },
+                          omitMetadataKeys
+                      )
         }))
 
         return docs


### PR DESCRIPTION
This updates the Spider tool to include optional additional metadata that can be used when eg. indexing vector DB's

Twitter: [@WilliamEspegren](https://x.com/WilliamEspegren)
![additional_metadata](https://github.com/user-attachments/assets/6dd491e5-a262-4191-8449-34d04af3c187)