### PR TITLE
Fix JSON Parsing Issue in Variable Substitution

### DIFF
--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -875,8 +875,9 @@ export const getVariableValue = async (
 
             if (variableFullPath.startsWith('$vars.')) {
                 const vars = await getGlobalVariable(flowConfig, availableVariables, variableOverrides)
-                const variableValue = get(vars, variableFullPath.replace('$vars.', ''))
+                let variableValue = get(vars, variableFullPath.replace('$vars.', ''))
                 if (variableValue != null) {
+                    variableValue = JSON.stringify(variableValue).slice(1, -1)
                     variableDict[`{{${variableFullPath}}}`] = variableValue
                     returnVal = returnVal.split(`{{${variableFullPath}}}`).join(variableValue)
                 }


### PR DESCRIPTION
returnVal is later parsed as JSON, so we need to ensure that the variable values are properly stringified. Previously, special characters (e.g., newlines) in variables like { hello: "this \n breaks" } would cause parsing issues.

Changes
	•	Properly stringify variableValue to maintain JSON validity.
	•	Prevent unwanted JSON parsing errors caused by special characters.

Testing
	•	Tested with variables containing special characters (e.g., newlines).
	•	Verified that returnVal remains correctly formatted for JSON parsing.
