### PR TITLE
Bugfix/langwatch missing returnids

### DIFF
--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -633,7 +633,8 @@ export class AnalyticHandler {
         const returnIds: ICommonObject = {
             langSmith: {},
             langFuse: {},
-            lunary: {}
+            lunary: {},
+            langWatch: {}
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langSmith')) {
@@ -789,7 +790,8 @@ export class AnalyticHandler {
         const returnIds: ICommonObject = {
             langSmith: {},
             langFuse: {},
-            lunary: {}
+            lunary: {},
+            langWatch: {}
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langSmith')) {

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -633,8 +633,7 @@ export class AnalyticHandler {
         const returnIds: ICommonObject = {
             langSmith: {},
             langFuse: {},
-            lunary: {},
-            langWatch: {}
+            lunary: {}
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langSmith')) {
@@ -790,8 +789,7 @@ export class AnalyticHandler {
         const returnIds: ICommonObject = {
             langSmith: {},
             langFuse: {},
-            lunary: {},
-            langWatch: {}
+            lunary: {}
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langSmith')) {


### PR DESCRIPTION
Fixed a bug where I got a missing 'span' when turning on langWatch in Analyse chatflow settings.