### PR TITLE
Add $flow to Variable Resolution in Flow Building Process

### DIFF
--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -328,13 +328,22 @@ export const utilBuildChatflow = async (req: Request, socketIO?: Server, isInter
                 nodeToExecute.data = replaceInputsWithConfig(nodeToExecute.data, incomingInput.overrideConfig)
             }
 
+            const options: ICommonObject = {
+                chatflowid,
+                chatId,
+                sessionId,
+                chatHistory,
+                ...incomingInput.overrideConfig
+            }
+
             const reactFlowNodeData: INodeData = await resolveVariables(
                 appServer.AppDataSource,
                 nodeToExecute.data,
                 reactFlowNodes,
                 incomingInput.question,
                 chatHistory,
-                incomingInput.overrideConfig
+                incomingInput.overrideConfig,
+                options
             )
             nodeToExecuteData = reactFlowNodeData
 

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -328,7 +328,7 @@ export const utilBuildChatflow = async (req: Request, socketIO?: Server, isInter
                 nodeToExecute.data = replaceInputsWithConfig(nodeToExecute.data, incomingInput.overrideConfig)
             }
 
-            const options: ICommonObject = {
+            const flowData: ICommonObject = {
                 chatflowid,
                 chatId,
                 sessionId,
@@ -342,8 +342,7 @@ export const utilBuildChatflow = async (req: Request, socketIO?: Server, isInter
                 reactFlowNodes,
                 incomingInput.question,
                 chatHistory,
-                incomingInput.overrideConfig,
-                options
+                flowData
             )
             nodeToExecuteData = reactFlowNodeData
 

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -491,7 +491,8 @@ export const buildFlow = async ({
         chatflowid,
         chatId,
         sessionId,
-        chatHistory
+        chatHistory,
+        ...overrideConfig
     }
     while (nodeQueue.length) {
         const { nodeId, depth } = nodeQueue.shift() as INodeQueue

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -486,6 +486,13 @@ export const buildFlow = async ({
 
     const initializedNodes: Set<string> = new Set()
     const reversedGraph = constructGraphs(reactFlowNodes, reactFlowEdges, { isReversed: true }).graph
+
+    const options: ICommonObject = {
+        chatflowid,
+        chatId,
+        sessionId,
+        chatHistory
+    }
     while (nodeQueue.length) {
         const { nodeId, depth } = nodeQueue.shift() as INodeQueue
 
@@ -509,7 +516,8 @@ export const buildFlow = async ({
                 flowNodes,
                 question,
                 chatHistory,
-                overrideConfig
+                overrideConfig,
+                options
             )
 
             if (isUpsert && stopNodeId && nodeId === stopNodeId) {
@@ -760,7 +768,8 @@ export const getVariableValue = async (
     question: string,
     chatHistory: IMessage[],
     isAcceptVariable = false,
-    overrideConfig?: ICommonObject
+    overrideConfig?: ICommonObject,
+    options?: ICommonObject
 ) => {
     const isObject = typeof paramValue === 'object'
     let returnVal = (isObject ? JSON.stringify(paramValue) : paramValue) ?? ''
@@ -799,6 +808,14 @@ export const getVariableValue = async (
             if (variableFullPath.startsWith('$vars.')) {
                 const vars = await getGlobalVariable(appDataSource, overrideConfig)
                 const variableValue = get(vars, variableFullPath.replace('$vars.', ''))
+                if (variableValue) {
+                    variableDict[`{{${variableFullPath}}}`] = variableValue
+                    returnVal = returnVal.split(`{{${variableFullPath}}}`).join(variableValue)
+                }
+            }
+
+            if (variableFullPath.startsWith('$flow.') && options) {
+                const variableValue = get(options, variableFullPath.replace('$flow.', ''))
                 if (variableValue) {
                     variableDict[`{{${variableFullPath}}}`] = variableValue
                     returnVal = returnVal.split(`{{${variableFullPath}}}`).join(variableValue)
@@ -897,7 +914,8 @@ export const resolveVariables = async (
     reactFlowNodes: IReactFlowNode[],
     question: string,
     chatHistory: IMessage[],
-    overrideConfig?: ICommonObject
+    overrideConfig?: ICommonObject,
+    options?: ICommonObject
 ): Promise<INodeData> => {
     let flowNodeData = cloneDeep(reactFlowNodeData)
     const types = 'inputs'
@@ -915,7 +933,8 @@ export const resolveVariables = async (
                         question,
                         chatHistory,
                         undefined,
-                        overrideConfig
+                        overrideConfig,
+                        options
                     )
                     resolvedInstances.push(resolvedInstance)
                 }
@@ -929,7 +948,8 @@ export const resolveVariables = async (
                     question,
                     chatHistory,
                     isAcceptVariable,
-                    overrideConfig
+                    overrideConfig,
+                    options
                 )
                 paramsObj[key] = resolvedInstance
             }

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -487,7 +487,7 @@ export const buildFlow = async ({
     const initializedNodes: Set<string> = new Set()
     const reversedGraph = constructGraphs(reactFlowNodes, reactFlowEdges, { isReversed: true }).graph
 
-    const options: ICommonObject = {
+    const flowData: ICommonObject = {
         chatflowid,
         chatId,
         sessionId,
@@ -517,8 +517,7 @@ export const buildFlow = async ({
                 flowNodes,
                 question,
                 chatHistory,
-                overrideConfig,
-                options
+                flowData
             )
 
             if (isUpsert && stopNodeId && nodeId === stopNodeId) {
@@ -769,8 +768,7 @@ export const getVariableValue = async (
     question: string,
     chatHistory: IMessage[],
     isAcceptVariable = false,
-    overrideConfig?: ICommonObject,
-    options?: ICommonObject
+    flowData?: ICommonObject
 ) => {
     const isObject = typeof paramValue === 'object'
     let returnVal = (isObject ? JSON.stringify(paramValue) : paramValue) ?? ''
@@ -807,7 +805,7 @@ export const getVariableValue = async (
             }
 
             if (variableFullPath.startsWith('$vars.')) {
-                const vars = await getGlobalVariable(appDataSource, overrideConfig)
+                const vars = await getGlobalVariable(appDataSource, flowData)
                 const variableValue = get(vars, variableFullPath.replace('$vars.', ''))
                 if (variableValue) {
                     variableDict[`{{${variableFullPath}}}`] = variableValue
@@ -815,8 +813,8 @@ export const getVariableValue = async (
                 }
             }
 
-            if (variableFullPath.startsWith('$flow.') && options) {
-                const variableValue = get(options, variableFullPath.replace('$flow.', ''))
+            if (variableFullPath.startsWith('$flow.') && flowData) {
+                const variableValue = get(flowData, variableFullPath.replace('$flow.', ''))
                 if (variableValue) {
                     variableDict[`{{${variableFullPath}}}`] = variableValue
                     returnVal = returnVal.split(`{{${variableFullPath}}}`).join(variableValue)
@@ -915,8 +913,7 @@ export const resolveVariables = async (
     reactFlowNodes: IReactFlowNode[],
     question: string,
     chatHistory: IMessage[],
-    overrideConfig?: ICommonObject,
-    options?: ICommonObject
+    flowData?: ICommonObject
 ): Promise<INodeData> => {
     let flowNodeData = cloneDeep(reactFlowNodeData)
     const types = 'inputs'
@@ -934,8 +931,7 @@ export const resolveVariables = async (
                         question,
                         chatHistory,
                         undefined,
-                        overrideConfig,
-                        options
+                        flowData
                     )
                     resolvedInstances.push(resolvedInstance)
                 }
@@ -949,8 +945,7 @@ export const resolveVariables = async (
                     question,
                     chatHistory,
                     isAcceptVariable,
-                    overrideConfig,
-                    options
+                    flowData
                 )
                 paramsObj[key] = resolvedInstance
             }


### PR DESCRIPTION
## Changes Overview

This PR enhances the variable resolution process in the flow building mechanism, particularly focusing on the `buildFlow` and `getVariableValue` functions.

### Key Updates

1. **Flow Options Enhancement**
   - Added a new `options` object in the `buildFlow` function:
     ```typescript
     const options: ICommonObject = {
         chatflowid,
         chatId,
         sessionId,
         chatHistory
     }
     ```

2. **Variable Resolution Improvements**
   - Updated `resolveVariables` and `getVariableValue` functions to accept and utilize the new `options` parameter.

3. **Flow-specific Variable Support**
   - Implemented handling for variables starting with `$flow.` in the `getVariableValue` function:
     ```typescript
     if (variableFullPath.startsWith('$flow.') && options) {
         const variableValue = get(options, variableFullPath.replace('$flow.', ''))
         if (variableValue) {
             variableDict[`{{${variableFullPath}}}`] = variableValue
             returnVal = returnVal.split(`{{${variableFullPath}}}`).join(variableValue)
         }
     }
     ```

## Rationale

These changes allow for more flexible and context-aware variable resolution within the flow building process. By introducing the `options` object and supporting `$flow.` prefixed variables, we enable access to flow-specific data like `chatflowid`, `chatId`, `sessionId`, and `chatHistory` during variable resolution.

Also it can be used to enhance filtering and logic in any flow input:
![image](https://github.com/user-attachments/assets/f39ccece-bd22-4831-af42-64b98687f6a8)


## Testing

![image](https://github.com/user-attachments/assets/1f505087-ea27-431b-9b47-c86eba7616ea)
![image](https://github.com/user-attachments/assets/2e2b157a-e262-4e6c-b1c9-f1fd37cf7c4b)
![image](https://github.com/user-attachments/assets/547a9bd6-c85e-462b-b618-64b810f985f7)



## Notes for Reviewers

- Pay special attention to the variable resolution logic in `getVariableValue`.
- Consider if there are any edge cases in flow-specific variable usage that should be addressed.