### PR TITLE
Slight Redis Memory description change to include units

### DIFF
--- a/packages/components/nodes/memory/RedisBackedChatMemory/RedisBackedChatMemory.ts
+++ b/packages/components/nodes/memory/RedisBackedChatMemory/RedisBackedChatMemory.ts
@@ -53,7 +53,7 @@ class RedisBackedChatMemory_Memory implements INode {
                 label: 'Session Timeouts',
                 name: 'sessionTTL',
                 type: 'number',
-                description: 'Omit this parameter to make sessions never expire',
+                description: 'Seconds till a session expires. If not specified, the session will never expire.',
                 additionalParams: true,
                 optional: true
             },

--- a/packages/components/nodes/memory/UpstashRedisBackedChatMemory/UpstashRedisBackedChatMemory.ts
+++ b/packages/components/nodes/memory/UpstashRedisBackedChatMemory/UpstashRedisBackedChatMemory.ts
@@ -80,7 +80,7 @@ class UpstashRedisBackedChatMemory_Memory implements INode {
                 label: 'Session Timeouts',
                 name: 'sessionTTL',
                 type: 'number',
-                description: 'Omit this parameter to make sessions never expire',
+                description: 'Seconds till a session expires. If not specified, the session will never expire.',
                 additionalParams: true,
                 optional: true
             },


### PR DESCRIPTION
TTL didn't mention that it was seconds, which differs from other Redis configs as well. 

Simple change to clear that up 👍 