### PR TITLE
Feature/bugfix Speech-to-Text provider settings

### DIFF
--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -427,7 +427,8 @@ export enum FollowUpPromptProvider {
     AZURE_OPENAI = 'azureChatOpenAI',
     GOOGLE_GENAI = 'chatGoogleGenerativeAI',
     MISTRALAI = 'chatMistralAI',
-    OPENAI = 'chatOpenAI'
+    OPENAI = 'chatOpenAI',
+    GROQ = 'chatGroq'
 }
 
 export type FollowUpPromptProviderConfig = {
@@ -436,6 +437,7 @@ export type FollowUpPromptProviderConfig = {
         modelName: string
         prompt: string
         temperature: string
+        audioModel?: 'whisper-large-v3' | 'whisper-large-v3-turbo' | 'distil-whisper-large-v3-en'
     }
 }
 


### PR DESCRIPTION
Fix Bug: Unable to Add or Update Speech-to-Text Provider in Flow Settings

Description:
Ever since the groq update, I’ve encountered a bug (reproducible on both Windows and Linux) where attempting to add or change the speech-to-text provider under Settings → Configuration → Speech to Text within a flow does nothing. Clicking the Save button multiple times has no effect—the settings are simply not applied.

I’m submitting this fix to resolve the issue. Below are the key changes I’ve made:

    State Management: Ensures state updates are handled properly.
    Provider Selection: Fixes the toggling mechanism so the chosen provider is updated correctly.
    Configuration Persistence: Makes sure saved settings actually persist after clicking Save.
    Validation: Adds proper checks before persisting new settings.
    User Feedback: Provides clear notifications through snackbars, improving UX.

The core problem appears to have been in how the state was managed, and the configuration prepared prior to saving. With these modifications, adding or updating a speech-to-text provider should now work as expected.

First PR, i hope this will be helpful for many! :-)

![grafik](https://github.com/user-attachments/assets/7fb34b94-8069-4feb-8d08-63c459de2e93)
