### PR TITLE
Feature/Add Groq for followup prompts

### DIFF
--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -427,7 +427,8 @@ export enum FollowUpPromptProvider {
     AZURE_OPENAI = 'azureChatOpenAI',
     GOOGLE_GENAI = 'chatGoogleGenerativeAI',
     MISTRALAI = 'chatMistralAI',
-    OPENAI = 'chatOpenAI'
+    OPENAI = 'chatOpenAI',
+    GROQ = 'groqChat'
 }
 
 export type FollowUpPromptProviderConfig = {

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -7,6 +7,7 @@ import { ChatOpenAI } from '@langchain/openai'
 import { z } from 'zod'
 import { PromptTemplate } from '@langchain/core/prompts'
 import { StructuredOutputParser } from '@langchain/core/output_parsers'
+import { ChatGroq } from '@langchain/groq'
 
 const FollowUpPromptType = z
     .object({
@@ -105,6 +106,16 @@ export const generateFollowUpPrompts = async (
                     temperature: parseFloat(`${providerConfig.temperature}`)
                 })
                 const structuredLLM = model.withStructuredOutput(FollowUpPromptType)
+                const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
+                return structuredResponse
+            }
+            case FollowUpPromptProvider.GROQ: {
+                const llm = new ChatGroq({
+                    apiKey: credentialData.groqApiKey,
+                    model: providerConfig.modelName,
+                    temperature: parseFloat(`${providerConfig.temperature}`)
+                })
+                const structuredLLM = llm.withStructuredOutput(FollowUpPromptType)
                 const structuredResponse = await structuredLLM.invoke(followUpPromptsPrompt)
                 return structuredResponse
             }

--- a/packages/ui/src/ui-component/extended/FollowUpPrompts.jsx
+++ b/packages/ui/src/ui-component/extended/FollowUpPrompts.jsx
@@ -13,6 +13,7 @@ import anthropicIcon from '@/assets/images/anthropic.svg'
 import azureOpenAiIcon from '@/assets/images/azure_openai.svg'
 import mistralAiIcon from '@/assets/images/mistralai.svg'
 import openAiIcon from '@/assets/images/openai.svg'
+import groqIcon from '@/assets/images/groq.png'
 import { TooltipWithParser } from '@/ui-component/tooltip/TooltipWithParser'
 import CredentialInputHandler from '@/views/canvas/CredentialInputHandler'
 import { Input } from '@/ui-component/input/Input'
@@ -32,6 +33,7 @@ const FollowUpPromptProviders = {
     ANTHROPIC: 'chatAnthropic',
     AZURE_OPENAI: 'azureChatOpenAI',
     GOOGLE_GENAI: 'chatGoogleGenerativeAI',
+    GROQ: 'groqChat',
     MISTRALAI: 'chatMistralAI',
     OPENAI: 'chatOpenAI'
 }
@@ -129,6 +131,42 @@ const followUpPromptsOptions = {
                     { label: 'gemini-1.5-flash-latest', name: 'gemini-1.5-flash-latest' },
                     { label: 'gemini-1.5-pro-latest', name: 'gemini-1.5-pro-latest' }
                 ]
+            },
+            {
+                label: 'Prompt',
+                name: 'prompt',
+                type: 'string',
+                rows: 4,
+                description: promptDescription,
+                optional: true,
+                default: defaultPrompt
+            },
+            {
+                label: 'Temperature',
+                name: 'temperature',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                default: 0.9
+            }
+        ]
+    },
+    [FollowUpPromptProviders.GROQ]: {
+        label: 'Groq',
+        name: FollowUpPromptProviders.GROQ,
+        icon: groqIcon,
+        inputs: [
+            {
+                label: 'Connect Credential',
+                name: 'credential',
+                type: 'credential',
+                credentialNames: ['groqApi']
+            },
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'asyncOptions',
+                loadMethod: 'listModels'
             },
             {
                 label: 'Prompt',


### PR DESCRIPTION
Adds support for the Groq language model to the follow-up prompts feature. 

Integration of Groq language model:

* Updated the `FollowUpPromptProvider` enum to include `GROQ`.
* Integrated Groq-specific logic in the `generateFollowUpPrompts` function.

UI updates for Groq support:

* Updated `FollowUpPromptProviders` and `followUpPromptsOptions` to include Groq-specific configurations and icons. 


<img width="1182" alt="image" src="https://github.com/user-attachments/assets/219a7110-f71f-4bb0-952c-7a49b2be727f" />
