### PR TITLE
feat: save Chatflow title when the `ENTER` key is pressed or discard upon `ESC` is pressed

### DIFF
--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -310,6 +310,13 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, handleSaveFlow, handleDeleteFlo
                                         ml: 2
                                     }}
                                     defaultValue={flowName}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            submitFlowName()
+                                        } else if (e.key === 'Escape') {
+                                            setEditingFlowName(false)
+                                        }
+                                    }}
                                 />
                                 <ButtonBase title='Save Name' sx={{ borderRadius: '50%' }}>
                                     <Avatar


### PR DESCRIPTION
This simple event handler improves the usability of the UI by avoiding having to use the mouse to save or discard title changes

Here you can see small example of the contribution of this PR

Before

![edit-flowname -without-keyboard-shortcut](https://github.com/user-attachments/assets/ca15b916-5521-4198-88a6-7a3f1d6f4600)

After

![edit-flowname -with-keyboard-shortcut](https://github.com/user-attachments/assets/982f96d8-8625-4636-8c74-d40769a67dd4)
