### PR TITLE
fix: warning when a non-boolean values was used to set `checked` prop of a SwitchInput component

### DIFF
--- a/packages/ui/src/ui-component/switch/Switch.jsx
+++ b/packages/ui/src/ui-component/switch/Switch.jsx
@@ -6,7 +6,7 @@ export const SwitchInput = ({ label, value, onChange, disabled = false }) => {
     const [myValue, setMyValue] = useState(value !== undefined ? !!value : false)
 
     useEffect(() => {
-        setMyValue(value)
+        setMyValue(value !== undefined ? !!value : false)
     }, [value])
 
     return (


### PR DESCRIPTION
The problem was that in the useEffect hook the plain value was used without validation like in useState

![Screenshot 2024-09-27 at 10 46 44](https://github.com/user-attachments/assets/4c53ab21-60dd-4d9e-8584-e5bd0a71b0f7)
