### PR TITLE
fix: Fixing logger for custom S3 stream

### DIFF
--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -39,14 +39,14 @@ if (process.env.STORAGE_TYPE === 's3') {
 
     s3ErrorStream = new S3StreamLogger({
         bucket: s3Bucket,
-        folder: 'logs/server',
+        folder: 'logs/error',
         name_format: `server-error-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log`,
         config: s3Config
     })
 
     s3ServerReqStream = new S3StreamLogger({
         bucket: s3Bucket,
-        folder: 'logs/server',
+        folder: 'logs/requests',
         name_format: `server-requests-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log`,
         config: s3Config
     })

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -23,7 +23,7 @@ if (process.env.STORAGE_TYPE === 's3') {
     const s3Config = {
         region: region,
         endpoint: customURL,
-        s3ForcePathStyle: forcePathStyle,
+        forcePathStyle: forcePathStyle,
         credentials: {
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -17,32 +17,38 @@ if (process.env.STORAGE_TYPE === 's3') {
     const secretAccessKey = process.env.S3_STORAGE_SECRET_ACCESS_KEY
     const region = process.env.S3_STORAGE_REGION
     const s3Bucket = process.env.S3_STORAGE_BUCKET_NAME
+    const customURL = process.env.S3_ENDPOINT_URL
+    const forcePathStyle = process.env.S3_FORCE_PATH_STYLE === 'true'
+
+    const s3Config = {
+        region: region,
+        endpoint: customURL,
+        s3ForcePathStyle: forcePathStyle,
+        credentials: {
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey
+        }
+    }
 
     s3ServerStream = new S3StreamLogger({
         bucket: s3Bucket,
         folder: 'logs/server',
-        region,
-        access_key_id: accessKeyId,
-        secret_access_key: secretAccessKey,
-        name_format: `server-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log`
+        name_format: `server-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log`,
+        config: s3Config
     })
 
     s3ErrorStream = new S3StreamLogger({
         bucket: s3Bucket,
-        folder: 'logs/error',
-        region,
-        access_key_id: accessKeyId,
-        secret_access_key: secretAccessKey,
-        name_format: `server-error-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log`
+        folder: 'logs/server',
+        name_format: `server-error-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log`,
+        config: s3Config
     })
 
     s3ServerReqStream = new S3StreamLogger({
         bucket: s3Bucket,
-        folder: 'logs/requests',
-        region,
-        access_key_id: accessKeyId,
-        secret_access_key: secretAccessKey,
-        name_format: `server-requests-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log.jsonl`
+        folder: 'logs/server',
+        name_format: `server-requests-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log`,
+        config: s3Config
     })
 }
 

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -47,7 +47,7 @@ if (process.env.STORAGE_TYPE === 's3') {
     s3ServerReqStream = new S3StreamLogger({
         bucket: s3Bucket,
         folder: 'logs/requests',
-        name_format: `server-requests-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log`,
+        name_format: `server-requests-%Y-%m-%d-%H-%M-%S-%L-${hostname()}.log.jsonl`,
         config: s3Config
     })
 }

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -4,6 +4,7 @@ import { hostname } from 'node:os'
 import config from './config' // should be replaced by node-config or similar
 import { createLogger, transports, format } from 'winston'
 import { NextFunction, Request, Response } from 'express'
+import { S3ClientConfig } from '@aws-sdk/client-s3'
 
 const { S3StreamLogger } = require('s3-streamlogger')
 
@@ -20,13 +21,13 @@ if (process.env.STORAGE_TYPE === 's3') {
     const customURL = process.env.S3_ENDPOINT_URL
     const forcePathStyle = process.env.S3_FORCE_PATH_STYLE === 'true'
 
-    const s3Config = {
+    const s3Config: S3ClientConfig = {
         region: region,
         endpoint: customURL,
         forcePathStyle: forcePathStyle,
         credentials: {
-            accessKeyId: accessKeyId,
-            secretAccessKey: secretAccessKey
+            accessKeyId: accessKeyId as string,
+            secretAccessKey: secretAccessKey as string
         }
     }
 


### PR DESCRIPTION
This PR solves the issue mentionned on #3899, The issue is that when trying to plug any S3 provider other than amazon aws, the server startup fails in dns request (check the issue for more info).

This pr solves the issue by using the custom s3 endpoint present in the env variables. 