### PR TITLE
Bugfix/Disabling of chatbotConfig.chatFeedback when share chatbot updated

### DIFF
--- a/packages/ui/src/views/chatflows/ShareChatbot.jsx
+++ b/packages/ui/src/views/chatflows/ShareChatbot.jsx
@@ -157,6 +157,7 @@ const ShareChatbot = ({ isSessionMemory, isAgentCanvas }) => {
         }
 
         if (chatbotConfig?.fullFileUpload) obj.fullFileUpload = chatbotConfig?.fullFileUpload
+        if (chatbotConfig?.chatFeedback) obj.chatFeedback = chatbotConfig?.chatFeedback
 
         return obj
     }


### PR DESCRIPTION
This PR is similar to #3707, but this time it is in the Chatflow Configuration's Enable chat feedback instead of File Upload.

<img width="930" alt="Screenshot 2024-12-18 at 9 18 23 AM" src="https://github.com/user-attachments/assets/44a393e5-a98e-4ca0-b066-9bfb03f7cb93" />
