### PR TITLE
fix: Error Cannot read properties of undefined (reading 'sendTelemetry')

### DIFF
--- a/packages/server/src/utils/getRunningExpressApp.ts
+++ b/packages/server/src/utils/getRunningExpressApp.ts
@@ -2,7 +2,11 @@ import * as Server from '../index'
 
 export const getRunningExpressApp = function () {
     const runningExpressInstance = Server.getInstance()
-    if (typeof runningExpressInstance === 'undefined' || typeof runningExpressInstance.nodesPool === 'undefined') {
+    if (
+        typeof runningExpressInstance === 'undefined' ||
+        typeof runningExpressInstance.nodesPool === 'undefined' ||
+        typeof runningExpressInstance.telemetry === 'undefined'
+    ) {
         throw new Error(`Error: getRunningExpressApp failed!`)
     }
     return runningExpressInstance


### PR DESCRIPTION
If the database closes the connection during initialization, the app server continues to work with uninitialized properties.

```
[server]: Error during Data Source initialization: Connection lost: The server closed the connection.
QueryFailedError: Connection lost: The server closed the connection.
[server]: Flowise Server is listening at :3000
...
[server]: Error: Cannot read properties of undefined (reading 'sendTelemetry')
TypeError: Cannot read properties of undefined (reading 'sendTelemetry')
```

https://github.com/FlowiseAI/Flowise/blob/main/packages/server/src/index.ts#L82

Current code only checks for _nodesPool_ initialization but there are still actions that can fail after the _nodesPool_ is initialized. This PR addresses this issue by checking if the telemetry is successfully initialized as the last action in the _initDatabase_ method. If it's not then the server should fail and be restarted.

