### PR TITLE
fix: Correct logic error in tool input assignment for ChatflowTool

### DIFF
--- a/packages/components/nodes/tools/ChatflowTool/ChatflowTool.ts
+++ b/packages/components/nodes/tools/ChatflowTool/ChatflowTool.ts
@@ -164,7 +164,7 @@ class ChatflowTool_Tools implements INode {
         let toolInput = ''
         if (useQuestionFromChat) {
             toolInput = input
-        } else if (!customInput) {
+        } else if (customInput) {
             toolInput = customInput
         }
 


### PR DESCRIPTION
According to the description of `customInput`, leaving it empty allows the LLM to decide the input. Therefore, if `customInput` is not an empty string, it should be passed to the chatflow.
The previous code incorrectly assigned `toolInput` to an empty string when `customInput` was non-empty. This has been corrected to ensure that `toolInput` is assigned `customInput` when `useQuestionFromChat` is false and `customInput` is non-empty.