### PR TITLE
fix migration with wrong unix timestamp

### DIFF
--- a/packages/server/src/database/migrations/mariadb/1716300000000-AddTypeToChatFlow.ts
+++ b/packages/server/src/database/migrations/mariadb/1716300000000-AddTypeToChatFlow.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class AddTypeToChatFlow1766759476232 implements MigrationInterface {
+export class AddTypeToChatFlow1716300000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         const columnExists = await queryRunner.hasColumn('chat_flow', 'type')
-        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`type\` TEXT;`)
+        if (!columnExists) await queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`type\` TEXT;`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/server/src/database/migrations/mariadb/index.ts
+++ b/packages/server/src/database/migrations/mariadb/index.ts
@@ -13,13 +13,13 @@ import { AddFileAnnotationsToChatMessage1700271021237 } from './1700271021237-Ad
 import { AddFileUploadsToChatMessage1701788586491 } from './1701788586491-AddFileUploadsToChatMessage'
 import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntity'
 import { AddSpeechToText1706364937060 } from './1706364937060-AddSpeechToText'
-import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { AddFeedback1707213626553 } from './1707213626553-AddFeedback'
-import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
+import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { AddLead1710832127079 } from './1710832127079-AddLead'
 import { AddLeadToChatMessage1711538023578 } from './1711538023578-AddLeadToChatMessage'
+import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
 import { AddAgentReasoningToChatMessage1714679514451 } from './1714679514451-AddAgentReasoningToChatMessage'
-import { AddTypeToChatFlow1766759476232 } from './1766759476232-AddTypeToChatFlow'
+import { AddTypeToChatFlow1716300000000 } from './1716300000000-AddTypeToChatFlow'
 import { AddApiKey1720230151480 } from './1720230151480-AddApiKey'
 import { AddActionToChatMessage1721078251523 } from './1721078251523-AddActionToChatMessage'
 import { LongTextColumn1722301395521 } from './1722301395521-LongTextColumn'
