### PR TITLE
This pull request addresses an Azure deployment issue related to the …

### DIFF
--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,18 +1,19 @@
 {
     "compilerOptions": {
-        "lib": ["es2021"],
-        "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-        "experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
-        "emitDecoratorMetadata": true /* Emit design-type metadata for decorated declarations in source files. */,
-        "module": "commonjs" /* Specify what module code is generated. */,
+        "lib": ["es2021", "dom"],
+        "target": "es2021",
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "module": "commonjs",
         "outDir": "dist",
-        "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
-        "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-        "strict": true /* Enable all strict type-checking options. */,
-        "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true,
         "sourceMap": true,
         "strictPropertyInitialization": false,
-        "declaration": true
+        "declaration": true,
+        "types": ["node"]
     },
     "include": ["src/**/*.ts"],
     "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
…DATABASE_SSL parameter. The changes allow for more flexible SSL configurations to be passed as a JSON string through the DATABASE_SSL environment variable.

Changes made:

Modified the getDatabaseSSLFromEnv function in packages/server/src/DataSource.ts to parse the DATABASE_SSL environment variable as a JSON string. Added support for complex SSL configurations, including the ability to specify a 'ca' certificate file path. Maintained backwards compatibility with the existing DATABASE_SSL_KEY_BASE64 and boolean DATABASE_SSL configurations. To use the new functionality:

Set the DATABASE_SSL environment variable to a JSON string containing the desired SSL configuration. For example: {rejectUnauthorized: true, ca: /path/to/certificate.pem} This change allows for more granular control over SSL settings when deploying to Azure, while maintaining compatibility with existing configurations.