### PR TITLE
feat: add shortcut text hint to the search field

### DIFF
--- a/packages/ui/src/layout/MainLayout/ViewHeader.jsx
+++ b/packages/ui/src/layout/MainLayout/ViewHeader.jsx
@@ -8,6 +8,12 @@ import { StyledFab } from '@/ui-component/button/StyledFab'
 // icons
 import { IconSearch, IconArrowLeft, IconEdit } from '@tabler/icons-react'
 
+import { getOS } from '@/utils/genericHelper'
+
+const isMac = getOS() === 'macos'
+export const isDesktop = isMac || os === 'windows' || os === 'linux'
+const keyboardShortcut = isMac ? '[ ⌘ + F ]' : '[ Ctrl + F ]'
+
 const ViewHeader = ({
     children,
     filters = null,
@@ -97,7 +103,7 @@ const ViewHeader = ({
                                 }
                             }}
                             variant='outlined'
-                            placeholder={searchPlaceholder}
+                            placeholder={`${searchPlaceholder} ${isDesktop ? keyboardShortcut : ''}`}
                             onChange={onSearchChange}
                             startAdornment={
                                 <Box


### PR DESCRIPTION
Before
<img width="1172" alt="Screenshot 2024-09-26 at 16 08 53" src="https://github.com/user-attachments/assets/67acae39-bd09-4095-bfaa-b99a6420ae92">


After

<img width="1172" alt="Screenshot 2024-09-26 at 16 08 09" src="https://github.com/user-attachments/assets/8a55ef51-f77d-4684-8f76-e0611841f0f0">
