### PR TITLE
docs: add ClawCloud Run button

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ Deploy Flowise self-hosted in your existing infrastructure, we support various [
 
         [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=29)
 
+    -   [ClawCloud Run](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
+        [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
       </details>
 
 ## ☁️ Flowise Cloud

--- a/i18n/README-JA.md
+++ b/i18n/README-JA.md
@@ -178,6 +178,10 @@ Flowise は、インスタンスを設定するためのさまざまな環境変
 
         [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=29)
 
+    -   [ClawCloud Run](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
+        [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
       </details>
 
 ## ☁️ クラウドホスト

--- a/i18n/README-KR.md
+++ b/i18n/README-KR.md
@@ -178,6 +178,10 @@ Flowise는 인스턴스 구성을 위한 다양한 환경 변수를 지원합니
 
         [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=29)
 
+    -   [ClawCloud Run](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
+        [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
       </details>
 
 ## ☁️ 클라우드 호스팅 서비스

--- a/i18n/README-TW.md
+++ b/i18n/README-TW.md
@@ -190,6 +190,10 @@ Flowise 支持不同的環境變量來配置您的實例。您可以在 `package
 
         [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=29)
 
+    -   [ClawCloud Run](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
+        [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
       </details>
 
 ## ☁️ Flowise 雲

--- a/i18n/README-ZH.md
+++ b/i18n/README-ZH.md
@@ -178,6 +178,10 @@ Flowise 支持不同的环境变量来配置您的实例。您可以在 `package
 
         [![部署到 RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=29)
 
+    -   [ClawCloud Run](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
+        [![部署到 ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=NHQHBCNFBJGI&openapp=system-fastdeploy%3FtemplateName%3Dflowise)
+
       </details>
 
 ## ☁️ 云托管


### PR DESCRIPTION
docs: add ClawCloud Run button

---
We are **ClawCloud Run** — a cloud-native deployment platform where users can deploy your application with one click. The referral code within the deployment link is just for anonymous traffic analytics in order to improve our platform. If you’d like to use your own code, just sign up on ClawCloud Run and replace it in seconds.