### PR TITLE
fix: warning when passing a boolean to border property of a Card

### DIFF
--- a/packages/ui/src/ui-component/cards/MainCard.jsx
+++ b/packages/ui/src/ui-component/cards/MainCard.jsx
@@ -30,10 +30,11 @@ const MainCard = forwardRef(function MainCard(
     },
     ref
 ) {
+    const otherProps = { ...others, border: others.border === false ? undefined : others.border }
     return (
         <Card
             ref={ref}
-            {...others}
+            {...otherProps}
             sx={{
                 background: 'transparent',
                 ':hover': {


### PR DESCRIPTION
By default MainCard wrappers like NodeCardWrapper and CardWrapper add a a solid border of 1px, but if the `MainCard.border` prop is used (`false`) the border prop was wrongly set to a boolean instead of string

Here is an example of the fixed warning

![Screenshot 2024-09-27 at 09 58 47](https://github.com/user-attachments/assets/974e2131-1479-4dc1-903f-d5b47af5e65d)
