### PR TITLE
o3-mini Adjustments.

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -613,8 +613,12 @@
                     "name": "gpt-4o-2024-05-13"
                 },
                 {
-                    "label": "o3-mini",
+                    "label": "o3-mini (latest)",
                     "name": "o3-mini"
+                },
+                {
+                    "label": "o3-mini-2025-01-31",
+                    "name": "o3-mini-2025-01-31"
                 },
                 {
                     "label": "o1-preview (latest)",

--- a/packages/components/nodes/chatmodels/AzureChatOpenAI/AzureChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/AzureChatOpenAI/AzureChatOpenAI.ts
@@ -156,7 +156,7 @@ class AzureChatOpenAI_ChatModels implements INode {
             },
             {
                 label: 'Reasoning Effort',
-                description: 'Constrains effort on reasoning for reasoning models. Only applicable for o1 models',
+                description: 'Constrains effort on reasoning for reasoning models. Only applicable for o1 and o3 models.',
                 name: 'reasoningEffort',
                 type: 'options',
                 options: [
@@ -173,7 +173,7 @@ class AzureChatOpenAI_ChatModels implements INode {
                         name: 'high'
                     }
                 ],
-                default: 'low',
+                default: 'medium',
                 optional: false,
                 additionalParams: true
             }

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -176,7 +176,7 @@ class ChatOpenAI_ChatModels implements INode {
             },
             {
                 label: 'Reasoning Effort',
-                description: 'Constrains effort on reasoning for reasoning models. Only applicable for o1 models',
+                description: 'Constrains effort on reasoning for reasoning models. Only applicable for o1 and o3 models.',
                 name: 'reasoningEffort',
                 type: 'options',
                 options: [
@@ -193,7 +193,7 @@ class ChatOpenAI_ChatModels implements INode {
                         name: 'high'
                     }
                 ],
-                default: 'low',
+                default: 'medium',
                 optional: false,
                 additionalParams: true
             }


### PR DESCRIPTION
Several small adjustments for o3-mini

**Update ChatOpenAI.ts - corrected reasoning description and default**
- Description for reasoning effort only mentioned o1. Added o3.
- Changed reasoning effort default to medium as this is OpenAI's default / what users will most likely expect (https://platform.openai.com/docs/guides/reasoning)

**Update AzureChatOpenAI.ts - corrected reasoning description and default**
- Description for reasoning effort only mentioned o1. Added o3.
- Changed reasoning effort default to medium as this is OpenAI's default / what users will most likely expect (https://platform.openai.com/docs/guides/reasoning)

**Update models.json - add specific model ID for o3-mini**
- Added o3-mini-2025-01-31
- Updated "o3-mini" label to "o3-mini (latest)"
This allows the user to choose a specific model ID and avoid the risk of unexpected behavior if the "o3-mini" alias is updated.

