### PR TITLE
feat(models): add Llama 3.3 70B models to groqChat

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -498,6 +498,14 @@
             "name": "groqChat",
             "models": [
                 {
+                    "label": "llama-3.3-70b-versatile",
+                    "name": "llama-3.3-70b-versatile"
+                },
+                {
+                    "label": "llama-3.3-70b-specdec",
+                    "name": "llama-3.3-70b-specdec"
+                },
+                {
                     "label": "llama-3.2-1b-preview",
                     "name": "llama-3.2-1b-preview"
                 },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-components",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "Flowiseai Components",
     "main": "dist/src/index",
     "types": "dist/src/index.d.ts",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flowise-components",
-    "version": "2.2.2",
+    "version": "2.2.1",
     "description": "Flowiseai Components",
     "main": "dist/src/index",
     "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Add Meta's latest Llama 3.3 70B models to groqChat options:
- llama-3.3-70b-versatile: New versatile model for general tasks
- llama-3.3-70b-specdec: Specialized model for specific tasks

These models offer comparable quality to Llama 3.1 405B at 1/5th the size, with improvements in:
- Reasoning and math capabilities
- General knowledge tasks
- Instruction following
- Tool use and JSON outputs
- Code generation and feedback