### PR TITLE
feat: Add option to disable conversation history

### DIFF
--- a/packages/components/nodes/sequentialagents/LLMNode/LLMNode.ts
+++ b/packages/components/nodes/sequentialagents/LLMNode/LLMNode.ts
@@ -188,6 +188,14 @@ class LLMNode_SeqAgents implements INode {
                 placeholder: 'LLM'
             },
             {
+                label: 'Disable Conversation History',
+                name: 'disableConversationHistory',
+                type: 'boolean',
+                optional: true,
+                description: `If set to true, the conversation history messages from the state will not be automatically included in the prompt`,
+                additionalParams: true
+            },
+            {
                 label: 'System Prompt',
                 name: 'systemMessagePrompt',
                 type: 'string',
@@ -535,7 +543,7 @@ async function agentNode(
         }
 
         // @ts-ignore
-        state.messages = restructureMessages(llm, state)
+        state.messages = nodeData.inputs?.disableConversationHistory | false ? [] : restructureMessages(llm, state)
 
         let result: AIMessageChunk | ICommonObject = await agent.invoke({ ...state, signal: abortControllerSignal.signal }, config)
 


### PR DESCRIPTION
- Add new `disableConversationHistory` boolean parameter in LLMNodes.ts and Agent.ts to optionally skip including conversation history in prompts
- Fix potential error in Agent.ts when messages array is empty by adding null safety checks
- Improve memory efficiency by allowing stateless interactions when history isn't needed