### PR TITLE
Update commonUtils.ts

### DIFF
--- a/packages/components/nodes/sequentialagents/commonUtils.ts
+++ b/packages/components/nodes/sequentialagents/commonUtils.ts
@@ -212,7 +212,7 @@ export const restructureMessages = (llm: BaseChatModel, state: ISeqAgentsState) 
     const messages: BaseMessage[] = []
     for (const message of state.messages as unknown as BaseMessage[]) {
         // Sometimes Anthropic can return a message with content types of array, ignore that EXECEPT when tool calls are present
-        if ((message as any).tool_calls?.length) {
+        if ((message as any).tool_calls?.length && message.content !== '') {
             message.content = JSON.stringify(message.content)
         }
 


### PR DESCRIPTION
Fixed a bug in `restructureMessages` leading to blowing up of the message content with escape characters and eventually crashing the flow with "repetitive patterns" error. This happens when the content is empty. Simple check for empty message content fixes the problem.