### PR TITLE
Add Ollama baseUrl for follow-up prompts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     },
     parser: '@typescript-eslint/parser',
     ignorePatterns: ['**/node_modules', '**/dist', '**/build', '**/package-lock.json'],
-    plugins: ['unused-imports'],
     rules: {
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         'no-unused-vars': 'off',

--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -436,6 +436,7 @@ export type FollowUpPromptProviderConfig = {
     [key in FollowUpPromptProvider]: {
         credentialId: string
         modelName: string
+        baseUrl: string
         prompt: string
         temperature: string
     }

--- a/packages/components/src/followUpPrompts.ts
+++ b/packages/components/src/followUpPrompts.ts
@@ -8,7 +8,7 @@ import { z } from 'zod'
 import { PromptTemplate } from '@langchain/core/prompts'
 import { StructuredOutputParser } from '@langchain/core/output_parsers'
 import { ChatGroq } from '@langchain/groq'
-import ollama from 'ollama'
+import { Ollama } from 'ollama'
 
 const FollowUpPromptType = z
     .object({
@@ -122,7 +122,11 @@ export const generateFollowUpPrompts = async (
                 return structuredResponse
             }
             case FollowUpPromptProvider.OLLAMA: {
-                const response = await ollama.chat({
+                const ollamaClient = new Ollama({
+                    host: providerConfig.baseUrl || 'http://127.0.0.1:11434'
+                })
+
+                const response = await ollamaClient.chat({
                     model: providerConfig.modelName,
                     messages: [
                         {

--- a/packages/ui/src/ui-component/extended/FollowUpPrompts.jsx
+++ b/packages/ui/src/ui-component/extended/FollowUpPrompts.jsx
@@ -270,6 +270,14 @@ const followUpPromptsOptions = {
         icon: ollamaIcon,
         inputs: [
             {
+                label: 'Base URL',
+                name: 'baseUrl',
+                type: 'string',
+                placeholder: 'http://127.0.0.1:11434',
+                description: 'Base URL of your Ollama instance',
+                default: 'http://127.0.0.1:11434'
+            },
+            {
                 label: 'Model Name',
                 name: 'modelName',
                 type: 'string',


### PR DESCRIPTION
When using Ollama for the follow-up prompts and you need to specify a different baseURL instead of  http://127.0.0.01:11434

This is especially usefull when:  

1. Flowise in running in Docker
2. Ollama is not used in the Chatflow but you still want to use it for follow-up prompts.