### PR TITLE
Update RateLimit.jsx - link to documentation incorrect

### DIFF
--- a/packages/ui/src/ui-component/extended/RateLimit.jsx
+++ b/packages/ui/src/ui-component/extended/RateLimit.jsx
@@ -151,7 +151,7 @@ const RateLimit = () => {
                 <TooltipWithParser
                     style={{ marginLeft: 10 }}
                     title={
-                        'Visit <a target="_blank" href="https://docs.flowiseai.com/rate-limit">Rate Limit Setup Guide</a> to set up Rate Limit correctly in your hosting environment.'
+                        'Visit <a target="_blank" href="https://docs.flowiseai.com/configuration/rate-limit">Rate Limit Setup Guide</a> to set up Rate Limit correctly in your hosting environment.'
                     }
                 />
             </Typography>


### PR DESCRIPTION
Current link to Rate Limit documentation is incorrect: 
https://docs.flowiseai.com/rate-limit

Corrected to:
https://docs.flowiseai.com/configuration/rate-limit