### PR TITLE
fix: unknown collate in AddCustomTemplate migration for MariaDB

### DIFF
--- a/packages/server/src/database/migrations/mariadb/1725629836652-AddCustomTemplate.ts
+++ b/packages/server/src/database/migrations/mariadb/1725629836652-AddCustomTemplate.ts
@@ -15,7 +15,7 @@ export class AddCustomTemplate1725629836652 implements MigrationInterface {
                 \`createdDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
                 \`updatedDate\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
                 PRIMARY KEY (\`id\`)
-              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;`
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;`
         )
     }
 


### PR DESCRIPTION
Fixes a problem when deploying with MariaDB database type.

`Migration "AddCustomTemplate1725629836652" failed, error: Unknown collation: 'utf8mb4_0900_ai_ci'`