### PR TITLE
bugfix: Fix speech-to-text configuration save issue

### DIFF
--- a/packages/ui/src/ui-component/extended/SpeechToText.jsx
+++ b/packages/ui/src/ui-component/extended/SpeechToText.jsx
@@ -250,7 +250,9 @@ const SpeechToText = ({ dialogProps }) => {
     const [selectedProvider, setSelectedProvider] = useState('none')
 
     const onSave = async () => {
+        console.log('onSave:', selectedProvider)
         const speechToText = setValue(true, selectedProvider, 'status')
+        console.log('speechToText:', speechToText)
         try {
             const saveResp = await chatflowsApi.updateChatflow(dialogProps.chatflow.id, {
                 speechToText: JSON.stringify(speechToText)
@@ -306,6 +308,10 @@ const SpeechToText = ({ dialogProps }) => {
                     newVal[provider.name] = { ...speechToText[provider.name], status: false }
                 }
             })
+            // Initialize 'none' property if it doesn't exist
+            if (!newVal['none']) {
+                newVal['none'] = {}
+            }
             if (providerName !== 'none') {
                 newVal['none'].status = false
             }


### PR DESCRIPTION
### Bug Description
- When configuring speech-to-text providers, the settings were not saved due to a missing initialization for the `none` provider in the state.

### Fix
- Added initialization for the `none` provider.
- Added debugging logs to aid troubleshooting.
- Tested locally and verified the fix works.

### Testing
- Configured speech-to-text providers and verified the settings were saved.
- No errors were encountered during testing.