### PR TITLE
Feat/new session btn

### DIFF
--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -39,7 +39,8 @@ import {
     IconDeviceSdCard,
     IconCheck,
     IconPaperclip,
-    IconSparkles
+    IconSparkles,
+    IconRefresh
 } from '@tabler/icons-react'
 import robotPNG from '@/assets/images/robot.png'
 import userPNG from '@/assets/images/account.png'
@@ -1557,13 +1558,13 @@ export const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, preview
                     <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end', p: 1 }}>
                         <Button
                             onClick={resetChat}
-                            startIcon={<IconTrash size={20} />}
+                            startIcon={<IconRefresh size={20} />}
                             variant='outlined'
-                            color='error'
+                            color='primary'
                             size='small'
                             sx={{ borderRadius: '20px' }}
                         >
-                            Reset Chat
+                            New Session
                         </Button>
                     </Box>
                     {messages &&

--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -1035,7 +1035,8 @@ export const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, preview
     // Get chatmessages successful
     useEffect(() => {
         if (getChatmessageApi.data?.length) {
-            const chatId = getChatmessageApi.data[0]?.chatId
+            const latestMessage = getChatmessageApi.data[getChatmessageApi.data.length - 1]
+            const chatId = latestMessage?.chatId
             setChatId(chatId)
             // Filter messages to only include those with matching chatId
             const messagesForChat = getChatmessageApi.data.filter((message) => message.chatId === chatId)

--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -1037,7 +1037,10 @@ export const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, preview
         if (getChatmessageApi.data?.length) {
             const chatId = getChatmessageApi.data[0]?.chatId
             setChatId(chatId)
-            const loadedMessages = getChatmessageApi.data.map((message) => {
+            // Filter messages to only include those with matching chatId
+            const messagesForChat = getChatmessageApi.data.filter((message) => message.chatId === chatId)
+
+            const loadedMessages = messagesForChat.map((message) => {
                 const obj = {
                     id: message.id,
                     message: message.content,

--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -167,6 +167,22 @@ export const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, preview
 
     const dispatch = useDispatch()
 
+    // Add resetChat function here, after initial declarations
+    const resetChat = useCallback(() => {
+        const newChatId = uuidv4()
+        setChatId(newChatId)
+        setMessages([
+            {
+                message: 'Hi there! How can I help?',
+                type: 'apiMessage'
+            }
+        ])
+        setUserInput('')
+        setUploadedFiles([])
+        setPreviews([])
+        setLocalStorageChatflow(chatflowid, newChatId)
+    }, [chatflowid, setPreviews])
+
     useNotifier()
     const enqueueSnackbar = (...args) => dispatch(enqueueSnackbarAction(...args))
     const closeSnackbar = (...args) => dispatch(closeSnackbarAction(...args))
@@ -1538,6 +1554,18 @@ export const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, preview
                 )}
             <div ref={ps} className={`${isDialog ? 'cloud-dialog' : 'cloud'}`}>
                 <div id='messagelist' className={'messagelist'}>
+                    <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end', p: 1 }}>
+                        <Button
+                            onClick={resetChat}
+                            startIcon={<IconTrash size={20} />}
+                            variant='outlined'
+                            color='error'
+                            size='small'
+                            sx={{ borderRadius: '20px' }}
+                        >
+                            Reset Chat
+                        </Button>
+                    </Box>
                     {messages &&
                         messages.map((message, index) => {
                             return (


### PR DESCRIPTION
Feature: support creating new internal chat session via the chat box instead of clearing the chat history.
Purpose: we may like to test with new flow configuration but still like to see the history of previous configs for the comparison.
 
<img width="403" alt="Screenshot 2024-12-28 at 10 09 11" src="https://github.com/user-attachments/assets/e9e2b963-14ac-4aee-9342-e84331718cc0" />
