### PR TITLE
Replace .edgebutton 'x' text with <IconX/>

### DIFF
--- a/packages/ui/src/views/canvas/ButtonEdge.jsx
+++ b/packages/ui/src/views/canvas/ButtonEdge.jsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux'
 import { useContext } from 'react'
 import { SET_DIRTY } from '@/store/actions'
 import { flowContext } from '@/store/context/ReactFlowContext'
+import { IconX } from '@tabler/icons-react'
 
 import './index.css'
 
@@ -53,7 +54,7 @@ const ButtonEdge = ({ id, sourceX, sourceY, targetX, targetY, sourcePosition, ta
             >
                 <div>
                     <button className='edgebutton' onClick={(event) => onEdgeClick(event, id)}>
-                        ×
+                        <IconX stroke={2} size='12' />
                     </button>
                 </div>
             </foreignObject>

--- a/packages/ui/src/views/canvas/index.css
+++ b/packages/ui/src/views/canvas/index.css
@@ -1,12 +1,14 @@
 .edgebutton {
     width: 20px;
     height: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0;
     background: #eee;
     border: 1px solid #fff;
     cursor: pointer;
     border-radius: 50%;
-    font-size: 12px;
-    line-height: 1;
 }
 
 .edgebutton:hover {


### PR DESCRIPTION
The edge removal button uses an uncentered 'x' character. This update replaces it with the <IconX/> component from Tabler to be consistent with the rest of the UI (verified appearance on Chrome, Firefox, and Edge).

![button_change](https://github.com/user-attachments/assets/d1ee2aa0-b0f4-428b-a592-2d7515c78bb1)
