### PR TITLE
feat: add shortcut text hint to the search field

### DIFF
--- a/packages/ui/src/layout/MainLayout/ViewHeader.jsx
+++ b/packages/ui/src/layout/MainLayout/ViewHeader.jsx
@@ -12,8 +12,9 @@ import { IconSearch, IconArrowLeft, IconEdit } from '@tabler/icons-react'
 import useSearchShorcut from '@/hooks/useSearchShortcut'
 import { getOS } from '@/utils/genericHelper'
 
-const isMac = getOS() === 'macos'
-export const isDesktop = isMac || os === 'windows' || os === 'linux'
+const os = getOS()
+const isMac = os === 'macos'
+const isDesktop = isMac || os === 'windows' || os === 'linux'
 const keyboardShortcut = isMac ? '[ ⌘ + F ]' : '[ Ctrl + F ]'
 
 const ViewHeader = ({

--- a/packages/ui/src/layout/MainLayout/ViewHeader.jsx
+++ b/packages/ui/src/layout/MainLayout/ViewHeader.jsx
@@ -10,6 +10,11 @@ import { StyledFab } from '@/ui-component/button/StyledFab'
 import { IconSearch, IconArrowLeft, IconEdit } from '@tabler/icons-react'
 
 import useSearchShorcut from '@/hooks/useSearchShortcut'
+import { getOS } from '@/utils/genericHelper'
+
+const isMac = getOS() === 'macos'
+export const isDesktop = isMac || os === 'windows' || os === 'linux'
+const keyboardShortcut = isMac ? '[ ⌘ + F ]' : '[ Ctrl + F ]'
 
 const ViewHeader = ({
     children,
@@ -103,7 +108,7 @@ const ViewHeader = ({
                                 }
                             }}
                             variant='outlined'
-                            placeholder={searchPlaceholder}
+                            placeholder={`${searchPlaceholder} ${isDesktop ? keyboardShortcut : ''}`}
                             onChange={onSearchChange}
                             startAdornment={
                                 <Box

--- a/packages/ui/src/layout/MainLayout/ViewHeader.jsx
+++ b/packages/ui/src/layout/MainLayout/ViewHeader.jsx
@@ -98,7 +98,7 @@ const ViewHeader = ({
                             inputRef={searchInputRef}
                             size='small'
                             sx={{
-                                width: '280px',
+                                width: '325px',
                                 height: '100%',
                                 display: { xs: 'none', sm: 'flex' },
                                 borderRadius: 2,


### PR DESCRIPTION
Before
<img width="1172" alt="Screenshot 2024-09-26 at 16 08 53" src="https://github.com/user-attachments/assets/4752a95f-b554-460f-95c1-33017c7f3f9f">
 
After
<img width="1172" alt="Screenshot 2024-09-26 at 16 08 09" src="https://github.com/user-attachments/assets/d8385d08-032e-4a5f-a144-2b58806f1b6b">
