### PR TITLE
now user can name each document loader for ease of tracking

### DIFF
--- a/packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx
+++ b/packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx
@@ -237,7 +237,7 @@ const LoaderConfigPreviewChunks = () => {
 
         // Set store id & loader name
         config.storeId = storeId
-        config.loaderName = loaderName
+        config.loaderName = loaderName || selectedDocumentLoader?.label
 
         // Set loader config
         if (selectedDocumentLoader.inputs) {
@@ -283,6 +283,7 @@ const LoaderConfigPreviewChunks = () => {
             // If this is a document store edit config, set the existing input values
             if (existingLoaderFromDocStoreTable && existingLoaderFromDocStoreTable.loaderConfig) {
                 nodeData.inputs = existingLoaderFromDocStoreTable.loaderConfig
+                setLoaderName(existingLoaderFromDocStoreTable.loaderName)
             }
             setSelectedDocumentLoader(nodeData)
 
@@ -445,17 +446,20 @@ const LoaderConfigPreviewChunks = () => {
                                             paddingRight: 15
                                         }}
                                     >
-                                        <TextField
-                                            size='small'
-                                            label={
-                                                selectedDocumentLoader?.label?.toLowerCase().includes('loader')
-                                                    ? selectedDocumentLoader.label + ' name'
-                                                    : selectedDocumentLoader?.label + ' Loader Name'
-                                            }
-                                            value={loaderName}
-                                            onChange={(e) => setLoaderName(e.target.value)}
-                                            sx={{ m: 2, width: '90%' }}
-                                        />
+                                        <Box sx={{ p: 2 }}>
+                                            <TextField
+                                                fullWidth
+                                                sx={{ mt: 1 }}
+                                                size='small'
+                                                label={
+                                                    selectedDocumentLoader?.label?.toLowerCase().includes('loader')
+                                                        ? selectedDocumentLoader.label + ' name'
+                                                        : selectedDocumentLoader?.label + ' Loader Name'
+                                                }
+                                                value={loaderName}
+                                                onChange={(e) => setLoaderName(e.target.value)}
+                                            />
+                                        </Box>
                                         {selectedDocumentLoader &&
                                             Object.keys(selectedDocumentLoader).length > 0 &&
                                             (selectedDocumentLoader.inputParams ?? [])

--- a/packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx
+++ b/packages/ui/src/views/docstore/LoaderConfigPreviewChunks.jsx
@@ -9,7 +9,7 @@ import ReactJson from 'flowise-react-json-view'
 import useApi from '@/hooks/useApi'
 
 // Material-UI
-import { Skeleton, Toolbar, Box, Button, Card, CardContent, Grid, OutlinedInput, Stack, Typography } from '@mui/material'
+import { Skeleton, Toolbar, Box, Button, Card, CardContent, Grid, OutlinedInput, Stack, Typography, TextField } from '@mui/material'
 import { useTheme, styled } from '@mui/material/styles'
 import { IconScissors, IconArrowLeft, IconDatabaseImport, IconBook, IconX, IconEye } from '@tabler/icons-react'
 
@@ -72,6 +72,7 @@ const LoaderConfigPreviewChunks = () => {
 
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState(null)
+    const [loaderName, setLoaderName] = useState('')
 
     const [textSplitterNodes, setTextSplitterNodes] = useState([])
     const [splitterOptions, setTextSplitterOptions] = useState([])
@@ -236,7 +237,7 @@ const LoaderConfigPreviewChunks = () => {
 
         // Set store id & loader name
         config.storeId = storeId
-        config.loaderName = selectedDocumentLoader?.label
+        config.loaderName = loaderName
 
         // Set loader config
         if (selectedDocumentLoader.inputs) {
@@ -444,6 +445,17 @@ const LoaderConfigPreviewChunks = () => {
                                             paddingRight: 15
                                         }}
                                     >
+                                        <TextField
+                                            size='small'
+                                            label={
+                                                selectedDocumentLoader?.label?.toLowerCase().includes('loader')
+                                                    ? selectedDocumentLoader.label + ' name'
+                                                    : selectedDocumentLoader?.label + ' Loader Name'
+                                            }
+                                            value={loaderName}
+                                            onChange={(e) => setLoaderName(e.target.value)}
+                                            sx={{ m: 2, width: '90%' }}
+                                        />
                                         {selectedDocumentLoader &&
                                             Object.keys(selectedDocumentLoader).length > 0 &&
                                             (selectedDocumentLoader.inputParams ?? [])


### PR DESCRIPTION
fix for issue #3882
Now user can set a name for each documentLoader that they upload. this will make it easy to track them from the dashboard
changes - 
![Screenshot 2025-02-17 at 5 04 55 PM](https://github.com/user-attachments/assets/cf150996-92b3-4d67-b428-4cb7aef0c659)
view in the dashboard(third entry) - 
![Screenshot 2025-02-17 at 5 04 38 PM](https://github.com/user-attachments/assets/dc0e0af7-fe0e-4451-8706-0066e99a339d)
