### PR TITLE
o3 "reasoning effort" options 

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -617,16 +617,20 @@
                     "name": "gpt-4o-2024-05-13"
                 },
                 {
-                    "label": "o3-mini",
+                    "label": "o3-mini (latest)",
                     "name": "o3-mini"
                 },
                 {
-                    "label": "o1-preview (latest)",
-                    "name": "o1-preview"
+                    "label": "o3-mini-2025-01-31",
+                    "name": "o3-mini-2025-01-31"
                 },
                 {
-                    "label": "o1-preview-2024-09-12",
-                    "name": "o1-preview-2024-09-12"
+                    "label": "o1 (latest)",
+                    "name": "o1"
+                },
+                {
+                    "label": "o1-2024-12-17",
+                    "name": "o1-2024-12-17"
                 },
                 {
                     "label": "o1-mini (latest)",
@@ -635,6 +639,14 @@
                 {
                     "label": "o1-mini-2024-09-12",
                     "name": "o1-mini-2024-09-12"
+                },
+                {
+                    "label": "o1-preview (latest)",
+                    "name": "o1-preview"
+                },
+                {
+                    "label": "o1-preview-2024-09-12",
+                    "name": "o1-preview-2024-09-12"
                 },
                 {
                     "label": "gpt-4 (latest)",

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -207,7 +207,7 @@ class ChatOpenAI_ChatModels implements INode {
         const temperature = nodeData.inputs?.temperature as string
         const modelName = nodeData.inputs?.modelName as string
         const maxTokens = nodeData.inputs?.maxTokens as string
-        const reasoningEffort = nodeData.inputs?.reasoningEffort as string
+        const reasoningEffort = nodeData.inputs?.reasoningEffort as "low" | "medium" | "high";
         const topP = nodeData.inputs?.topP as string
         const frequencyPenalty = nodeData.inputs?.frequencyPenalty as string
         const presencePenalty = nodeData.inputs?.presencePenalty as string
@@ -240,7 +240,9 @@ class ChatOpenAI_ChatModels implements INode {
 
         if (modelName === 'o3-mini') {
             delete obj.temperature
-            obj.reasoning_effort = reasoningEffort;
+            if (reasoningEffort) {
+                obj.reasoning_effort = reasoningEffort;
+            }
         }
         if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
         if (topP) obj.topP = parseFloat(topP)

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -23,7 +23,7 @@ class ChatOpenAI_ChatModels implements INode {
     constructor() {
         this.label = 'ChatOpenAI'
         this.name = 'chatOpenAI'
-        this.version = 8.0
+        this.version = 8.1
         this.type = 'ChatOpenAI'
         this.icon = 'openai.svg'
         this.category = 'Chat Models'
@@ -72,6 +72,27 @@ class ChatOpenAI_ChatModels implements INode {
                 step: 1,
                 optional: true,
                 additionalParams: true
+            },
+            {
+                label: 'Reasoning Effort',
+                description: 'Only used for reasoning models (currently only o3-mini). This gives the model guidance on how many reasoning tokens it should generate before creating a response to the prompt. "low" will favor speed and economical token usage, and "high" will favor more complete reasoning at the cost of more tokens generated and slower responses. The default value is medium, which is a balance between speed and reasoning accuracy.',
+                name: 'reasoningEffort',
+                optional: true,
+                type: 'options',
+                options: [
+                    {
+                        label: 'Low',
+                        name: 'low'
+                    },
+                    {
+                        label: 'Medium',
+                        name: 'medium'
+                    },
+                    {
+                        label: 'High',
+                        name: 'high'
+                    }
+                ],
             },
             {
                 label: 'Top Probability',
@@ -181,6 +202,7 @@ class ChatOpenAI_ChatModels implements INode {
         const temperature = nodeData.inputs?.temperature as string
         const modelName = nodeData.inputs?.modelName as string
         const maxTokens = nodeData.inputs?.maxTokens as string
+        const reasoningEffort = nodeData.inputs?.reasoningEffort as string
         const topP = nodeData.inputs?.topP as string
         const frequencyPenalty = nodeData.inputs?.frequencyPenalty as string
         const presencePenalty = nodeData.inputs?.presencePenalty as string
@@ -213,6 +235,7 @@ class ChatOpenAI_ChatModels implements INode {
 
         if (modelName === 'o3-mini') {
             delete obj.temperature
+            obj.reasoningEffort = reasoningEffort;
         }
         if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
         if (topP) obj.topP = parseFloat(topP)

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -8,6 +8,11 @@ import { ChatOpenAI } from './FlowiseChatOpenAI'
 import { getModels, MODEL_TYPE } from '../../../src/modelLoader'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 
+// Extend OpenAIChatInput to include reasoning_effort
+interface ExtendedOpenAIChatInput extends OpenAIChatInput {
+    reasoning_effort?: 'low' | 'medium' | 'high';
+}
+
 class ChatOpenAI_ChatModels implements INode {
     label: string
     name: string
@@ -224,7 +229,7 @@ class ChatOpenAI_ChatModels implements INode {
 
         const cache = nodeData.inputs?.cache as BaseCache
 
-        const obj: Partial<OpenAIChatInput> &
+        const obj: Partial<ExtendedOpenAIChatInput> &
             Partial<AzureOpenAIInput> &
             BaseChatModelParams & { configuration?: ClientOptions & LegacyOpenAIInput } = {
             temperature: parseFloat(temperature),
@@ -235,7 +240,7 @@ class ChatOpenAI_ChatModels implements INode {
 
         if (modelName === 'o3-mini') {
             delete obj.temperature
-            obj.reasoningEffort = reasoningEffort;
+            obj.reasoning_effort = reasoningEffort;
         }
         if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
         if (topP) obj.topP = parseFloat(topP)

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -57,6 +57,7 @@ class ChatOpenAI_ChatModels implements INode {
             {
                 label: 'Temperature',
                 name: 'temperature',
+                description: 'Temperature is ignored when a reasoning model is selected as it is currently not supported.',
                 type: 'number',
                 step: 0.1,
                 default: 0.9,
@@ -83,6 +84,7 @@ class ChatOpenAI_ChatModels implements INode {
                 description: 'Only used for reasoning models (currently only o3-mini). This gives the model guidance on how many reasoning tokens it should generate before creating a response to the prompt. "low" will favor speed and economical token usage, and "high" will favor more complete reasoning at the cost of more tokens generated and slower responses. The default value is medium, which is a balance between speed and reasoning accuracy.',
                 name: 'reasoningEffort',
                 optional: true,
+                additionalParams: true,
                 type: 'options',
                 options: [
                     {

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -81,7 +81,7 @@ class ChatOpenAI_ChatModels implements INode {
             },
             {
                 label: 'Reasoning Effort',
-                description: 'Only used for reasoning models (currently only o3-mini). This gives the model guidance on how many reasoning tokens it should generate before creating a response to the prompt. "low" will favor speed and economical token usage, and "high" will favor more complete reasoning at the cost of more tokens generated and slower responses. The default value is medium, which is a balance between speed and reasoning accuracy.',
+                description: 'Only used for reasoning models (o1 & o3-mini). This gives the model guidance on how many reasoning tokens it should generate before creating a response to the prompt. "low" will favor speed and economical token usage, and "high" will favor more complete reasoning at the cost of more tokens generated and slower responses. The default value is medium, which is a balance between speed and reasoning accuracy.',
                 name: 'reasoningEffort',
                 optional: true,
                 additionalParams: true,
@@ -240,7 +240,7 @@ class ChatOpenAI_ChatModels implements INode {
             streaming: streaming ?? true
         }
 
-        if (modelName === 'o3-mini') {
+        if (modelName.includes('o1') || modelName.includes('o3')) {
             delete obj.temperature
             if (reasoningEffort) {
                 obj.reasoning_effort = reasoningEffort;


### PR DESCRIPTION
@HenryHengZJ , a couple additions for the new o3-mini update!

**ChatOpenAI.ts**
- Added "Reasoning effort" to additional parameters for o1 and o3 models.
- "o3" check updated to also check for "o1". If model name contains o1 or o3, reasoning_effort will be used.
- "Temperature" description added to indicate it's ignored for reasoning models.

![image](https://github.com/user-attachments/assets/dbf52dc9-ef28-4b9e-89bf-bea3873b0a44)

**models.json**
- Specific pointer added for o3-mini
- Latest o1 added