### PR TITLE
feat:Adds new Param in getChatMessages for better context handling

### DIFF
--- a/packages/components/nodes/chains/ConversationChain/ConversationChain.ts
+++ b/packages/components/nodes/chains/ConversationChain/ConversationChain.ts
@@ -24,7 +24,8 @@ import {
     INodeData,
     INodeParams,
     MessageContentImageUrl,
-    IServerSideEventStreamer
+    IServerSideEventStreamer,
+    IMessage
 } from '../../../src/Interface'
 import { ConsoleCallbackHandler, CustomChainHandler, additionalCallbacks } from '../../../src/handler'
 import { getBaseClasses, handleEscapeCharacters, transformBracesWithColon } from '../../../src/utils'
@@ -260,8 +261,14 @@ const prepareChain = async (nodeData: INodeData, options: ICommonObject, session
     const conversationChain = RunnableSequence.from([
         {
             [inputKey]: (input: { input: string }) => input.input,
-            [memoryKey]: async () => {
-                const history = await memory.getChatMessages(sessionId, true, prependMessages)
+            [memoryKey]: async (input: { input: string }) => {
+                const currentMessages = [
+                    {
+                        message: input.input,
+                        type: 'userMessage'
+                    }
+                ] as IMessage[]
+                const history = await memory.getChatMessages(sessionId, true, prependMessages, currentMessages)
                 return history
             },
             ...promptVariables

--- a/packages/components/nodes/memory/Mem0/Mem0.ts
+++ b/packages/components/nodes/memory/Mem0/Mem0.ts
@@ -290,7 +290,8 @@ class Mem0MemoryExtended extends BaseMem0Memory implements MemoryMethods {
     async getChatMessages(
         overrideUserId = '',
         returnBaseMessages = false,
-        prependMessages?: IMessage[]
+        prependMessages?: IMessage[],
+        currentMessages?: IMessage[]
     ): Promise<IMessage[] | BaseMessage[]> {
         const flowiseSessionId = overrideUserId
         if (!flowiseSessionId) {
@@ -322,7 +323,12 @@ class Mem0MemoryExtended extends BaseMem0Memory implements MemoryMethods {
         }
 
         if (returnBaseMessages) {
-            const memoryVariables = await this.loadMemoryVariables({}, overrideUserId)
+            const memoryVariables = await this.loadMemoryVariables(
+                {
+                    [this.inputKey]: currentMessages?.[0]?.message ?? ''
+                },
+                overrideUserId
+            )
             const mem0History = memoryVariables[this.memoryKey]
 
             if (mem0History && typeof mem0History === 'string') {

--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -347,7 +347,8 @@ export abstract class FlowiseMemory extends BufferMemory implements MemoryMethod
     abstract getChatMessages(
         overrideSessionId?: string,
         returnBaseMessages?: boolean,
-        prependMessages?: IMessage[]
+        prependMessages?: IMessage[],
+        currentMessages?: IMessage[]
     ): Promise<IMessage[] | BaseMessage[]>
     abstract addChatMessages(msgArray: { text: string; type: MessageType }[], overrideSessionId?: string): Promise<void>
     abstract clearChatMessages(overrideSessionId?: string): Promise<void>


### PR DESCRIPTION
This is a proposal to introduce a new parameter in the `getChatMessages` function that allows us to retrieve the latest user message, enabling more accurate memory retrieval. Currently, Mem0 Memory uses `get_all` to fetch all user memories, but this change would allow us to perform a semantic search, which is more efficient for handling context.

I'd like to understand if there's a better approach to achieve this, and whether it makes sense to apply the same logic to other components as well. Thanks!

### Changelog

- Enhanced `getChatMessages` Method: Introduced a new parameter `currentMessages` to allow for dynamic message retrieval based on the latest user input, improving the context handling during chat sessions.
- Improved Message Handling: Updated logic to prepend messages from `currentMessages` to the chat history, ensuring that the latest user input is considered when fetching the memories.