### PR TITLE
Bugfix/S3 Credentials

### DIFF
--- a/packages/components/src/storageUtils.ts
+++ b/packages/components/src/storageUtils.ts
@@ -384,20 +384,21 @@ export const getS3Config = () => {
         throw new Error('S3 storage configuration is missing')
     }
 
-    let credentials: S3ClientConfig['credentials'] | undefined
+    const s3Config: S3ClientConfig = {
+        region: region,
+        endpoint: customURL,
+        forcePathStyle: forcePathStyle
+    }
+
     if (accessKeyId && secretAccessKey) {
-        credentials = {
-            accessKeyId,
-            secretAccessKey
+        s3Config.credentials = {
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey
         }
     }
 
-    const s3Client = new S3Client({
-        credentials,
-        region,
-        endpoint: customURL,
-        forcePathStyle: forcePathStyle
-    })
+    const s3Client = new S3Client(s3Config)
+
     return { s3Client, Bucket }
 }
 

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -27,14 +27,18 @@ if (USE_AWS_SECRETS_MANAGER) {
     const accessKeyId = process.env.SECRETKEY_AWS_ACCESS_KEY
     const secretAccessKey = process.env.SECRETKEY_AWS_SECRET_KEY
 
-    let credentials: SecretsManagerClientConfig['credentials'] | undefined
+    const secretManagerConfig: SecretsManagerClientConfig = {
+        region: region
+    }
+
     if (accessKeyId && secretAccessKey) {
-        credentials = {
+        secretManagerConfig.credentials = {
             accessKeyId,
             secretAccessKey
         }
     }
-    secretsManagerClient = new SecretsManagerClient({ credentials, region })
+
+    secretsManagerClient = new SecretsManagerClient(secretManagerConfig)
 }
 
 /*

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -76,14 +76,17 @@ if (USE_AWS_SECRETS_MANAGER) {
     const accessKeyId = process.env.SECRETKEY_AWS_ACCESS_KEY
     const secretAccessKey = process.env.SECRETKEY_AWS_SECRET_KEY
 
-    let credentials: SecretsManagerClientConfig['credentials'] | undefined
+    const secretManagerConfig: SecretsManagerClientConfig = {
+        region: region
+    }
+
     if (accessKeyId && secretAccessKey) {
-        credentials = {
+        secretManagerConfig.credentials = {
             accessKeyId,
             secretAccessKey
         }
     }
-    secretsManagerClient = new SecretsManagerClient({ credentials, region })
+    secretsManagerClient = new SecretsManagerClient(secretManagerConfig)
 }
 
 export const databaseEntities: IDatabaseEntity = {

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -25,19 +25,17 @@ if (process.env.STORAGE_TYPE === 's3') {
         throw new Error('S3 storage configuration is missing')
     }
 
-    let credentials: S3ClientConfig['credentials'] | undefined
-    if (accessKeyId && secretAccessKey) {
-        credentials = {
-            accessKeyId,
-            secretAccessKey
-        }
-    }
-
     const s3Config: S3ClientConfig = {
         region: region,
         endpoint: customURL,
-        forcePathStyle: forcePathStyle,
-        credentials: credentials
+        forcePathStyle: forcePathStyle
+    }
+
+    if (accessKeyId && secretAccessKey) {
+        s3Config.credentials = {
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey
+        }
     }
 
     s3ServerStream = new S3StreamLogger({


### PR DESCRIPTION
Fix invalid credentials:
```
2025-03-11 21:25:25 [ERROR]: unhandledRejection: Resolved credential object is not valid
Error: Resolved credential object is not valid
    at _SignatureV4S3Express.validateResolvedCredentials (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:440:13)
    at _SignatureV4S3Express.signRequest (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:365:10)
Error: Resolved credential object is not valid
    at _SignatureV4S3Express.validateResolvedCredentials (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:440:13)
    at _SignatureV4S3Express.signRequest (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:365:10)
2025-03-11 21:25:25 [ERROR]: unhandledRejection:  Resolved credential object is not valid
Error: Resolved credential object is not valid
    at _SignatureV4S3Express.validateResolvedCredentials (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:440:13)
    at _SignatureV4S3Express.signRequest (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:365:10)
2025-03-11 21:25:25 [ERROR]: unhandledRejection: Resolved credential object is not valid
Error: Resolved credential object is not valid
    at _SignatureV4S3Express.validateResolvedCredentials (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:440:13)
    at _SignatureV4S3Express.signRequest (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:365:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Error: Resolved credential object is not valid
    at _SignatureV4S3Express.validateResolvedCredentials (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:440:13)
    at _SignatureV4S3Express.signRequest (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:365:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-03-11 21:25:25 [ERROR]: unhandledRejection:  Resolved credential object is not valid
Error: Resolved credential object is not valid
    at _SignatureV4S3Express.validateResolvedCredentials (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:440:13)
    at _SignatureV4S3Express.signRequest (/usr/src/node_modules/.pnpm/@smithy+signature-v4@2.1.4/node_modules/@smithy/signature-v4/dist-cjs/index.js:365:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```