### PR TITLE
fix: ignore `allowedOrigins` config for undefined `origin` header to ensure correct CORS behavior

### DIFF
--- a/packages/server/src/controllers/predictions/index.ts
+++ b/packages/server/src/controllers/predictions/index.ts
@@ -26,13 +26,13 @@ const createPrediction = async (req: Request, res: Response, next: NextFunction)
             throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${req.params.id} not found`)
         }
         let isDomainAllowed = true
-        logger.info(`[server]: Request originated from ${req.headers.origin}`)
+        logger.info(`[server]: Request originated from ${req.headers.origin || 'UNKNOWN ORIGIN'}`)
         if (chatflow.chatbotConfig) {
             const parsedConfig = JSON.parse(chatflow.chatbotConfig)
             // check whether the first one is not empty. if it is empty that means the user set a value and then removed it.
             const isValidAllowedOrigins = parsedConfig.allowedOrigins?.length && parsedConfig.allowedOrigins[0] !== ''
-            if (isValidAllowedOrigins) {
-                const originHeader = req.headers.origin as string
+            if (isValidAllowedOrigins && req.headers.origin) {
+                const originHeader = req.headers.origin
                 const origin = new URL(originHeader).host
                 isDomainAllowed =
                     parsedConfig.allowedOrigins.filter((domain: string) => {


### PR DESCRIPTION
Hi Flowise team, 

I discovered that after configuring `allowedDomains` (as dynamic CORS) for a chatflow, It checks my origin header even if it is undefined. The request might be sent from a proxy server or postman and usually sends requests with undefined origin.

The error I got when requesting to `/api/v1/prediction` from postman or curl was:
```
{
    "statusCode": 500,
    "success": false,
    "message": "Invalid URL",
    "stack": {}
}
```