### PR TITLE
feat: enable autofocus to the `new chatflow title` to improve usability

### DIFF
--- a/packages/ui/src/ui-component/dialog/SaveChatflowDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/SaveChatflowDialog.jsx
@@ -24,12 +24,15 @@ const SaveChatflowDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
             onClose={onCancel}
             aria-labelledby='alert-dialog-title'
             aria-describedby='alert-dialog-description'
+            disableRestoreFocus // needed due to StrictMode
         >
             <DialogTitle sx={{ fontSize: '1rem' }} id='alert-dialog-title'>
                 {dialogProps.title}
             </DialogTitle>
             <DialogContent>
                 <OutlinedInput
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
                     sx={{ mt: 1 }}
                     id='chatflow-name'
                     type='text'


### PR DESCRIPTION
The save flow dialog has only one input and it is the primary one, there is no need for an extra click to be able to set the title. With the autofocus on the user can start writing right away.

I think that in this case the eslint rule is properly disabled and it aligns with even [one](https://brucelawson.co.uk/2009/the-accessibility-of-html-5-autofocus/) of the refs listed in the jsx-a11y/no-autofocus

Here you can find two small gifs showing the contribution of this PR.

Before
![saveflow-autofocus-off](https://github.com/user-attachments/assets/acd18094-4a2b-4fe3-b4de-4bd6c5e791e5)

After 
![saveflow-autofocus-on](https://github.com/user-attachments/assets/0dc28bfa-0fcb-47a4-911c-46d5cd3e5673)
