### PR TITLE
fix: addEventListener error on views without search box introduced by commit #3267

### DIFF
--- a/packages/ui/src/hooks/useSearchShortcut.jsx
+++ b/packages/ui/src/hooks/useSearchShortcut.jsx
@@ -5,6 +5,7 @@ const isMac = getOS() === 'macos'
 
 const useSearchShorcut = (inputRef) => {
     useEffect(() => {
+        if (!inputRef.current) return
         const component = inputRef.current
         const handleKeyDown = (event) => {
             if ((isMac && event.metaKey && event.key === 'f') || (!isMac && event.ctrlKey && event.key === 'f')) {


### PR DESCRIPTION
The error was caused  by [#3267](https://github.com/FlowiseAI/Flowise/pull/3267) when trying to add an event listener to an undefined search box in views without one like tools and assistants