### PR TITLE
feat(Mem0): Add option to use Flowise Chat ID

### DIFF
--- a/packages/components/nodes/memory/Mem0/Mem0.ts
+++ b/packages/components/nodes/memory/Mem0/Mem0.ts
@@ -49,9 +49,17 @@ class Mem0_Memory implements INode {
                 label: 'User ID',
                 name: 'user_id',
                 type: 'string',
-                description: 'Unique identifier for the user',
+                description: 'Unique identifier for the user. Required only if "Use Flowise Chat ID" is OFF.',
                 default: 'flowise-default-user',
-                optional: false
+                optional: true
+            },
+            {
+                label: 'Use Flowise Chat ID',
+                name: 'useFlowiseChatId',
+                type: 'boolean',
+                description: 'Use the Flowise internal Chat ID as the Mem0 User ID, overriding the "User ID" field above.',
+                default: false,
+                optional: true
             },
             {
                 label: 'Search Only',
@@ -140,9 +148,11 @@ class Mem0_Memory implements INode {
 }
 
 const initializeMem0 = async (nodeData: INodeData, options: ICommonObject): Promise<BaseMem0Memory> => {
-    const userId = nodeData.inputs?.user_id as string
-    if (!userId) {
-        throw new Error('user_id is required for Mem0Memory')
+    const initialUserId = nodeData.inputs?.user_id as string
+    const useFlowiseChatId = nodeData.inputs?.useFlowiseChatId as boolean
+
+    if (!useFlowiseChatId && !initialUserId) {
+        throw new Error('User ID field cannot be empty when "Use Flowise Chat ID" is OFF.')
     }
 
     const credentialData = await getCredentialData(nodeData.credential ?? '', options)
@@ -155,8 +165,12 @@ const initializeMem0 = async (nodeData: INodeData, options: ICommonObject): Prom
         projectId: nodeData.inputs?.project_id as string
     }
 
+    const memOptionsUserId = initialUserId
+
+    const constructorSessionId = initialUserId || (useFlowiseChatId ? 'flowise-chat-id-placeholder' : '')
+
     const memoryOptions: MemoryOptions & SearchOptions = {
-        user_id: userId,
+        user_id: memOptionsUserId,
         run_id: (nodeData.inputs?.run_id as string) || undefined,
         agent_id: (nodeData.inputs?.agent_id as string) || undefined,
         app_id: (nodeData.inputs?.app_id as string) || undefined,
@@ -168,30 +182,34 @@ const initializeMem0 = async (nodeData: INodeData, options: ICommonObject): Prom
         filters: (nodeData.inputs?.filters as Record<string, any>) || {}
     }
 
-    const obj: Mem0MemoryInput & Mem0MemoryExtendedInput & BufferMemoryExtendedInput & { searchOnly: boolean } = {
-        apiKey: apiKey,
-        humanPrefix: nodeData.inputs?.humanPrefix as string,
-        aiPrefix: nodeData.inputs?.aiPrefix as string,
-        inputKey: nodeData.inputs?.inputKey as string,
-        sessionId: nodeData.inputs?.user_id as string,
-        mem0Options: mem0Options,
-        memoryOptions: memoryOptions,
-        separateMessages: false,
-        returnMessages: false,
-        appDataSource: options.appDataSource as DataSource,
-        databaseEntities: options.databaseEntities as IDatabaseEntity,
-        chatflowid: options.chatflowid as string,
-        searchOnly: (nodeData.inputs?.searchOnly as boolean) || false
-    }
+    const obj: Mem0MemoryInput & Mem0MemoryExtendedInput & BufferMemoryExtendedInput & { searchOnly: boolean; useFlowiseChatId: boolean } =
+        {
+            apiKey: apiKey,
+            humanPrefix: nodeData.inputs?.humanPrefix as string,
+            aiPrefix: nodeData.inputs?.aiPrefix as string,
+            inputKey: nodeData.inputs?.inputKey as string,
+            sessionId: constructorSessionId,
+            mem0Options: mem0Options,
+            memoryOptions: memoryOptions,
+            separateMessages: false,
+            returnMessages: false,
+            appDataSource: options.appDataSource as DataSource,
+            databaseEntities: options.databaseEntities as IDatabaseEntity,
+            chatflowid: options.chatflowid as string,
+            searchOnly: (nodeData.inputs?.searchOnly as boolean) || false,
+            useFlowiseChatId: useFlowiseChatId
+        }
 
     return new Mem0MemoryExtended(obj)
 }
 
 interface Mem0MemoryExtendedInput extends Mem0MemoryInput {
     memoryOptions?: MemoryOptions | SearchOptions
+    useFlowiseChatId: boolean
 }
 
 class Mem0MemoryExtended extends BaseMem0Memory implements MemoryMethods {
+    initialUserId: string
     userId: string
     memoryKey: string
     inputKey: string
@@ -199,38 +217,70 @@ class Mem0MemoryExtended extends BaseMem0Memory implements MemoryMethods {
     databaseEntities: IDatabaseEntity
     chatflowid: string
     searchOnly: boolean
+    useFlowiseChatId: boolean
 
-    constructor(fields: Mem0MemoryInput & Mem0MemoryExtendedInput & BufferMemoryExtendedInput & { searchOnly: boolean }) {
+    constructor(
+        fields: Mem0MemoryInput & Mem0MemoryExtendedInput & BufferMemoryExtendedInput & { searchOnly: boolean; useFlowiseChatId: boolean }
+    ) {
         super(fields)
-        this.userId = fields.memoryOptions?.user_id ?? ''
+        this.initialUserId = fields.memoryOptions?.user_id ?? ''
+        this.userId = this.initialUserId
         this.memoryKey = 'history'
         this.inputKey = fields.inputKey ?? 'input'
         this.appDataSource = fields.appDataSource
         this.databaseEntities = fields.databaseEntities
         this.chatflowid = fields.chatflowid
         this.searchOnly = fields.searchOnly
+        this.useFlowiseChatId = fields.useFlowiseChatId
+    }
+
+    private getEffectiveUserId(overrideUserId?: string): string {
+        let effectiveUserId: string | undefined
+
+        if (this.useFlowiseChatId) {
+            if (overrideUserId) {
+                effectiveUserId = overrideUserId
+            } else {
+                throw new Error('Mem0: "Use Flowise Chat ID" is ON, but no runtime chat ID (overrideUserId) was provided.')
+            }
+        } else {
+            // If toggle is OFF, ALWAYS use the ID from the input field.
+            effectiveUserId = this.initialUserId
+        }
+
+        // This check is now primarily for the case where the toggle is OFF and the initialUserId was somehow empty (should be caught by init validation).
+        if (!effectiveUserId) {
+            throw new Error('Mem0: Could not determine a valid User ID for the operation. Check User ID input field.')
+        }
+        return effectiveUserId
     }
 
     async loadMemoryVariables(values: InputValues, overrideUserId = ''): Promise<MemoryVariables> {
-        if (overrideUserId) {
-            this.userId = overrideUserId
+        const effectiveUserId = this.getEffectiveUserId(overrideUserId)
+        this.userId = effectiveUserId
+        if (this.memoryOptions) {
+            this.memoryOptions.user_id = effectiveUserId
         }
         return super.loadMemoryVariables(values)
     }
 
     async saveContext(inputValues: InputValues, outputValues: OutputValues, overrideUserId = ''): Promise<void> {
-        if (overrideUserId) {
-            this.userId = overrideUserId
-        }
         if (this.searchOnly) {
             return
+        }
+        const effectiveUserId = this.getEffectiveUserId(overrideUserId)
+        this.userId = effectiveUserId
+        if (this.memoryOptions) {
+            this.memoryOptions.user_id = effectiveUserId
         }
         return super.saveContext(inputValues, outputValues)
     }
 
     async clear(overrideUserId = ''): Promise<void> {
-        if (overrideUserId) {
-            this.userId = overrideUserId
+        const effectiveUserId = this.getEffectiveUserId(overrideUserId)
+        this.userId = effectiveUserId
+        if (this.memoryOptions) {
+            this.memoryOptions.user_id = effectiveUserId
         }
         return super.clear()
     }
@@ -240,12 +290,15 @@ class Mem0MemoryExtended extends BaseMem0Memory implements MemoryMethods {
         returnBaseMessages = false,
         prependMessages?: IMessage[]
     ): Promise<IMessage[] | BaseMessage[]> {
-        const id = overrideUserId ? overrideUserId : this.userId
-        if (!id) return []
+        const flowiseSessionId = overrideUserId
+        if (!flowiseSessionId) {
+            console.warn('Mem0: getChatMessages called without overrideUserId (Flowise Session ID). Cannot fetch DB messages.')
+            return []
+        }
 
         let chatMessage = await this.appDataSource.getRepository(this.databaseEntities['ChatMessage']).find({
             where: {
-                sessionId: id,
+                sessionId: flowiseSessionId,
                 chatflowid: this.chatflowid
             },
             order: {
@@ -260,24 +313,44 @@ class Mem0MemoryExtended extends BaseMem0Memory implements MemoryMethods {
         for (const m of chatMessage) {
             returnIMessages.push({
                 message: m.content as string,
-                type: m.role
+                type: m.role as MessageType
             })
         }
 
         if (prependMessages?.length) {
-            chatMessage.unshift(...prependMessages)
+            chatMessage.unshift(
+                ...prependMessages.map(
+                    (m) =>
+                        ({
+                            role: m.type,
+                            content: m.message,
+                            sessionId: flowiseSessionId,
+                            chatflowid: this.chatflowid,
+                            createdDate: new Date()
+                        } as any)
+                )
+            )
+            returnIMessages.unshift(...prependMessages)
         }
 
         if (returnBaseMessages) {
-            const memoryVariables = await this.loadMemoryVariables({}, id)
-            let baseMessages = memoryVariables[this.memoryKey]
+            const memoryVariables = await this.loadMemoryVariables({}, overrideUserId)
+            const mem0History = memoryVariables[this.memoryKey]
 
-            const systemMessage = { ...chatMessage[0] }
-            systemMessage.content = baseMessages
-            systemMessage.id = uuidv4()
-            systemMessage.role = 'apiMessage'
+            if (mem0History && typeof mem0History === 'string') {
+                const systemMessage = {
+                    role: 'apiMessage' as MessageType,
+                    content: mem0History,
+                    id: uuidv4(),
+                    sessionId: flowiseSessionId,
+                    chatflowid: this.chatflowid,
+                    createdDate: new Date()
+                }
+                chatMessage.unshift(systemMessage as any)
+            } else if (mem0History) {
+                console.warn('Mem0 history is not a string, cannot prepend directly.')
+            }
 
-            chatMessage.unshift(systemMessage)
             return await mapChatMessageToBaseMessage(chatMessage)
         }
 
@@ -285,18 +358,31 @@ class Mem0MemoryExtended extends BaseMem0Memory implements MemoryMethods {
     }
 
     async addChatMessages(msgArray: { text: string; type: MessageType }[], overrideUserId = ''): Promise<void> {
-        const id = overrideUserId ? overrideUserId : this.userId
+        const effectiveUserId = this.getEffectiveUserId(overrideUserId)
         const input = msgArray.find((msg) => msg.type === 'userMessage')
         const output = msgArray.find((msg) => msg.type === 'apiMessage')
-        const inputValues = { [this.inputKey ?? 'input']: input?.text }
-        const outputValues = { output: output?.text }
 
-        await this.saveContext(inputValues, outputValues, id)
+        if (input && output) {
+            const inputValues = { [this.inputKey ?? 'input']: input.text }
+            const outputValues = { output: output.text }
+            await this.saveContext(inputValues, outputValues, effectiveUserId)
+        } else {
+            console.warn('Mem0: Could not find both input and output messages to save context.')
+        }
     }
 
     async clearChatMessages(overrideUserId = ''): Promise<void> {
-        const id = overrideUserId ? overrideUserId : this.userId
-        await this.clear(id)
+        const effectiveUserId = this.getEffectiveUserId(overrideUserId)
+        await this.clear(effectiveUserId)
+
+        const flowiseSessionId = overrideUserId
+        if (flowiseSessionId) {
+            await this.appDataSource
+                .getRepository(this.databaseEntities['ChatMessage'])
+                .delete({ sessionId: flowiseSessionId, chatflowid: this.chatflowid })
+        } else {
+            console.warn('Mem0: clearChatMessages called without overrideUserId (Flowise Session ID). Cannot clear DB messages.')
+        }
     }
 }
 


### PR DESCRIPTION
**Description:**

This PR enhances the Mem0 memory node by adding a new toggle option: "Use Flowise Chat ID".

*   **When Enabled:** The node will ignore the hardcoded "User ID" input field and use the internal Flowise `chatId` (session ID) as the `user_id` for all Mem0 operations (saving context, loading variables, clearing memory).
*   **When Disabled (Default):** The node behaves as before, using the value provided in the "User ID" input field for Mem0 operations.

**Changes:**

*   Added a "Use Flowise Chat ID" boolean input toggle to the Mem0 node UI.
*   Updated internal logic (`getEffectiveUserId`) to select the correct ID (Flowise `chatId` or the input field value) based on the toggle state.
*   The "User ID" input field is now only strictly required if the "Use Flowise Chat ID" toggle is disabled.

This provides users with more flexibility, allowing them to easily tie Mem0 memory directly to Flowise chat sessions without manual configuration if desired.

![image](https://github.com/user-attachments/assets/761c609f-ae06-49a6-a172-6c651b43d97d)

![image](https://github.com/user-attachments/assets/a2331104-8d46-441e-95a8-8867ab4d4738)
