### PR TITLE
bugfix: Add nil check in escapeAllStrings to prevent TypeError when upsert vectors

### DIFF
--- a/packages/components/nodes/vectorstores/Redis/utils.ts
+++ b/packages/components/nodes/vectorstores/Redis/utils.ts
@@ -1,3 +1,5 @@
+import { isNil } from 'lodash'
+
 /*
  * Escapes all '-' characters.
  * Redis Search considers '-' as a negative operator, hence we need
@@ -8,6 +10,10 @@ export const escapeSpecialChars = (str: string) => {
 }
 
 export const escapeAllStrings = (obj: object) => {
+    if (isNil(obj)) {
+        // return if obj is null or undefined to avoid "TypeError: Cannot convert undefined or null to object"
+        return
+    }
     Object.keys(obj).forEach((key: string) => {
         // @ts-ignore
         let item = obj[key]


### PR DESCRIPTION
There is an issue when upsert vectors using redis vector store. I encountered this problem when doing document upsert from some PDF files. Not all PDF files are affected, just some

![image](https://github.com/user-attachments/assets/4f92825c-0ca2-4522-aff3-a3c06defae7a)

This pull request includes changes to the `packages/components/nodes/vectorstores/Redis/utils.ts` file to improve error handling and ensure that null or undefined objects are properly managed.


