### PR TITLE
Azure OpenAI Embeddings ignores env variable AZURE_OPENAI_BASE_PATH

### DIFF
--- a/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/AzureOpenAIEmbedding/AzureOpenAIEmbedding.ts
@@ -71,7 +71,7 @@ class AzureOpenAIEmbedding_Embeddings implements INode {
             azureOpenAIApiInstanceName,
             azureOpenAIApiDeploymentName,
             azureOpenAIApiVersion,
-            azureOpenAIBasePath: basePath
+            azureOpenAIBasePath: basePath || undefined
         }
 
         if (batchSize) obj.batchSize = parseInt(batchSize, 10)


### PR DESCRIPTION
* Set azureOpenAIBasePath to undefined if empty to enforce usage of env variable AZURE_OPENAI_BASE_PATH in @langchain+openai@0.0.30_encoding@0.1.13_langchain@0.2.11/node_modules/@langchain/openai/dist/embeddings.cjs