### PR TITLE
Fix 'label' undefined errors for sequential agents

### DIFF
--- a/packages/server/src/utils/buildAgentGraph.ts
+++ b/packages/server/src/utils/buildAgentGraph.ts
@@ -325,7 +325,7 @@ export const buildAgentGraph = async (
                                 // Send loading next agent indicator
                                 if (reasoning.next && reasoning.next !== 'FINISH' && reasoning.next !== 'END') {
                                     if (sseStreamer) {
-                                        sseStreamer.streamNextAgentEvent(chatId, mapNameToLabel[reasoning.next].label || reasoning.next)
+                                        sseStreamer.streamNextAgentEvent(chatId, mapNameToLabel[reasoning.next]?.label || reasoning.next)
                                     }
                                 }
                             }

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -218,7 +218,7 @@ export const utilBuildChatflow = async (req: Request, isInternal: boolean = fals
 
         /*** Get session ID ***/
         const memoryNode = findMemoryNode(nodes, edges)
-        const memoryType = memoryNode?.data.label
+        const memoryType = memoryNode?.data?.label
         let sessionId = getMemorySessionId(memoryNode, incomingInput, chatId, isInternal)
 
         /*** Get Ending Node with Directed Graph  ***/


### PR DESCRIPTION
Simple Flow: Follow part of video on sequential flows until 9:15 where LLM Node setup is complete and connected to an end node.
https://www.youtube.com/watch?v=3ZmBq8_4vCs&list=PL4HikwTaYE0H7wBxhvQqxYcKOkZ4O3zXh

Stacktrace:
Error: Cannot read properties of undefined (reading 'label') flowise:dev: at buildAgentGraph (\Flowise\packages\server\dist\utils\buildAgentGraph.js:402:19) flowise:dev: at async utilBuildAgentResponse (\Flowise\packages\server\dist\utils\buildChatflow.js:435:31) flowise:dev: at async utilBuildChatflow (\Flowise\packages\server\dist\utils\buildChatflow.js:198:20) flowise:dev: at async createAndStreamInternalPrediction (\Flowise\packages\server\dist\controllers\internal-predictions\index.js:33:29) flowise:dev: 2024-11-26 13:50:21 [ERROR]: [server]: Error: Error buildAgentGraph - Cannot read properties of undefined (reading 'label') flowise:dev: Error: Error buildAgentGraph - Cannot read properties of undefined (reading 'label') flowise:dev: at buildAgentGraph (\Flowise\packages\server\dist\utils\buildAgentGraph.js:408:15) flowise:dev: at async utilBuildAgentResponse (\Flowise\packages\server\dist\utils\buildChatflow.js:435:31) flowise:dev: at async utilBuildChatflow (\Flowise\packages\server\dist\utils\buildChatflow.js:198:20) flowise:dev: at async createAndStreamInternalPrediction (\Flowise\packages\server\dist\controllers\internal-predictions\index.js:33:29) flowise:dev: 2024-11-26 13:50:21 [ERROR]: [server]: Error: Error buildAgentGraph - Cannot read properties of undefined (reading 'label') flowise:dev: Error: Error buildAgentGraph - Cannot read properties of undefined (reading 'label') flowise:dev: at utilBuildAgentResponse (\Flowise\packages\server\dist\utils\buildChatflow.js:541:15) flowise:dev: at async utilBuildChatflow (\Flowise\packages\server\dist\utils\buildChatflow.js:198:20) flowise:dev: at async createAndStreamInternalPrediction (\Flowise\packages\server\dist\controllers\internal-predictions\index.js:33:29)

Commit adds some optional chaining around 2 reads of 'label' property.

Without this change some usage of sequential agents requires a memory node to not hit a runtime error when trying to access 'label'.