### PR TITLE
[Fix] Change S3 logger to accept more authorization methods for AWS

### DIFF
--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -32,7 +32,7 @@ if (process.env.STORAGE_TYPE === 's3') {
             secretAccessKey
         }
     }
-    
+
     const s3Config: S3ClientConfig = {
         region: region,
         endpoint: customURL,

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -21,14 +21,23 @@ if (process.env.STORAGE_TYPE === 's3') {
     const customURL = process.env.S3_ENDPOINT_URL
     const forcePathStyle = process.env.S3_FORCE_PATH_STYLE === 'true'
 
+    if (!region || !s3Bucket) {
+        throw new Error('S3 storage configuration is missing')
+    }
+
+    let credentials: S3ClientConfig['credentials'] | undefined
+    if (accessKeyId && secretAccessKey) {
+        credentials = {
+            accessKeyId,
+            secretAccessKey
+        }
+    }
+    
     const s3Config: S3ClientConfig = {
         region: region,
         endpoint: customURL,
         forcePathStyle: forcePathStyle,
-        credentials: {
-            accessKeyId: accessKeyId as string,
-            secretAccessKey: secretAccessKey as string
-        }
+        credentials: credentials
     }
 
     s3ServerStream = new S3StreamLogger({


### PR DESCRIPTION
This PR solves issue #3997 by making environment credentials optional for S3 logger, so they can be taken from different alternative sources like K8S service accounts.