### PR TITLE
Add support for GPT-4.5-preview model in OpenAI Assistant Dialog

### DIFF
--- a/packages/ui/src/views/assistants/openai/AssistantDialog.jsx
+++ b/packages/ui/src/views/assistants/openai/AssistantDialog.jsx
@@ -47,6 +47,10 @@ import { maxScroll } from '@/store/constant'
 
 const assistantAvailableModels = [
     {
+        label: 'gpt-4.5-preview',
+        name: 'gpt-4.5-preview'
+    },
+    {
         label: 'gpt-4o-mini',
         name: 'gpt-4o-mini'
     },


### PR DESCRIPTION
This PR adds support for OpenAI's new GPT-4.5-preview model in the OpenAI Assistant Dialog.

## Changes
- Added GPT-4.5-preview to the list of available models in the Assistant Dialog

## Reference
OpenAI recently announced GPT-4.5-preview as their latest model with improved capabilities:
https://openai.com/index/introducing-gpt-4-5/
https://community.openai.com/t/gpt-4-5-is-live-in-the-api/1131571

## Testing
- Verified that the model appears in the dropdown list, and is working fine
- Confirmed that it can be selected when creating or editing an assistant

## Note
I didn't include `o1` and `o3-mini` in the Dialog because these models don't support parameters such as Assistant Temperature or Top P.