### PR TITLE
feat: Add Custom Api Url Param for Self-hosted FireCrawl endpoint

### DIFF
--- a/packages/components/credentials/FireCrawlApi.credential.ts
+++ b/packages/components/credentials/FireCrawlApi.credential.ts
@@ -10,7 +10,7 @@ class FireCrawlApiCredential implements INodeCredential {
     constructor() {
         this.label = 'FireCrawl API'
         this.name = 'fireCrawlApi'
-        this.version = 1.0
+        this.version = 2.0
         this.description =
             'You can find the FireCrawl API token on your <a target="_blank" href="https://www.firecrawl.dev/">FireCrawl account</a> page.'
         this.inputs = [

--- a/packages/components/credentials/FireCrawlApi.credential.ts
+++ b/packages/components/credentials/FireCrawlApi.credential.ts
@@ -18,6 +18,12 @@ class FireCrawlApiCredential implements INodeCredential {
                 label: 'FireCrawl API',
                 name: 'firecrawlApiToken',
                 type: 'password'
+            },
+            {
+                label: 'FireCrawl API URL',
+                name: 'firecrawlApiUrl',
+                type: 'string',
+                default: 'https://api.firecrawl.dev'
             }
         ]
     }


### PR DESCRIPTION
Minor change for supporting [self-hosted FireCrawl endpoint](https://docs.firecrawl.dev/contributing/self-host)
(By adding a missing param for `Api Url`)

Works fine for the  ver.0 API Scrape func.