### PR TITLE
Bugfix/Hide agent response for chatflow

### DIFF
--- a/packages/ui/src/views/chatflows/ShareChatbot.jsx
+++ b/packages/ui/src/views/chatflows/ShareChatbot.jsx
@@ -451,7 +451,7 @@ const ShareChatbot = ({ isSessionMemory, isAgentCanvas }) => {
             {colorField(backgroundColor, 'backgroundColor', 'Background Color')}
             {textField(fontSize, 'fontSize', 'Font Size', 'number')}
             {colorField(poweredByTextColor, 'poweredByTextColor', 'PoweredBy TextColor')}
-            {booleanField(showAgentMessages, 'showAgentMessages', 'Show Agent Reasoning')}
+            {isAgentCanvas && booleanField(showAgentMessages, 'showAgentMessages', 'Show Agent Reasoning')}
 
             {/*BOT Message*/}
             <Typography variant='h4' sx={{ mb: 1, mt: 2 }}>


### PR DESCRIPTION
`Show Agent Reasoning` is not saving for chatflows, based on code line number 150:

```
if (isAgentCanvas) {
            // if showAgentMessages is undefined, default to true
            if (showAgentMessages === undefined || showAgentMessages === null) {
                obj.showAgentMessages = true
            } else {
                obj.showAgentMessages = showAgentMessages
            }
        }
```

it is only applicable for Agentflows, so maybe better to hide it for Chatflows.