### PR TITLE
Passing state to tool so that we can use them in custom tools

### DIFF
--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -396,3 +396,7 @@ export interface IVisionChatModal {
     revertToOriginalModel(): void
     setMultiModalOption(multiModalOption: IMultiModalOption): void
 }
+export interface IStateWithMessages extends ICommonObject {
+    messages: BaseMessage[]
+    [key: string]: any
+}


### PR DESCRIPTION
Allows the use of `$flow.state.var` inside the custom tool by passing the state in the ToolNode:

for example:
![image](https://github.com/user-attachments/assets/d0d34086-4987-49e1-817b-dcd393f78697)

we have the output 
![image](https://github.com/user-attachments/assets/9e24ed16-c8ce-477f-84ae-a1d6dbfc02a9)


when we use the following function in the custom tool node:  ```return successfully called tool ${$flow.state.test}`;```

This is inlie with the behaviour mentionsed in the `How to Use Function`

![image](https://github.com/user-attachments/assets/34a84389-cb30-49e7-9da3-94c12c7a3e63)

Previously we were getting the following an error:
![image](https://github.com/user-attachments/assets/df1791c2-966f-4cc6-8b35-1cda8fa985b5)

Ps: I am only passing the state without the messages since we are already using the toolNode to get the functions to calls. I dont see why we would need the messages in the tool itself but I could be shortsighted on this.







