### PR TITLE
Chore/Vertically center text labels in MuiDrawer side menu

### DIFF
--- a/packages/ui/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.jsx
+++ b/packages/ui/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.jsx
@@ -143,6 +143,7 @@ const NavItem = ({ item, level, navType, onClick, onUploadFile }) => {
             {item.isBeta && (
                 <Chip
                     sx={{
+                        my: 'auto',
                         width: 'max-content',
                         fontWeight: 700,
                         fontSize: '0.65rem',

--- a/packages/ui/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.jsx
+++ b/packages/ui/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.jsx
@@ -124,7 +124,7 @@ const NavItem = ({ item, level, navType, onClick, onUploadFile }) => {
                 }
                 secondary={
                     item.caption && (
-                        <Typography variant='caption' sx={{ ...theme.typography.subMenuCaption }} display='block' gutterBottom>
+                        <Typography variant='caption' sx={{ ...theme.typography.subMenuCaption, mt: -0.6 }} display='block' gutterBottom>
                             {item.caption}
                         </Typography>
                     )

--- a/packages/ui/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.jsx
+++ b/packages/ui/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.jsx
@@ -114,7 +114,11 @@ const NavItem = ({ item, level, navType, onClick, onUploadFile }) => {
             <ListItemIcon sx={{ my: 'auto', minWidth: !item?.icon ? 18 : 36 }}>{itemIcon}</ListItemIcon>
             <ListItemText
                 primary={
-                    <Typography variant={customization.isOpen.findIndex((id) => id === item.id) > -1 ? 'h5' : 'body1'} color='inherit'>
+                    <Typography
+                        variant={customization.isOpen.findIndex((id) => id === item.id) > -1 ? 'h5' : 'body1'}
+                        color='inherit'
+                        sx={{ my: 0.5 }}
+                    >
                         {item.title}
                     </Typography>
                 }
@@ -125,6 +129,7 @@ const NavItem = ({ item, level, navType, onClick, onUploadFile }) => {
                         </Typography>
                     )
                 }
+                sx={{ my: 'auto' }}
             />
             {item.chip && (
                 <Chip


### PR DESCRIPTION
### Summary
This pull request addresses vertical alignment issues in the side menu (MuiDrawer component) by making the following improvements:

1. **Vertical Alignment of Side Menu Button Labels**
   - Fixed the vertical alignment of labels, such as 'Agentflows', which were not centered within their containers.
   - Applied automatic vertical margins to `<ListItemText>` and added a 4px vertical margin to the primary text element `<Typography>` to maintain existing margins.

2. **Vertical Alignment of Side Menu BETA Chips**
   - Corrected the vertical alignment of 'BETA' chips in the side menu.
   - Ensured that the chips are consistently centered regardless of the presence of captions in the corresponding text labels.

3. **Adjust Margin for Secondary Labels (a.k.a., captions)**
   - Added `mt: -0.6` to the secondary (caption) label to replicate the original gap between the primary and secondary labels.

### Before and After Screenshots

| Before | After |
| :- | :- |
| <img width="175" alt="Before" src="https://github.com/user-attachments/assets/10530b6a-d522-4b1a-8a1c-c0bfb70ac24f"> | <img width="175" alt="After" src="https://github.com/user-attachments/assets/ec52a545-c1a6-4611-94ab-2075faf2474d"> |

### Before and After Screenshots with Added Caption Labels

| Before with Caption | After with Caption |
| :- | :- |
| <img width="175" alt="Before with caption" src="https://github.com/user-attachments/assets/4eeab16a-810a-45be-a12e-c31684ab7b09"> | <img width="175" alt="After with caption" src="https://github.com/user-attachments/assets/8eaa2874-6c7d-4509-99a3-78953d49048a"> |

### Detailed Changes
- Updated `<ListItemText>` components with `sx={{ my: 'auto' }}` to automatically center the nav button labels vertically.
- Modified `<Typography>` elements within `<ListItemText>` to include `sx={{ my: 0.5 }}` for consistent vertical margins, replicating the 4px vertical margins that existed before this change.
- Updated 'BETA' chip elements with `sx={{ my: 'auto' }}` to automatically center them vertically.
- Added `mt: -0.6` to the secondary (caption) label to replicate the original gap between the primary and secondary labels.

### Additional Information
These changes enhance the visual alignment and consistency of the side menu items, improving the overall user experience.