### PR TITLE
Bugfix/Handling empty strings when resolving variables

### DIFF
--- a/packages/components/nodes/chains/LLMChain/LLMChain.ts
+++ b/packages/components/nodes/chains/LLMChain/LLMChain.ts
@@ -249,7 +249,7 @@ const runPrediction = async (
 
         for (const variable of inputVariables) {
             seen.push(variable)
-            if (promptValues[variable]) {
+            if (promptValues[variable] != null) {
                 seen.pop()
             }
         }

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -877,7 +877,7 @@ export const getVariableValue = async (
             if (variableFullPath.startsWith('$vars.')) {
                 const vars = await getGlobalVariable(appDataSource, flowData, availableVariables, variableOverrides)
                 const variableValue = get(vars, variableFullPath.replace('$vars.', ''))
-                if (variableValue) {
+                if (variableValue != null) {
                     variableDict[`{{${variableFullPath}}}`] = variableValue
                     returnVal = returnVal.split(`{{${variableFullPath}}}`).join(variableValue)
                 }
@@ -885,7 +885,7 @@ export const getVariableValue = async (
 
             if (variableFullPath.startsWith('$flow.') && flowData) {
                 const variableValue = get(flowData, variableFullPath.replace('$flow.', ''))
-                if (variableValue) {
+                if (variableValue != null) {
                     variableDict[`{{${variableFullPath}}}`] = variableValue
                     returnVal = returnVal.split(`{{${variableFullPath}}}`).join(variableValue)
                 }


### PR DESCRIPTION
There are some issues. 

1. Not considering empty string when LLMChain process the given promptValues. It makes the 'seen' stack do unexpected things

2. The value of the variable is the intended empty string, but it doesn't resolve.

- Expected: Sending a request using a prompt where the `emptystring` variable (the output of a custom function) is replaced with an empty string.
<img width="994" alt="스크린샷 2025-01-14 오전 1 33 01" src="https://github.com/user-attachments/assets/3bc9ea9c-c6b1-42e9-b23b-e2e850929fcd" />

- Current behavior: The value of `question` is repeatedly assigned to a variable that should be assigned an empty string
<img width="374" alt="스크린샷 2025-01-14 오전 1 32 47" src="https://github.com/user-attachments/assets/64df71f4-a4c5-40d8-8f62-826a25f51f56" />