### PR TITLE
Update DeleteDocStoreDialog.jsx - added clarification that data will also be removed from the record manager.

### DIFF
--- a/packages/ui/src/views/docstore/DeleteDocStoreDialog.jsx
+++ b/packages/ui/src/views/docstore/DeleteDocStoreDialog.jsx
@@ -147,7 +147,7 @@ const DeleteDocStoreDialog = ({ show, dialogProps, onCancel, onDelete }) => {
                 {dialogProps.type === 'STORE' && dialogProps.recordManagerConfig && (
                     <FormControlLabel
                         control={<Checkbox checked={removeFromVS} onChange={(event) => setRemoveFromVS(event.target.checked)} />}
-                        label='Remove data from vector store'
+                        label='Remove data from vector store and record manager'
                     />
                 )}
                 {removeFromVS && (


### PR DESCRIPTION
Added clarification that data will also be removed from the record manager.

Before: 
"Remove data from vector store"

After:
"Remove data from vector store and record manager"

Note: this dialog box only appears when a record manager exists in the doc store. If it's intended to be shown regardless of whether a record manager exists, updates will be needed.