### PR TITLE
Enable Filters in MongoDB Vector Search Retriever

### DIFF
--- a/packages/components/nodes/vectorstores/MongoDBAtlas/MongoDBAtlas.ts
+++ b/packages/components/nodes/vectorstores/MongoDBAtlas/MongoDBAtlas.ts
@@ -86,6 +86,13 @@ class MongoDBAtlas_VectorStores implements INode {
                 additionalParams: true,
                 optional: true
             },
+						{
+                label: 'Mongodb Metadata Filter',
+                name: 'mongoMetadataFilter',
+                type: 'json',
+                optional: true,
+                additionalParams: true
+            },
             {
                 label: 'Top K',
                 name: 'topK',
@@ -164,8 +171,11 @@ class MongoDBAtlas_VectorStores implements INode {
         let textKey = nodeData.inputs?.textKey as string
         let embeddingKey = nodeData.inputs?.embeddingKey as string
         const embeddings = nodeData.inputs?.embeddings as Embeddings
+				const mongoMetadataFilter = nodeData.inputs?.mongoMetadataFilter as object
 
         let mongoDBConnectUrl = getCredentialParam('mongoDBConnectUrl', credentialData, nodeData)
+
+				const filter: MongoDBAtlasVectorSearch['FilterType'] = {}
 
         const mongoClient = await getMongoClient(mongoDBConnectUrl)
         try {
@@ -181,7 +191,20 @@ class MongoDBAtlas_VectorStores implements INode {
                 embeddingKey
             }) as unknown as VectorStore
 
-            return resolveVectorStoreOrRetriever(nodeData, vectorStore)
+						if(mongoMetadataFilter){
+							const metadataFilter = typeof mongoMetadataFilter === 'object' ? mongoMetadataFilter : JSON.parse(mongoMetadataFilter)
+
+							for (const key in metadataFilter) {
+								filter.preFilter = {
+									...filter.preFilter,
+									[key]: {
+										$eq: metadataFilter[key],
+									},
+								}
+							}
+						}
+
+            return resolveVectorStoreOrRetriever(nodeData, vectorStore, filter)
         } catch (e) {
             throw new Error(e)
         }

--- a/packages/components/nodes/vectorstores/MongoDBAtlas/MongoDBAtlas.ts
+++ b/packages/components/nodes/vectorstores/MongoDBAtlas/MongoDBAtlas.ts
@@ -86,7 +86,7 @@ class MongoDBAtlas_VectorStores implements INode {
                 additionalParams: true,
                 optional: true
             },
-						{
+            {
                 label: 'Mongodb Metadata Filter',
                 name: 'mongoMetadataFilter',
                 type: 'json',
@@ -171,11 +171,11 @@ class MongoDBAtlas_VectorStores implements INode {
         let textKey = nodeData.inputs?.textKey as string
         let embeddingKey = nodeData.inputs?.embeddingKey as string
         const embeddings = nodeData.inputs?.embeddings as Embeddings
-				const mongoMetadataFilter = nodeData.inputs?.mongoMetadataFilter as object
+        const mongoMetadataFilter = nodeData.inputs?.mongoMetadataFilter as object
 
         let mongoDBConnectUrl = getCredentialParam('mongoDBConnectUrl', credentialData, nodeData)
 
-				const filter: MongoDBAtlasVectorSearch['FilterType'] = {}
+        const filter: MongoDBAtlasVectorSearch['FilterType'] = {}
 
         const mongoClient = await getMongoClient(mongoDBConnectUrl)
         try {
@@ -191,18 +191,18 @@ class MongoDBAtlas_VectorStores implements INode {
                 embeddingKey
             }) as unknown as VectorStore
 
-						if(mongoMetadataFilter){
-							const metadataFilter = typeof mongoMetadataFilter === 'object' ? mongoMetadataFilter : JSON.parse(mongoMetadataFilter)
+            if (mongoMetadataFilter) {
+                const metadataFilter = typeof mongoMetadataFilter === 'object' ? mongoMetadataFilter : JSON.parse(mongoMetadataFilter)
 
-							for (const key in metadataFilter) {
-								filter.preFilter = {
-									...filter.preFilter,
-									[key]: {
-										$eq: metadataFilter[key],
-									},
-								}
-							}
-						}
+                for (const key in metadataFilter) {
+                    filter.preFilter = {
+                        ...filter.preFilter,
+                        [key]: {
+                            $eq: metadataFilter[key]
+                        }
+                    }
+                }
+            }
 
             return resolveVectorStoreOrRetriever(nodeData, vectorStore, filter)
         } catch (e) {


### PR DESCRIPTION
Summary:

This pull request introduces changes that enable the use of filters in the MongoDB vector search retriever, similar to how it’s done in Pinecone.

Description:

• These changes will allow the implementation of filters in the MongoDB Vector Search Retriever, aligning with the capabilities provided by Pinecone.
• When creating an Atlas Vector Search to index the embedding field, it’s important to also add the filters you want to use, as demonstrated in the MongoDB documentation: [MongoDB Atlas Vector Search - Create Index](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/#std-label-avs-create-index).

Points to consider:

• Ensure that when configuring the Atlas Vector Search for your application, you define both the embedding field and any necessary filters during index creation, as described in the documentation.

screenshots:

![Screenshot 2024-10-10 at 12 18 04 PM](https://github.com/user-attachments/assets/b12cff3b-ee68-4762-b073-d1b7a122c4f5)

![Screenshot 2024-10-10 at 12 19 56 PM](https://github.com/user-attachments/assets/d0f2c1f2-96cc-47f6-8d23-3f7f057290c2)

