### PR TITLE
[FEATURE] Add "base path" to Azure OpenAI embeddings node

### DIFF
--- a/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
@@ -44,6 +44,13 @@ class AzureOpenAIEmbedding_Embeddings implements INode {
                 type: 'number',
                 optional: true,
                 additionalParams: true
+            },
+            {
+                label: 'BasePath',
+                name: 'basepath',
+                type: 'string',
+                optional: true,
+                additionalParams: true
             }
         ]
     }
@@ -51,6 +58,7 @@ class AzureOpenAIEmbedding_Embeddings implements INode {
     async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
         const batchSize = nodeData.inputs?.batchSize as string
         const timeout = nodeData.inputs?.timeout as string
+        const basePath = nodeData.inputs?.basepath as string
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const azureOpenAIApiKey = getCredentialParam('azureOpenAIApiKey', credentialData, nodeData)
@@ -62,7 +70,8 @@ class AzureOpenAIEmbedding_Embeddings implements INode {
             azureOpenAIApiKey,
             azureOpenAIApiInstanceName,
             azureOpenAIApiDeploymentName,
-            azureOpenAIApiVersion
+            azureOpenAIApiVersion,
+            azureOpenAIBasePath: basePath
         }
 
         if (batchSize) obj.batchSize = parseInt(batchSize, 10)


### PR DESCRIPTION
In the Azure OpenAI Embeddings node, I added a BasePath item to the endpoint like the Azure OpenAI node. 
- #3048 

![image](https://github.com/user-attachments/assets/b666356b-60a9-4fd7-9589-ca6a42623cfc)
![image](https://github.com/user-attachments/assets/d472b2be-a3ba-48bf-9972-ec666a1c95c2)