@@ -46,7 +46,7 @@ export const mariadbMigrations = [
     AddLead1710832127079,
     AddLeadToChatMessage1711538023578,
     AddAgentReasoningToChatMessage1714679514451,
-    AddTypeToChatFlow1766759476232,
+    AddTypeToChatFlow1716300000000,
     AddApiKey1720230151480,
     AddActionToChatMessage1721078251523,
     LongTextColumn1722301395521

--- a/packages/server/src/database/migrations/mysql/1716300000000-AddTypeToChatFlow.ts
+++ b/packages/server/src/database/migrations/mysql/1716300000000-AddTypeToChatFlow.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class AddTypeToChatFlow1766759476232 implements MigrationInterface {
+export class AddTypeToChatFlow1716300000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
         const columnExists = await queryRunner.hasColumn('chat_flow', 'type')
-        if (!columnExists) queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`type\` TEXT;`)
+        if (!columnExists) await queryRunner.query(`ALTER TABLE \`chat_flow\` ADD COLUMN \`type\` TEXT;`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/server/src/database/migrations/mysql/index.ts
+++ b/packages/server/src/database/migrations/mysql/index.ts
@@ -13,13 +13,13 @@ import { AddFileAnnotationsToChatMessage1700271021237 } from './1700271021237-Ad
 import { AddFileUploadsToChatMessage1701788586491 } from './1701788586491-AddFileUploadsToChatMessage'
 import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntity'
 import { AddSpeechToText1706364937060 } from './1706364937060-AddSpeechToText'
-import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { AddFeedback1707213626553 } from './1707213626553-AddFeedback'
-import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
+import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { AddLead1710832127079 } from './1710832127079-AddLead'
 import { AddLeadToChatMessage1711538023578 } from './1711538023578-AddLeadToChatMessage'
+import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
 import { AddAgentReasoningToChatMessage1714679514451 } from './1714679514451-AddAgentReasoningToChatMessage'
-import { AddTypeToChatFlow1766759476232 } from './1766759476232-AddTypeToChatFlow'
+import { AddTypeToChatFlow1716300000000 } from './1716300000000-AddTypeToChatFlow'
 import { AddApiKey1720230151480 } from './1720230151480-AddApiKey'
 import { AddActionToChatMessage1721078251523 } from './1721078251523-AddActionToChatMessage'
 import { LongTextColumn1722301395521 } from './1722301395521-LongTextColumn'
@@ -46,7 +46,7 @@ export const mysqlMigrations = [
     AddLead1710832127079,
     AddLeadToChatMessage1711538023578,
     AddAgentReasoningToChatMessage1714679514451,
-    AddTypeToChatFlow1766759476232,
+    AddTypeToChatFlow1716300000000,
     AddApiKey1720230151480,
     AddActionToChatMessage1721078251523,
     LongTextColumn1722301395521

--- a/packages/server/src/database/migrations/postgres/1716300000000-AddTypeToChatFlow.ts
+++ b/packages/server/src/database/migrations/postgres/1716300000000-AddTypeToChatFlow.ts
@@ -1,8 +1,8 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class AddTypeToChatFlow1766759476232 implements MigrationInterface {
+export class AddTypeToChatFlow1716300000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN "type" TEXT;`)
+        await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN IF NOT EXISTS "type" TEXT;`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -13,14 +13,14 @@ import { AddFileAnnotationsToChatMessage1700271021237 } from './1700271021237-Ad
 import { AddFileUploadsToChatMessage1701788586491 } from './1701788586491-AddFileUploadsToChatMessage'
 import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntity'
 import { AddSpeechToText1706364937060 } from './1706364937060-AddSpeechToText'
-import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { AddFeedback1707213601923 } from './1707213601923-AddFeedback'
+import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { FieldTypes1710497452584 } from './1710497452584-FieldTypes'
-import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
 import { AddLead1710832137905 } from './1710832137905-AddLead'
 import { AddLeadToChatMessage1711538016098 } from './1711538016098-AddLeadToChatMessage'
+import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
 import { AddAgentReasoningToChatMessage1714679514451 } from './1714679514451-AddAgentReasoningToChatMessage'
-import { AddTypeToChatFlow1766759476232 } from './1766759476232-AddTypeToChatFlow'
+import { AddTypeToChatFlow1716300000000 } from './1716300000000-AddTypeToChatFlow'
 import { AddApiKey1720230151480 } from './1720230151480-AddApiKey'
 import { AddActionToChatMessage1721078251523 } from './1721078251523-AddActionToChatMessage'
 
@@ -47,7 +47,7 @@ export const postgresMigrations = [
     AddLead1710832137905,
     AddLeadToChatMessage1711538016098,
     AddAgentReasoningToChatMessage1714679514451,
-    AddTypeToChatFlow1766759476232,
+    AddTypeToChatFlow1716300000000,
     AddApiKey1720230151480,
     AddActionToChatMessage1721078251523
 ]

--- a/packages/server/src/database/migrations/sqlite/1716300000000-AddTypeToChatFlow.ts
+++ b/packages/server/src/database/migrations/sqlite/1716300000000-AddTypeToChatFlow.ts
@@ -1,8 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class AddTypeToChatFlow1766759476232 implements MigrationInterface {
+export class AddTypeToChatFlow1716300000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "chat_flow" ADD COLUMN IF NOT EXISTS "type" TEXT;`)
+        const columnExists = await queryRunner.hasColumn('chat_flow', 'type')
+        if (!columnExists) await queryRunner.query(`ALTER TABLE "chat_flow"ADD COLUMN "type" TEXT;`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/server/src/database/migrations/sqlite/index.ts
+++ b/packages/server/src/database/migrations/sqlite/index.ts
@@ -13,15 +13,15 @@ import { AddFileAnnotationsToChatMessage1700271021237 } from './1700271021237-Ad
 import { AddFileUploadsToChatMessage1701788586491 } from './1701788586491-AddFileUploadsToChatMessage'
 import { AddVariableEntity1699325775451 } from './1702200925471-AddVariableEntity'
 import { AddSpeechToText1706364937060 } from './1706364937060-AddSpeechToText'
-import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { AddFeedback1707213619308 } from './1707213619308-AddFeedback'
-import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
+import { AddUpsertHistoryEntity1709814301358 } from './1709814301358-AddUpsertHistoryEntity'
 import { AddLead1710832117612 } from './1710832117612-AddLead'
 import { AddLeadToChatMessage1711537986113 } from './1711537986113-AddLeadToChatMessage'
+import { AddDocumentStore1711637331047 } from './1711637331047-AddDocumentStore'
 import { AddAgentReasoningToChatMessage1714679514451 } from './1714679514451-AddAgentReasoningToChatMessage'
-import { AddTypeToChatFlow1766759476232 } from './1766759476232-AddTypeToChatFlow'
-import { AddActionToChatMessage1721078251523 } from './1721078251523-AddActionToChatMessage'
+import { AddTypeToChatFlow1716300000000 } from './1716300000000-AddTypeToChatFlow'
 import { AddApiKey1720230151480 } from './1720230151480-AddApiKey'
+import { AddActionToChatMessage1721078251523 } from './1721078251523-AddActionToChatMessage'
 
 export const sqliteMigrations = [
     Init1693835579790,
@@ -45,7 +45,7 @@ export const sqliteMigrations = [
     AddLead1710832117612,
     AddLeadToChatMessage1711537986113,
     AddAgentReasoningToChatMessage1714679514451,
-    AddTypeToChatFlow1766759476232,
+    AddTypeToChatFlow1716300000000,
     AddApiKey1720230151480,
     AddActionToChatMessage1721078251523
 ]


### PR DESCRIPTION
## Resason for this fix
1. When new user come in it will always be the last to run.
![problem](https://github.com/user-attachments/assets/996d702c-c67c-44ea-a414-7ae3f454d9f0)
3. sqlite does not check whether column is created.

## Solution
1. Modify `1766759476232` to `1716300000000`.
2. Add check whether column exists in sqlite.

## Results
### Affect to current user
![what will current user see from the fix 1](https://github.com/user-attachments/assets/13e7b2f5-0ab1-4b01-971a-4b71fa3e1ab3)
![what will current user see from the fix 2](https://github.com/user-attachments/assets/96cff933-291a-4bed-a1ce-ab3bd449be55)

### Affect to new user
![what new user will see from the fix 1](https://github.com/user-attachments/assets/1e02fe70-cf73-4662-86ba-fc52afb283f8)
![what new user will see from the fix 2](https://github.com/user-attachments/assets/47a61dd2-ad41-4fa3-ac6f-90959bba4795)


