### PR TITLE
Updating models.json with new Gemini models

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -369,8 +369,24 @@
                     "name": "gemini-1.5-flash-latest"
                 },
                 {
+                    "label": "gemini-1.5-flash-001",
+                    "name": "gemini-1.5-flash-001"
+                },
+                {
+                    "label": "gemini-1.5-flash-002",
+                    "name": "gemini-1.5-flash-002"
+                },
+                {
                     "label": "gemini-1.5-pro-latest",
                     "name": "gemini-1.5-pro-latest"
+                },
+                {
+                    "label": "gemini-1.5-pro-001",
+                    "name": "gemini-1.5-pro-001"
+                },
+                {
+                    "label": "gemini-1.5-pro-002",
+                    "name": "gemini-1.5-pro-002"
                 },
                 {
                     "label": "gemini-pro",


### PR DESCRIPTION
> The gemini-1.5-pro and gemini-1.5-flash model codes will default to use the -002 versions automatically on October 8, 2024. You can continue to use the previous model version by using the gemini-1.5-pro-001 or gemini-1.5-flash-001 model codes.

Source: https://ai.google.dev/gemini-api/docs/models/gemini