### PR TITLE
feat: Add SSL configuration option for Postgres connections

### DIFF
--- a/packages/components/nodes/recordmanager/PostgresRecordManager/PostgresRecordManager.ts
+++ b/packages/components/nodes/recordmanager/PostgresRecordManager/PostgresRecordManager.ts
@@ -2,8 +2,9 @@ import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Inter
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 import { ListKeyOptions, RecordManagerInterface, UpdateOptions } from '@langchain/community/indexes/base'
 import { DataSource } from 'typeorm'
-import { getHost } from '../../vectorstores/Postgres/utils'
+import { getHost, getSSL } from '../../vectorstores/Postgres/utils'
 import { getDatabase, getPort, getTableName } from './utils'
+import fs from 'fs'
 
 const serverCredentialsExists = !!process.env.POSTGRES_RECORDMANAGER_USER && !!process.env.POSTGRES_RECORDMANAGER_PASSWORD
 
@@ -49,6 +50,14 @@ class PostgresRecordManager_RecordManager implements INode {
                 name: 'port',
                 type: 'number',
                 placeholder: getPort(),
+                optional: true
+            },
+            {
+                label: 'SSL',
+                name: 'ssl',
+                description: 'Use SSL to connect to Postgres',
+                type: 'boolean',
+                additionalParams: true,
                 optional: true
             },
             {
@@ -149,6 +158,7 @@ class PostgresRecordManager_RecordManager implements INode {
             type: 'postgres',
             host: getHost(nodeData),
             port: getPort(nodeData),
+            ssl: getSSL(nodeData),
             username: user,
             password: password,
             database: getDatabase(nodeData)

--- a/packages/components/nodes/recordmanager/PostgresRecordManager/README.md
+++ b/packages/components/nodes/recordmanager/PostgresRecordManager/README.md
@@ -4,14 +4,15 @@ Postgres Record Manager integration for Flowise
 
 ## 🌱 Env Variables
 
-| Variable                          | Description                                     | Type   | Default           |
-| --------------------------------- | ----------------------------------------------- | ------ | ----------------- |
-| POSTGRES_RECORDMANAGER_HOST       | Default `host` for Postgres Record Manager      | String |                   |
-| POSTGRES_RECORDMANAGER_PORT       | Default `port` for Postgres Record Manager      | Number | 5432              |
-| POSTGRES_RECORDMANAGER_USER       | Default `user` for Postgres Record Manager      | String |                   |
-| POSTGRES_RECORDMANAGER_PASSWORD   | Default `password` for Postgres Record Manager  | String |                   |
-| POSTGRES_RECORDMANAGER_DATABASE   | Default `database` for Postgres Record Manager  | String |                   |
-| POSTGRES_RECORDMANAGER_TABLE_NAME | Default `tableName` for Postgres Record Manager | String | upsertion_records |
+| Variable                          | Description                                     | Type    | Default           |
+| --------------------------------- | ----------------------------------------------- | ------- | ----------------- |
+| POSTGRES_RECORDMANAGER_HOST       | Default `host` for Postgres Record Manager      | String  |                   |
+| POSTGRES_RECORDMANAGER_PORT       | Default `port` for Postgres Record Manager      | Number  | 5432              |
+| POSTGRES_RECORDMANAGER_USER       | Default `user` for Postgres Record Manager      | String  |                   |
+| POSTGRES_RECORDMANAGER_PASSWORD   | Default `password` for Postgres Record Manager  | String  |                   |
+| POSTGRES_RECORDMANAGER_DATABASE   | Default `database` for Postgres Record Manager  | String  |                   |
+| POSTGRES_RECORDMANAGER_TABLE_NAME | Default `tableName` for Postgres Record Manager | String  | upsertion_records |
+| POSTGRES_RECORDMANAGER_SSL        | Default `ssl` for Postgres Vector Store         | Boolean | false             |
 
 ## License
 

--- a/packages/components/nodes/recordmanager/PostgresRecordManager/utils.ts
+++ b/packages/components/nodes/recordmanager/PostgresRecordManager/utils.ts
@@ -12,6 +12,10 @@ export function getPort(nodeData?: INodeData) {
     return defaultChain(nodeData?.inputs?.port, process.env.POSTGRES_RECORDMANAGER_PORT, '5432')
 }
 
+export function getSSL(nodeData?: INodeData) {
+    return defaultChain(nodeData?.inputs?.ssl, process.env.POSTGRES_RECORDMANAGER_SSL, false)
+}
+
 export function getTableName(nodeData?: INodeData) {
     return defaultChain(nodeData?.inputs?.tableName, process.env.POSTGRES_RECORDMANAGER_TABLE_NAME, 'upsertion_records')
 }

--- a/packages/components/nodes/vectorstores/Postgres/Postgres.ts
+++ b/packages/components/nodes/vectorstores/Postgres/Postgres.ts
@@ -84,6 +84,14 @@ class Postgres_VectorStores implements INode {
                 optional: true
             },
             {
+                label: 'SSL',
+                name: 'ssl',
+                description: 'Use SSL to connect to Postgres',
+                type: 'boolean',
+                additionalParams: true,
+                optional: true
+            },
+            {
                 label: 'Table Name',
                 name: 'tableName',
                 type: 'string',

--- a/packages/components/nodes/vectorstores/Postgres/README.md
+++ b/packages/components/nodes/vectorstores/Postgres/README.md
@@ -4,15 +4,16 @@ Postgres Vector Store integration for Flowise
 
 ## 🌱 Env Variables
 
-| Variable                                 | Description                                           | Type   | Default     |
-| ---------------------------------------- | ----------------------------------------------------- | ------ | ----------- |
-| POSTGRES_VECTORSTORE_HOST                | Default `host` for Postgres Vector Store              | String |             |
-| POSTGRES_VECTORSTORE_PORT                | Default `port` for Postgres Vector Store              | Number | 5432        |
-| POSTGRES_VECTORSTORE_USER                | Default `user` for Postgres Vector Store              | String |             |
-| POSTGRES_VECTORSTORE_PASSWORD            | Default `password` for Postgres Vector Store          | String |             |
-| POSTGRES_VECTORSTORE_DATABASE            | Default `database` for Postgres Vector Store          | String |             |
-| POSTGRES_VECTORSTORE_TABLE_NAME          | Default `tableName` for Postgres Vector Store         | String | documents   |
-| POSTGRES_VECTORSTORE_CONTENT_COLUMN_NAME | Default `contentColumnName` for Postgres Vector Store | String | pageContent |
+| Variable                                 | Description                                           | Type    | Default     |
+| ---------------------------------------- | ----------------------------------------------------- | ------- | ----------- |
+| POSTGRES_VECTORSTORE_HOST                | Default `host` for Postgres Vector Store              | String  |             |
+| POSTGRES_VECTORSTORE_PORT                | Default `port` for Postgres Vector Store              | Number  | 5432        |
+| POSTGRES_VECTORSTORE_USER                | Default `user` for Postgres Vector Store              | String  |             |
+| POSTGRES_VECTORSTORE_PASSWORD            | Default `password` for Postgres Vector Store          | String  |             |
+| POSTGRES_VECTORSTORE_DATABASE            | Default `database` for Postgres Vector Store          | String  |             |
+| POSTGRES_VECTORSTORE_TABLE_NAME          | Default `tableName` for Postgres Vector Store         | String  | documents   |
+| POSTGRES_VECTORSTORE_CONTENT_COLUMN_NAME | Default `contentColumnName` for Postgres Vector Store | String  | pageContent |
+| POSTGRES_VECTORSTORE_SSL                 | Default `ssl` for Postgres Vector Store               | Boolean | false       |
 
 ## License
 

--- a/packages/components/nodes/vectorstores/Postgres/driver/Base.ts
+++ b/packages/components/nodes/vectorstores/Postgres/driver/Base.ts
@@ -2,7 +2,7 @@ import { VectorStore } from '@langchain/core/vectorstores'
 import { getCredentialData, getCredentialParam, ICommonObject, INodeData } from '../../../../src'
 import { Document } from '@langchain/core/documents'
 import { Embeddings } from '@langchain/core/embeddings'
-import { getDatabase, getHost, getPort, getTableName } from '../utils'
+import { getDatabase, getHost, getPort, getSSL, getTableName } from '../utils'
 
 export abstract class VectorStoreDriver {
     constructor(protected nodeData: INodeData, protected options: ICommonObject) {}
@@ -21,6 +21,10 @@ export abstract class VectorStoreDriver {
 
     getPort() {
         return getPort(this.nodeData) as number
+    }
+
+    getSSL() {
+        return getSSL(this.nodeData) as boolean
     }
 
     getDatabase() {

--- a/packages/components/nodes/vectorstores/Postgres/driver/TypeORM.ts
+++ b/packages/components/nodes/vectorstores/Postgres/driver/TypeORM.ts
@@ -29,6 +29,7 @@ export class TypeORMDriver extends VectorStoreDriver {
                 type: 'postgres',
                 host: this.getHost(),
                 port: this.getPort(),
+                ssl: this.getSSL(),
                 username: user, // Required by TypeORMVectorStore
                 user: user, // Required by Pool in similaritySearchVectorWithScore
                 password: password,

--- a/packages/components/nodes/vectorstores/Postgres/utils.ts
+++ b/packages/components/nodes/vectorstores/Postgres/utils.ts
@@ -12,6 +12,10 @@ export function getPort(nodeData?: INodeData) {
     return defaultChain(nodeData?.inputs?.port, process.env.POSTGRES_VECTORSTORE_PORT, '5432')
 }
 
+export function getSSL(nodeData?: INodeData) {
+    return defaultChain(nodeData?.inputs?.ssl, process.env.POSTGRES_VECTORSTORE_SSL, false)
+}
+
 export function getTableName(nodeData?: INodeData) {
     return defaultChain(nodeData?.inputs?.tableName, process.env.POSTGRES_VECTORSTORE_TABLE_NAME, 'documents')
 }


### PR DESCRIPTION
Add SSL option to vector store and record manager to be consistent with the postgres database driver. Most commercial postgres implementation will require us to use SSL. 