### PR TITLE
Late Chunking support for Jina Embeddings

### DIFF
--- a/packages/components/nodes/embeddings/JinaAIEmbedding/JinaAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/JinaAIEmbedding/JinaAIEmbedding.ts
@@ -6,20 +6,16 @@ class ExtendedJinaEmbeddings extends JinaEmbeddings {
     private late_chunking: boolean
 
     constructor(fields: ConstructorParameters<typeof JinaEmbeddings>[0] & { late_chunking?: boolean }) {
-        const { late_chunking, ...restFields } = fields
+        const { late_chunking = false, ...restFields } = fields
         super(restFields)
-        this.late_chunking = late_chunking ?? false
+        this.late_chunking = late_chunking
     }
 
     public override async embedDocuments(texts: string[]): Promise<number[][]> {
-        // eslint-disable-next-line no-self-assign
-        this.late_chunking = this.late_chunking
         return super.embedDocuments(texts)
     }
 
     public override async embedQuery(text: string): Promise<number[]> {
-        // eslint-disable-next-line no-self-assign
-        this.late_chunking = this.late_chunking
         return super.embedQuery(text)
     }
 }

--- a/packages/components/nodes/embeddings/JinaAIEmbedding/JinaAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/JinaAIEmbedding/JinaAIEmbedding.ts
@@ -2,6 +2,28 @@ import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Inter
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 import { JinaEmbeddings } from '@langchain/community/embeddings/jina'
 
+class ExtendedJinaEmbeddings extends JinaEmbeddings {
+    private late_chunking: boolean
+
+    constructor(fields: ConstructorParameters<typeof JinaEmbeddings>[0] & { late_chunking?: boolean }) {
+        const { late_chunking, ...restFields } = fields
+        super(restFields)
+        this.late_chunking = late_chunking ?? false
+    }
+
+    public override async embedDocuments(texts: string[]): Promise<number[][]> {
+        // eslint-disable-next-line no-self-assign
+        this.late_chunking = this.late_chunking
+        return super.embedDocuments(texts)
+    }
+
+    public override async embedQuery(text: string): Promise<number[]> {
+        // eslint-disable-next-line no-self-assign
+        this.late_chunking = this.late_chunking
+        return super.embedQuery(text)
+    }
+}
+
 class JinaAIEmbedding_Embeddings implements INode {
     label: string
     name: string
@@ -17,7 +39,7 @@ class JinaAIEmbedding_Embeddings implements INode {
     constructor() {
         this.label = 'Jina Embeddings'
         this.name = 'jinaEmbeddings'
-        this.version = 2.0
+        this.version = 3.0
         this.type = 'JinaEmbeddings'
         this.icon = 'JinaAIEmbedding.svg'
         this.category = 'Embeddings'
@@ -34,7 +56,7 @@ class JinaAIEmbedding_Embeddings implements INode {
                 label: 'Model Name',
                 name: 'modelName',
                 type: 'string',
-                default: 'jina-embeddings-v2-base-en',
+                default: 'jina-embeddings-v3',
                 description: 'Refer to <a href="https://jina.ai/embeddings/" target="_blank">JinaAI documentation</a> for available models'
             },
             {
@@ -44,6 +66,15 @@ class JinaAIEmbedding_Embeddings implements INode {
                 default: 1024,
                 description:
                     'Refer to <a href="https://jina.ai/embeddings/" target="_blank">JinaAI documentation</a> for available dimensions'
+            },
+            {
+                label: 'Allow Late Chunking',
+                name: 'allowLateChunking',
+                type: 'boolean',
+                description:
+                    'Refer to <a href="https://jina.ai/embeddings/" target="_blank">JinaAI documentation</a> guidance on late chunking',
+                default: false,
+                optional: true
             }
         ]
     }
@@ -51,13 +82,15 @@ class JinaAIEmbedding_Embeddings implements INode {
     async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
         const modelName = nodeData.inputs?.modelName as string
         const modelDimensions = nodeData.inputs?.modelDimensions as number
+        const allowLateChunking = nodeData.inputs?.modelDimensions as boolean
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const apiKey = getCredentialParam('jinaAIAPIKey', credentialData, nodeData)
 
-        const model = new JinaEmbeddings({
+        const model = new ExtendedJinaEmbeddings({
             apiKey: apiKey,
             model: modelName,
-            dimensions: modelDimensions
+            dimensions: modelDimensions,
+            late_chunking: allowLateChunking
         })
 
         return model

--- a/packages/components/nodes/embeddings/JinaAIEmbedding/JinaAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/JinaAIEmbedding/JinaAIEmbedding.ts
@@ -10,14 +10,6 @@ class ExtendedJinaEmbeddings extends JinaEmbeddings {
         super(restFields)
         this.late_chunking = late_chunking
     }
-
-    public override async embedDocuments(texts: string[]): Promise<number[][]> {
-        return super.embedDocuments(texts)
-    }
-
-    public override async embedQuery(text: string): Promise<number[]> {
-        return super.embedQuery(text)
-    }
 }
 
 class JinaAIEmbedding_Embeddings implements INode {


### PR DESCRIPTION
* Add support for Jina [Late Chunking](https://github.com/jina-ai/late-chunking)
* Switch default Jina embedding from jina-embeddings-v2-base-en to jina-embeddings-v3, which is the newer recommended embedding. Also supports multilingual text.

jina-embeddings-v3 support Late Chunking:
`Apply the late chunking technique to leverage the model's long-context capabilities for generating contextual chunk embeddings.`

