### PR TITLE
fix(proxy): restrict proxy to exact /api routes only

### DIFF
--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig(async ({ mode }) => {
         const serverPort = parseInt(serverEnv?.['PORT'] ?? 3000)
         if (!Number.isNaN(serverPort) && serverPort > 0 && serverPort < 65535) {
             proxy = {
-                '/api': {
+                '^/api(/|$).*': {
                     target: `http://${serverHost}:${serverPort}`,
                     changeOrigin: true
                 },


### PR DESCRIPTION
The proxy settings currently apply to all URLs that start with /api, including /apikey. This causes unintended routing where /apikey is proxied, resulting in a 404 error or incorrect loading behavior. The solution restricts proxy settings to exact /api routes or those that follow the /api/ pattern, allowing /apikey and similar routes to be handled by the frontend.