### PR TITLE
Update model names for deepseek components

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -580,8 +580,8 @@
                     "name": "deepseek-chat"
                 },
                 {
-                    "label": "deepseek-coder",
-                    "name": "deepseek-coder"
+                    "label": "deepseek-reasoner",
+                    "name": "deepseek-reasoner"
                 }
             ]
         },


### PR DESCRIPTION
Update model list for Deepseek chat: Deepseek now no longer has model `deepseek-coder`, new model `deepseek-reasoner`