### PR TITLE
Fix Agent Chat History Retrieval

### DIFF
--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -156,9 +156,9 @@ const getChatHistory = async ({
 
     if (isAgentFlow) {
         const startNode = nodes.find((node) => node.data.name === 'seqStart')
-        if (!startNode?.data?.inputs?.memory) return []
+        if (!startNode?.data?.inputs?.agentMemory) return prependMessages
 
-        const memoryNodeId = startNode.data.inputs.memory.split('.')[0].replace('{{', '')
+        const memoryNodeId = startNode.data.inputs.agentMemory.split('.')[0].replace('{{', '')
         const memoryNode = nodes.find((node) => node.data.id === memoryNodeId)
 
         if (memoryNode) {


### PR DESCRIPTION
fixes the retrieval of agent chat history from the API. 

The issue was caused by referencing the incorrect input key (memory instead of agentMemory) in getChatHistory. This update ensures that agent memory is correctly accessed, preventing chat history from being lost or incorrectly fetched.

Changes:
	•	Updated the input reference from memory to agentMemory in buildChatflow.ts.
	•	Ensured that when agentMemory is not present, the function returns prependMessages instead of an empty array.
