### PR TITLE
Several features for OpenAPI toolkit and OpenAI Assistants

### DIFF
--- a/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
+++ b/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
@@ -924,14 +924,12 @@ async function handleToolSubmission(params: ToolSubmissionParams): Promise<ToolS
         chatId,
         options,
         input,
-        usedTools,
-        text,
-        isStreamingStarted
+        usedTools
     } = params
 
     let updatedText = params.text
     let updatedIsStreamingStarted = params.isStreamingStarted
-    
+
     const stream = openai.beta.threads.runs.submitToolOutputsStream(threadId, runThreadId, {
         tool_outputs: submitToolOutputs
     })
@@ -955,7 +953,7 @@ async function handleToolSubmission(params: ToolSubmissionParams): Promise<ToolS
             } else if (event.event === 'thread.run.requires_action') {
                 if (event.data.required_action?.submit_tool_outputs.tool_calls) {
                     const actions: ICommonObject[] = []
-                    
+
                     event.data.required_action.submit_tool_outputs.tool_calls.forEach((item) => {
                         const functionCall = item.function
                         let args = {}
@@ -976,7 +974,7 @@ async function handleToolSubmission(params: ToolSubmissionParams): Promise<ToolS
                         const tool = tools.find((tool: any) => tool.name === actions[i].tool)
                         if (!tool) continue
 
-                        const toolIds = await analyticHandlers.onToolStart(tool.name, actions[i].toolInput, parentIds )
+                        const toolIds = await analyticHandlers.onToolStart(tool.name, actions[i].toolInput, parentIds)
 
                         try {
                             const toolOutput = await tool.call(actions[i].toolInput, undefined, undefined, {
@@ -997,9 +995,7 @@ async function handleToolSubmission(params: ToolSubmissionParams): Promise<ToolS
                         } catch (e) {
                             await analyticHandlers.onToolEnd(toolIds, e)
                             console.error('Error executing tool', e)
-                            throw new Error(
-                                `Error executing tool. Tool: ${tool.name}. Thread ID: ${threadId}. Run ID: ${runThreadId}`
-                            )
+                            throw new Error(`Error executing tool. Tool: ${tool.name}. Thread ID: ${threadId}. Run ID: ${runThreadId}`)
                         }
                     }
 
@@ -1093,7 +1089,7 @@ const formatToOpenAIAssistantTool = (tool: any): OpenAI.Beta.FunctionTool => {
 
     // Add strict property if the tool is marked as strict
     if (tool instanceof DynamicStructuredTool && tool.isStrict()) {
-        (functionTool.function as any).strict = true
+        ;(functionTool.function as any).strict = true
     }
 
     return functionTool

--- a/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
+++ b/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
@@ -18,6 +18,7 @@ import { AnalyticHandler } from '../../../src/handler'
 import { Moderation, checkInputs, streamResponse } from '../../moderation/Moderation'
 import { formatResponse } from '../../outputparsers/OutputParserHelpers'
 import { addSingleFileToStorage } from '../../../src/storageUtils'
+import { DynamicStructuredTool } from '../../tools/OpenAPIToolkit/core'
 
 const lenticularBracketRegex = /【[^】]*】/g
 const imageRegex = /<img[^>]*\/>/g
@@ -504,7 +505,6 @@ class OpenAIAssistant_Agents implements INode {
                                     toolCallId: item.id
                                 })
                             })
-
                             const submitToolOutputs = []
                             for (let i = 0; i < actions.length; i += 1) {
                                 const tool = tools.find((tool: any) => tool.name === actions[i].tool)
@@ -539,30 +539,23 @@ class OpenAIAssistant_Agents implements INode {
                             }
 
                             try {
-                                const stream = openai.beta.threads.runs.submitToolOutputsStream(threadId, runThreadId, {
-                                    tool_outputs: submitToolOutputs
+                                await handleToolSubmission({
+                                    openai,
+                                    threadId,
+                                    runThreadId,
+                                    submitToolOutputs,
+                                    tools,
+                                    analyticHandlers,
+                                    parentIds,
+                                    llmIds,
+                                    sseStreamer,
+                                    chatId,
+                                    options,
+                                    input,
+                                    usedTools,
+                                    text,
+                                    isStreamingStarted
                                 })
-
-                                for await (const event of stream) {
-                                    if (event.event === 'thread.message.delta') {
-                                        const chunk = event.data.delta.content?.[0]
-                                        if (chunk && 'text' in chunk && chunk.text?.value) {
-                                            text += chunk.text.value
-                                            if (!isStreamingStarted) {
-                                                isStreamingStarted = true
-                                                if (sseStreamer) {
-                                                    sseStreamer.streamStartEvent(chatId, chunk.text.value)
-                                                }
-                                            }
-                                            if (sseStreamer) {
-                                                sseStreamer.streamTokenEvent(chatId, chunk.text.value)
-                                            }
-                                        }
-                                    }
-                                }
-                                if (sseStreamer) {
-                                    sseStreamer.streamUsedToolsEvent(chatId, usedTools)
-                                }
                             } catch (error) {
                                 console.error('Error submitting tool outputs:', error)
                                 await openai.beta.threads.runs.cancel(threadId, runThreadId)
@@ -634,7 +627,6 @@ class OpenAIAssistant_Agents implements INode {
                                             toolCallId: item.id
                                         })
                                     })
-
                                     const submitToolOutputs = []
                                     for (let i = 0; i < actions.length; i += 1) {
                                         const tool = tools.find((tool: any) => tool.name === actions[i].tool)
@@ -895,15 +887,216 @@ const downloadFile = async (openAIApiKey: string, fileObj: any, fileName: string
     }
 }
 
+interface ToolSubmissionParams {
+    openai: OpenAI
+    threadId: string
+    runThreadId: string
+    submitToolOutputs: any[]
+    tools: any[]
+    analyticHandlers: AnalyticHandler
+    parentIds: ICommonObject
+    llmIds: ICommonObject
+    sseStreamer: IServerSideEventStreamer
+    chatId: string
+    options: ICommonObject
+    input: string
+    usedTools: IUsedTool[]
+    text: string
+    isStreamingStarted: boolean
+}
+
+interface ToolSubmissionResult {
+    text: string
+    isStreamingStarted: boolean
+}
+
+async function handleToolSubmission(params: ToolSubmissionParams): Promise<ToolSubmissionResult> {
+    const {
+        openai,
+        threadId,
+        runThreadId,
+        submitToolOutputs,
+        tools,
+        analyticHandlers,
+        parentIds,
+        llmIds,
+        sseStreamer,
+        chatId,
+        options,
+        input,
+        usedTools,
+        text,
+        isStreamingStarted
+    } = params
+
+    let updatedText = params.text
+    let updatedIsStreamingStarted = params.isStreamingStarted
+    
+    const stream = openai.beta.threads.runs.submitToolOutputsStream(threadId, runThreadId, {
+        tool_outputs: submitToolOutputs
+    })
+
+    try {
+        for await (const event of stream) {
+            if (event.event === 'thread.message.delta') {
+                const chunk = event.data.delta.content?.[0]
+                if (chunk && 'text' in chunk && chunk.text?.value) {
+                    updatedText += chunk.text.value
+                    if (!updatedIsStreamingStarted) {
+                        updatedIsStreamingStarted = true
+                        if (sseStreamer) {
+                            sseStreamer.streamStartEvent(chatId, chunk.text.value)
+                        }
+                    }
+                    if (sseStreamer) {
+                        sseStreamer.streamTokenEvent(chatId, chunk.text.value)
+                    }
+                }
+            } else if (event.event === 'thread.run.requires_action') {
+                if (event.data.required_action?.submit_tool_outputs.tool_calls) {
+                    const actions: ICommonObject[] = []
+                    
+                    event.data.required_action.submit_tool_outputs.tool_calls.forEach((item) => {
+                        const functionCall = item.function
+                        let args = {}
+                        try {
+                            args = JSON.parse(functionCall.arguments)
+                        } catch (e) {
+                            console.error('Error parsing arguments, default to empty object')
+                        }
+                        actions.push({
+                            tool: functionCall.name,
+                            toolInput: args,
+                            toolCallId: item.id
+                        })
+                    })
+
+                    const nestedToolOutputs = []
+                    for (let i = 0; i < actions.length; i += 1) {
+                        const tool = tools.find((tool: any) => tool.name === actions[i].tool)
+                        if (!tool) continue
+
+                        const toolIds = await analyticHandlers.onToolStart(tool.name, actions[i].toolInput, parentIds )
+
+                        try {
+                            const toolOutput = await tool.call(actions[i].toolInput, undefined, undefined, {
+                                sessionId: threadId,
+                                chatId: options.chatId,
+                                input
+                            })
+                            await analyticHandlers.onToolEnd(toolIds, toolOutput)
+                            nestedToolOutputs.push({
+                                tool_call_id: actions[i].toolCallId,
+                                output: toolOutput
+                            })
+                            usedTools.push({
+                                tool: tool.name,
+                                toolInput: actions[i].toolInput,
+                                toolOutput
+                            })
+                        } catch (e) {
+                            await analyticHandlers.onToolEnd(toolIds, e)
+                            console.error('Error executing tool', e)
+                            throw new Error(
+                                `Error executing tool. Tool: ${tool.name}. Thread ID: ${threadId}. Run ID: ${runThreadId}`
+                            )
+                        }
+                    }
+
+                    // Recursively handle nested tool submissions
+                    const result = await handleToolSubmission({
+                        openai,
+                        threadId,
+                        runThreadId,
+                        submitToolOutputs: nestedToolOutputs,
+                        tools,
+                        analyticHandlers,
+                        parentIds,
+                        llmIds,
+                        sseStreamer,
+                        chatId,
+                        options,
+                        input,
+                        usedTools,
+                        text: updatedText,
+                        isStreamingStarted: updatedIsStreamingStarted
+                    })
+                    updatedText = result.text
+                    updatedIsStreamingStarted = result.isStreamingStarted
+                }
+            }
+        }
+
+        if (sseStreamer) {
+            sseStreamer.streamUsedToolsEvent(chatId, usedTools)
+        }
+
+        return {
+            text: updatedText,
+            isStreamingStarted: updatedIsStreamingStarted
+        }
+    } catch (error) {
+        console.error('Error submitting tool outputs:', error)
+        await openai.beta.threads.runs.cancel(threadId, runThreadId)
+
+        const errMsg = `Error submitting tool outputs. Thread ID: ${threadId}. Run ID: ${runThreadId}`
+
+        await analyticHandlers.onLLMError(llmIds, errMsg)
+        await analyticHandlers.onChainError(parentIds, errMsg, true)
+
+        throw new Error(errMsg)
+    }
+}
+
+interface JSONSchema {
+    type?: string
+    properties?: Record<string, JSONSchema>
+    additionalProperties?: boolean
+    required?: string[]
+    [key: string]: any
+}
+
 const formatToOpenAIAssistantTool = (tool: any): OpenAI.Beta.FunctionTool => {
-    return {
+    const parameters = zodToJsonSchema(tool.schema) as JSONSchema
+
+    // For strict tools, we need to:
+    // 1. Set additionalProperties to false
+    // 2. Make all parameters required
+    // 3. Set the strict flag
+    if (tool instanceof DynamicStructuredTool && tool.isStrict()) {
+        // Get all property names from the schema
+        const properties = parameters.properties || {}
+        const allPropertyNames = Object.keys(properties)
+
+        parameters.additionalProperties = false
+        parameters.required = allPropertyNames
+
+        // Handle nested objects
+        for (const [_, prop] of Object.entries(properties)) {
+            if (prop.type === 'object') {
+                prop.additionalProperties = false
+                if (prop.properties) {
+                    prop.required = Object.keys(prop.properties)
+                }
+            }
+        }
+    }
+
+    const functionTool: OpenAI.Beta.FunctionTool = {
         type: 'function',
         function: {
             name: tool.name,
             description: tool.description,
-            parameters: zodToJsonSchema(tool.schema)
+            parameters
         }
     }
+
+    // Add strict property if the tool is marked as strict
+    if (tool instanceof DynamicStructuredTool && tool.isStrict()) {
+        (functionTool.function as any).strict = true
+    }
+
+    return functionTool
 }
 
 module.exports = { nodeClass: OpenAIAssistant_Agents }

--- a/packages/components/nodes/tools/OpenAPIToolkit/OpenAPIToolkit.ts
+++ b/packages/components/nodes/tools/OpenAPIToolkit/OpenAPIToolkit.ts
@@ -5,6 +5,7 @@ import $RefParser from '@apidevtools/json-schema-ref-parser'
 import { z, ZodSchema, ZodTypeAny } from 'zod'
 import { defaultCode, DynamicStructuredTool, howToUseCode } from './core'
 import { DataSource } from 'typeorm'
+import { zodToJsonSchema } from 'zod-to-json-schema'
 
 class OpenAPIToolkit_Tools implements INode {
     label: string
@@ -49,6 +50,13 @@ class OpenAPIToolkit_Tools implements INode {
                 optional: true
             },
             {
+                label: 'Remove null parameters',
+                name: 'removeNulls',
+                type: 'boolean',
+                optional: true,
+                description: 'Remove all keys with null values from the parsed arguments'
+            },
+            {
                 label: 'Custom Code',
                 name: 'customCode',
                 type: 'code',
@@ -71,6 +79,7 @@ class OpenAPIToolkit_Tools implements INode {
         const yamlFileBase64 = nodeData.inputs?.yamlFile as string
         const customCode = nodeData.inputs?.customCode as string
         const _headers = nodeData.inputs?.headers as string
+        const removeNulls = nodeData.inputs?.removeNulls as boolean
 
         const headers = typeof _headers === 'object' ? _headers : _headers ? JSON.parse(_headers) : {}
 
@@ -105,8 +114,8 @@ class OpenAPIToolkit_Tools implements INode {
         const variables = await getVars(appDataSource, databaseEntities, nodeData)
 
         const flow = { chatflowId: options.chatflowid }
-
-        const tools = getTools(_data.paths, baseUrl, headers, variables, flow, toolReturnDirect, customCode)
+        
+        const tools = getTools(_data.paths, baseUrl, headers, variables, flow, toolReturnDirect, customCode, removeNulls)
         return tools
     }
 }
@@ -119,17 +128,18 @@ const jsonSchemaToZodSchema = (schema: any, requiredList: string[], keyName: str
             zodShape[key] = jsonSchemaToZodSchema(schema.properties[key], requiredList, key)
         }
         return z.object(zodShape)
-    } else if (schema.oneOf) {
-        // Handle oneOf by mapping each option to a Zod schema
-        const zodSchemas = schema.oneOf.map((subSchema: any) => jsonSchemaToZodSchema(subSchema, requiredList, keyName))
-        return z.union(zodSchemas)
+    } else if (schema.oneOf || schema.anyOf) {
+        // Handle oneOf/anyOf by mapping each option to a Zod schema
+        const schemas = schema.oneOf || schema.anyOf
+        const zodSchemas = schemas.map((subSchema: any) => jsonSchemaToZodSchema(subSchema, requiredList, keyName))
+        return z.union(zodSchemas).describe(schema?.description ?? schema?.title ?? keyName)
     } else if (schema.enum) {
-        // Handle enum types
+        // Handle enum types with their title and description
         return requiredList.includes(keyName)
-            ? z.enum(schema.enum).describe(schema?.description ?? keyName)
+            ? z.enum(schema.enum).describe(schema?.description ?? schema?.title ?? keyName)
             : z
                   .enum(schema.enum)
-                  .describe(schema?.description ?? keyName)
+                  .describe(schema?.description ?? schema?.title ?? keyName)
                   .optional()
     } else if (schema.type === 'string') {
         return requiredList.includes(keyName)
@@ -142,20 +152,28 @@ const jsonSchemaToZodSchema = (schema: any, requiredList: string[], keyName: str
         return z.array(jsonSchemaToZodSchema(schema.items, requiredList, keyName))
     } else if (schema.type === 'boolean') {
         return requiredList.includes(keyName)
-            ? z.number({ required_error: `${keyName} required` }).describe(schema?.description ?? keyName)
-            : z
-                  .number()
-                  .describe(schema?.description ?? keyName)
-                  .optional()
-    } else if (schema.type === 'number') {
-        return requiredList.includes(keyName)
             ? z.boolean({ required_error: `${keyName} required` }).describe(schema?.description ?? keyName)
-            : z
-                  .boolean()
-                  .describe(schema?.description ?? keyName)
-                  .optional()
+            : z.boolean().describe(schema?.description ?? keyName).optional()
+    } else if (schema.type === 'number') {
+        let numberSchema = z.number()
+        if (typeof schema.minimum === 'number') {
+            numberSchema = numberSchema.min(schema.minimum)
+        }
+        if (typeof schema.maximum === 'number') {
+            numberSchema = numberSchema.max(schema.maximum)
+        }
+        return requiredList.includes(keyName)
+            ? numberSchema.describe(schema?.description ?? keyName)
+            : numberSchema.describe(schema?.description ?? keyName).optional()
+    } else if (schema.type === 'integer') {
+        let numberSchema = z.number().int()
+        return requiredList.includes(keyName)
+            ? numberSchema.describe(schema?.description ?? keyName)
+            : numberSchema.describe(schema?.description ?? keyName).optional()
+    } else if (schema.type === 'null') {
+        return z.null()
     }
-
+    console.error(`jsonSchemaToZodSchema returns UNKNOWN! ${keyName}`, schema);
     // Fallback to unknown type if unrecognized
     return z.unknown()
 }
@@ -163,9 +181,24 @@ const jsonSchemaToZodSchema = (schema: any, requiredList: string[], keyName: str
 const extractParameters = (param: ICommonObject, paramZodObj: ICommonObject) => {
     const paramSchema = param.schema
     const paramName = param.name
-    const paramDesc = param.description || param.name
-
-    if (paramSchema.type === 'string') {
+    const paramDesc = paramSchema.description || paramSchema.title || param.description || param.name
+    
+    if (paramSchema.enum) {
+        const enumValues = paramSchema.enum as string[]
+        // Combine title and description from schema
+        const enumDesc = [
+            paramSchema.title,
+            paramSchema.description,
+            `Valid values: ${enumValues.join(', ')}`
+        ].filter(Boolean).join('. ')
+        
+        if (param.required) {
+            paramZodObj[paramName] = z.enum(enumValues as [string, ...string[]]).describe(enumDesc)
+        } else {
+            paramZodObj[paramName] = z.enum(enumValues as [string, ...string[]]).describe(enumDesc).optional()
+        }
+        return paramZodObj
+    } else if (paramSchema.type === 'string') {
         if (param.required) {
             paramZodObj[paramName] = z.string({ required_error: `${paramName} required` }).describe(paramDesc)
         } else {
@@ -176,13 +209,17 @@ const extractParameters = (param: ICommonObject, paramZodObj: ICommonObject) => 
             paramZodObj[paramName] = z.number({ required_error: `${paramName} required` }).describe(paramDesc)
         } else {
             paramZodObj[paramName] = z.number().describe(paramDesc).optional()
-        }
+        }            
     } else if (paramSchema.type === 'boolean') {
         if (param.required) {
             paramZodObj[paramName] = z.boolean({ required_error: `${paramName} required` }).describe(paramDesc)
         } else {
             paramZodObj[paramName] = z.boolean().describe(paramDesc).optional()
         }
+    } else if ( paramSchema.anyOf || (paramSchema.type === 'anyOf')) {
+        // Handle anyOf by using jsonSchemaToZodSchema
+        const requiredList = param.required ? [paramName] : []
+        paramZodObj[paramName] = jsonSchemaToZodSchema(paramSchema, requiredList, paramName)
     }
 
     return paramZodObj
@@ -195,7 +232,8 @@ const getTools = (
     variables: IVariable[],
     flow: ICommonObject,
     returnDirect: boolean,
-    customCode?: string
+    customCode?: string,
+    removeNulls?: boolean
 ) => {
     const tools = []
     for (const path in paths) {
@@ -269,7 +307,9 @@ const getTools = (
                 baseUrl: `${baseUrl}${path}`,
                 method: method,
                 headers,
-                customCode
+                customCode,
+                strict: spec['x-strict'] === true,
+                removeNulls
             }
 
             const dynamicStructuredTool = new DynamicStructuredTool(toolObj)

--- a/packages/components/nodes/tools/OpenAPIToolkit/core.ts
+++ b/packages/components/nodes/tools/OpenAPIToolkit/core.ts
@@ -8,7 +8,7 @@ import { availableDependencies, defaultAllowBuiltInDep, prepareSandboxVars } fro
 import { ICommonObject } from '../../../src/Interface'
 
 const removeNulls = (obj: Record<string, any>) => {
-    Object.keys(obj).forEach(key => {
+    Object.keys(obj).forEach((key) => {
         if (obj[key] === null) {
             delete obj[key]
         } else if (typeof obj[key] === 'object' && obj[key] !== null) {
@@ -225,11 +225,11 @@ export class DynamicStructuredTool<
             process: undefined
         }
         let processedArg = { ...arg }
-        
+
         if (this.removeNulls && typeof processedArg === 'object' && processedArg !== null) {
             processedArg = removeNulls(processedArg)
         }
-        
+
         if (typeof processedArg === 'object' && Object.keys(processedArg).length) {
             for (const item in processedArg) {
                 sandbox[`$${item}`] = processedArg[item]

--- a/packages/components/nodes/tools/OpenAPIToolkit/core.ts
+++ b/packages/components/nodes/tools/OpenAPIToolkit/core.ts
@@ -7,6 +7,20 @@ import { CallbackManagerForToolRun, Callbacks, CallbackManager, parseCallbackCon
 import { availableDependencies, defaultAllowBuiltInDep, prepareSandboxVars } from '../../../src/utils'
 import { ICommonObject } from '../../../src/Interface'
 
+const removeNulls = (obj: Record<string, any>) => {
+    Object.keys(obj).forEach(key => {
+        if (obj[key] === null) {
+            delete obj[key]
+        } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+            removeNulls(obj[key])
+            if (Object.keys(obj[key]).length === 0) {
+                delete obj[key]
+            }
+        }
+    })
+    return obj
+}
+
 interface HttpRequestObject {
     PathParameters?: Record<string, any>
     QueryParameters?: Record<string, any>
@@ -104,6 +118,8 @@ export interface DynamicStructuredToolInput<
     method: string
     headers: ICommonObject
     customCode?: string
+    strict?: boolean
+    removeNulls?: boolean
 }
 
 export class DynamicStructuredTool<
@@ -122,12 +138,15 @@ export class DynamicStructuredTool<
 
     customCode?: string
 
+    strict?: boolean
+
     func: DynamicStructuredToolInput['func']
 
     // @ts-ignore
     schema: T
     private variables: any[]
     private flowObj: any
+    private removeNulls: boolean
 
     constructor(fields: DynamicStructuredToolInput<T>) {
         super(fields)
@@ -140,6 +159,8 @@ export class DynamicStructuredTool<
         this.method = fields.method
         this.headers = fields.headers
         this.customCode = fields.customCode
+        this.strict = fields.strict
+        this.removeNulls = fields.removeNulls ?? false
     }
 
     async call(
@@ -156,7 +177,7 @@ export class DynamicStructuredTool<
         try {
             parsed = await this.schema.parseAsync(arg)
         } catch (e) {
-            throw new ToolInputParsingException(`Received tool input did not match expected schema`, JSON.stringify(arg))
+            throw new ToolInputParsingException(`Received tool input did not match expected schema ${e}`, JSON.stringify(arg))
         }
         const callbackManager_ = await CallbackManager.configure(
             config.callbacks,
@@ -203,9 +224,15 @@ export class DynamicStructuredTool<
             fs: undefined,
             process: undefined
         }
-        if (typeof arg === 'object' && Object.keys(arg).length) {
-            for (const item in arg) {
-                sandbox[`$${item}`] = arg[item]
+        let processedArg = { ...arg }
+        
+        if (this.removeNulls && typeof processedArg === 'object' && processedArg !== null) {
+            processedArg = removeNulls(processedArg)
+        }
+        
+        if (typeof processedArg === 'object' && Object.keys(processedArg).length) {
+            for (const item in processedArg) {
+                sandbox[`$${item}`] = processedArg[item]
             }
         }
 
@@ -261,5 +288,9 @@ export class DynamicStructuredTool<
 
     setFlowObject(flow: any) {
         this.flowObj = flow
+    }
+
+    isStrict(): boolean {
+        return this.strict === true
     }
 }


### PR DESCRIPTION

The PR proposes to:

1. Allow OpenAI assistant to call several tools in the same run. This is quite common when the assistant decides to call a second tool after the first one
2. The OpenAPI Toolkit now supports a "x-strict": true  attribute for an action. This creates a function with "strict mode".

The "strict mode" is described here: https://openai.com/index/introducing-structured-outputs-in-the-api/ , https://platform.openai.com/docs/guides/structured-outputs 
Basically it allows to drastically reduce hallucination problems while generating tool calls.

The strict mode has the problem that only a subset of the json spec is supported.
One of the caveats is that all fields must be required. So the workaround is to use an "anyOf" schema with the type null.

For example if we want to make the "limit" parameter optional we can specify it like this:
```
{
            "name": "limit",
            "in": "query",
            "required": true,
            "schema": {
              "anyOf": [
                {
                  "type": "integer"
                },
                {
                  "type": "null"
                }
              ],
              "description": "Maximum number of records to return (1-100)",
              "title": "Limit"
            },
            "description": "Maximum number of records to return (1-100)"
          },
```
But then the model will call the api with "limit=null" .
So the PR adds the option to remove null parameters from the api call, so that your api backend won't choke on the null parameter.
 