### PR TITLE
Fix: Ensure normalizeURL retains port number

### DIFF
--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -379,7 +379,7 @@ function getURLsFromHTML(htmlBody: string, baseURL: string): string[] {
 function normalizeURL(urlString: string): string {
     const urlObj = new URL(urlString)
     const port = urlObj.port ? `:${urlObj.port}` : ''
-    const hostPath = urlObj.hostname + port + urlObj.pathname + urlObj.search    
+    const hostPath = urlObj.hostname + port + urlObj.pathname + urlObj.search
     if (hostPath.length > 0 && hostPath.slice(-1) == '/') {
         // handling trailing slash
         return hostPath.slice(0, -1)

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -378,7 +378,8 @@ function getURLsFromHTML(htmlBody: string, baseURL: string): string[] {
  */
 function normalizeURL(urlString: string): string {
     const urlObj = new URL(urlString)
-    const hostPath = urlObj.hostname + urlObj.pathname + urlObj.search
+    const port = urlObj.port ? `:${urlObj.port}` : ''
+    const hostPath = urlObj.hostname + port + urlObj.pathname + urlObj.search    
     if (hostPath.length > 0 && hostPath.slice(-1) == '/') {
         // handling trailing slash
         return hostPath.slice(0, -1)


### PR DESCRIPTION
## Issue
The normalizeURL function was incorrectly removing the port from URLs.

## Fix
- Explicitly include the port if it's present (`urlObj.port`)
- Prevents unintended behavior where ports (e.g., `:3000`) were stripped

## Example
Before:
normalizeURL("http://example.com:3000/path?query=1") → "example.com/path?query=1" (port missing)

After:
normalizeURL("http://example.com:3000/path?query=1") → "example.com:3000/path?query=1" (port retained)
