### PR TITLE
Add Paste JSON Schema Functionality to Custom Tools

### DIFF
--- a/packages/ui/src/views/tools/PasteJSONDialog.jsx
+++ b/packages/ui/src/views/tools/PasteJSONDialog.jsx
@@ -1,0 +1,87 @@
+import { createPortal } from 'react-dom'
+import PropTypes from 'prop-types'
+import { useState } from 'react'
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material'
+import { StyledButton } from '@/ui-component/button/StyledButton'
+import { CodeEditor } from '@/ui-component/editor/CodeEditor'
+
+const PasteJSONDialog = ({ show, onCancel, onConfirm, customization }) => {
+    const portalElement = document.getElementById('portal')
+    const [jsonInput, setJsonInput] = useState('')
+    const [error, setError] = useState('')
+
+    const handleConfirm = () => {
+        try {
+            const parsedJSON = JSON.parse(jsonInput)
+            if (!Array.isArray(parsedJSON)) throw new Error('Input must be an array of properties')
+            const formattedData = parsedJSON.map((item, index) => ({
+                id: index + 1,
+                property: item.property || '',
+                type: item.type || 'string',
+                description: item.description || '',
+                required: item.required || false
+            }))
+            onConfirm(formattedData)
+            setError('')
+        } catch (err) {
+            setError('Invalid JSON format. Please check your input.')
+        }
+    }
+
+    const exampleJSON = `[
+    {
+        "property": "name",
+        "type": "string",
+        "description": "User's name",
+        "required": true
+    },
+    {
+        "property": "age",
+        "type": "number",
+        "description": "User's age",
+        "required": false
+    }
+]`
+
+    const component = show ? (
+        <Dialog fullWidth maxWidth='md' open={show} onClose={onCancel} aria-labelledby='paste-json-dialog-title'>
+            <DialogTitle sx={{ fontSize: '1rem' }} id='paste-json-dialog-title'>
+                Paste JSON Schema
+            </DialogTitle>
+            <DialogContent>
+                <Box sx={{ mt: 2 }}>
+                    <Button variant='outlined' size='small' onClick={() => setJsonInput(exampleJSON)} sx={{ mb: 2 }}>
+                        See Example
+                    </Button>
+                    <CodeEditor
+                        value={jsonInput}
+                        theme={customization.isDarkMode ? 'dark' : 'light'}
+                        lang='json'
+                        onValueChange={(code) => {
+                            setJsonInput(code)
+                            setError('')
+                        }}
+                    />
+                    {error && <Box sx={{ color: 'error.main', mt: 1, fontSize: '0.875rem' }}>{error}</Box>}
+                </Box>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onCancel}>Cancel</Button>
+                <StyledButton variant='contained' onClick={handleConfirm}>
+                    Confirm
+                </StyledButton>
+            </DialogActions>
+        </Dialog>
+    ) : null
+
+    return createPortal(component, portalElement)
+}
+
+PasteJSONDialog.propTypes = {
+    show: PropTypes.bool,
+    onCancel: PropTypes.func,
+    onConfirm: PropTypes.func,
+    customization: PropTypes.object
+}
+
+export default PasteJSONDialog

--- a/packages/ui/src/views/tools/ToolDialog.jsx
+++ b/packages/ui/src/views/tools/ToolDialog.jsx
@@ -14,9 +14,10 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import ConfirmDialog from '@/ui-component/dialog/ConfirmDialog'
 import { CodeEditor } from '@/ui-component/editor/CodeEditor'
 import HowToUseFunctionDialog from './HowToUseFunctionDialog'
+import PasteJSONDialog from './PasteJSONDialog'
 
 // Icons
-import { IconX, IconFileDownload, IconPlus, IconTemplate } from '@tabler/icons-react'
+import { IconX, IconFileDownload, IconPlus, IconTemplate, IconCode } from '@tabler/icons-react'
 
 // API
 import toolsApi from '@/api/tools'
@@ -82,6 +83,8 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
 
     const [exportAsTemplateDialogOpen, setExportAsTemplateDialogOpen] = useState(false)
     const [exportAsTemplateDialogProps, setExportAsTemplateDialogProps] = useState({})
+
+    const [showPasteJSONDialog, setShowPasteJSONDialog] = useState(false)
 
     const deleteItem = useCallback(
         (id) => () => {
@@ -409,6 +412,11 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
         }
     }
 
+    const handlePastedJSON = (formattedData) => {
+        setToolSchema(formattedData)
+        setShowPasteJSONDialog(false)
+    }
+
     const component = show ? (
         <Dialog
             fullWidth
@@ -507,9 +515,14 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
                                 <TooltipWithParser title={'What is the input format in JSON?'} />
                             </Stack>
                             {dialogProps.type !== 'TEMPLATE' && (
-                                <Button variant='outlined' onClick={addNewRow} startIcon={<IconPlus />}>
-                                    Add Item
-                                </Button>
+                                <Stack direction='row' spacing={1}>
+                                    <Button variant='outlined' onClick={() => setShowPasteJSONDialog(true)} startIcon={<IconCode />}>
+                                        Paste JSON
+                                    </Button>
+                                    <Button variant='outlined' onClick={addNewRow} startIcon={<IconPlus />}>
+                                        Add Item
+                                    </Button>
+                                </Stack>
                             )}
                         </Stack>
                         <Grid columns={columns} rows={toolSchema} disabled={dialogProps.type === 'TEMPLATE'} onRowUpdate={onRowUpdate} />
@@ -577,6 +590,15 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
             )}
 
             <HowToUseFunctionDialog show={showHowToDialog} onCancel={() => setShowHowToDialog(false)} />
+
+            {showPasteJSONDialog && (
+                <PasteJSONDialog
+                    show={showPasteJSONDialog}
+                    onCancel={() => setShowPasteJSONDialog(false)}
+                    onConfirm={handlePastedJSON}
+                    customization={customization}
+                />
+            )}
         </Dialog>
     ) : null
 


### PR DESCRIPTION
## What's Changed
Added a new feature to make it easier to add input schema to custom tools by pasting JSON directly.

### New Features:
- Added "Paste JSON" button next to "Add Item" in the Tool Dialog
- Created new PasteJSONDialog component with JSON code editor
- Added JSON validation and error handling
- Included example JSON template for reference

### How to Use:
1. Click "Paste JSON" button in the Input Schema section
2. Either paste your JSON or click "See Example" to see the format
3. Click Confirm to add the properties to the grid


## Screenshots
![Screenshot 2025-02-20 192218](https://github.com/user-attachments/assets/18ddc1f0-3075-4bf2-9683-6af912e91ffe)
![Screenshot 2025-02-20 192425](https://github.com/user-attachments/assets/785fa189-f633-4ccd-a02f-d7009cb28095)

## Testing Done
- Tested JSON validation
- Tested example template
- Tested error handling
- Tested dark/light theme support

## Related Issues
https://github.com/FlowiseAI/Flowise/issues/4052