### PR TITLE
feat: add support for calling tools in CustomFunction

### DIFF
--- a/packages/components/nodes/utilities/CustomFunction/CustomFunction.ts
+++ b/packages/components/nodes/utilities/CustomFunction/CustomFunction.ts
@@ -1,3 +1,5 @@
+import { flatten } from 'lodash'
+import { type StructuredTool } from '@langchain/core/tools'
 import { ICommonObject, IDatabaseEntity, INode, INodeData, INodeOutputsValue, INodeParams } from '../../../src/Interface'
 import { NodeVM } from 'vm2'
 import { DataSource } from 'typeorm'
@@ -19,7 +21,7 @@ class CustomFunction_Utilities implements INode {
     constructor() {
         this.label = 'Custom JS Function'
         this.name = 'customFunction'
-        this.version = 2.0
+        this.version = 3.0
         this.type = 'CustomFunction'
         this.icon = 'customfunction.svg'
         this.category = 'Utilities'
@@ -42,6 +44,14 @@ class CustomFunction_Utilities implements INode {
                 type: 'string',
                 optional: true,
                 placeholder: 'My Function'
+            },
+            {
+                label: 'Additional Tools',
+                description: 'Tools can be used in the function with $tools.{tool_name}.invoke(args)',
+                name: 'tools',
+                type: 'Tool',
+                list: true,
+                optional: true
             },
             {
                 label: 'Javascript Function',
@@ -71,6 +81,7 @@ class CustomFunction_Utilities implements INode {
         const functionInputVariablesRaw = nodeData.inputs?.functionInputVariables
         const appDataSource = options.appDataSource as DataSource
         const databaseEntities = options.databaseEntities as IDatabaseEntity
+        const tools = Object.fromEntries((flatten(nodeData.inputs?.tools) as StructuredTool[])?.map((tool) => [tool.name, tool]) ?? [])
 
         const variables = await getVars(appDataSource, databaseEntities, nodeData)
         const flow = {
@@ -109,6 +120,7 @@ class CustomFunction_Utilities implements INode {
         let sandbox: any = { $input: input }
         sandbox['$vars'] = prepareSandboxVars(variables)
         sandbox['$flow'] = flow
+        sandbox['$tools'] = tools
 
         if (Object.keys(inputVars).length) {
             for (const item in inputVars) {


### PR DESCRIPTION
It is easier to handle some complex logic with CustomFunction, but it lacks the ability to directly call existing tools, 

so this PR is added to support this feature, reuse existing Chatflows, tools, etc.

<img width="910" alt="image" src="https://github.com/user-attachments/assets/c179718b-55cc-4a96-87a4-4bccfea269ce">
