### PR TITLE
fix : data persistence issue while saving config in documentStore

### DIFF
--- a/packages/server/src/Interface.DocumentStore.ts
+++ b/packages/server/src/Interface.DocumentStore.ts
@@ -249,31 +249,68 @@ export class DocumentStoreDTO {
         documentStoreDTO.totalChunks = 0
 
         if (entity.whereUsed) {
-            documentStoreDTO.whereUsed = JSON.parse(entity.whereUsed)
+            try {
+                documentStoreDTO.whereUsed = JSON.parse(entity.whereUsed)
+            } catch (e) {
+                documentStoreDTO.whereUsed = []
+            }
         } else {
             documentStoreDTO.whereUsed = []
         }
 
         if (entity.vectorStoreConfig) {
-            documentStoreDTO.vectorStoreConfig = JSON.parse(entity.vectorStoreConfig)
+            try {
+                documentStoreDTO.vectorStoreConfig = JSON.parse(entity.vectorStoreConfig)
+            } catch (e) {
+                // If it's already an object, use it directly
+                if (typeof entity.vectorStoreConfig === 'object') {
+                    documentStoreDTO.vectorStoreConfig = entity.vectorStoreConfig
+                } else {
+                    documentStoreDTO.vectorStoreConfig = null
+                }
+            }
         }
+
         if (entity.embeddingConfig) {
-            documentStoreDTO.embeddingConfig = JSON.parse(entity.embeddingConfig)
+            try {
+                documentStoreDTO.embeddingConfig = JSON.parse(entity.embeddingConfig)
+            } catch (e) {
+                // If it's already an object, use it directly
+                if (typeof entity.embeddingConfig === 'object') {
+                    documentStoreDTO.embeddingConfig = entity.embeddingConfig
+                } else {
+                    documentStoreDTO.embeddingConfig = null
+                }
+            }
         }
+
         if (entity.recordManagerConfig) {
-            documentStoreDTO.recordManagerConfig = JSON.parse(entity.recordManagerConfig)
+            try {
+                documentStoreDTO.recordManagerConfig = JSON.parse(entity.recordManagerConfig)
+            } catch (e) {
+                // If it's already an object, use it directly
+                if (typeof entity.recordManagerConfig === 'object') {
+                    documentStoreDTO.recordManagerConfig = entity.recordManagerConfig
+                } else {
+                    documentStoreDTO.recordManagerConfig = null
+                }
+            }
         }
 
         if (entity.loaders) {
-            documentStoreDTO.loaders = JSON.parse(entity.loaders)
-            documentStoreDTO.loaders.map((loader) => {
-                documentStoreDTO.totalChars += loader.totalChars || 0
-                documentStoreDTO.totalChunks += loader.totalChunks || 0
-                loader.source = addLoaderSource(loader)
-                if (loader.status !== 'SYNC') {
-                    documentStoreDTO.status = DocumentStoreStatus.STALE
-                }
-            })
+            try {
+                documentStoreDTO.loaders = JSON.parse(entity.loaders)
+                documentStoreDTO.loaders.map((loader) => {
+                    documentStoreDTO.totalChars += loader.totalChars || 0
+                    documentStoreDTO.totalChunks += loader.totalChunks || 0
+                    loader.source = addLoaderSource(loader)
+                    if (loader.status !== 'SYNC') {
+                        documentStoreDTO.status = DocumentStoreStatus.STALE
+                    }
+                })
+            } catch (e) {
+                documentStoreDTO.loaders = []
+            }
         }
 
         return documentStoreDTO

--- a/packages/server/src/controllers/documentstore/index.ts
+++ b/packages/server/src/controllers/documentstore/index.ts
@@ -334,8 +334,7 @@ const saveVectorStoreConfig = async (req: Request, res: Response, next: NextFunc
         }
         const body = req.body
         const appDataSource = getRunningExpressApp().AppDataSource
-        const componentNodes = getRunningExpressApp().nodesPool.componentNodes
-        const apiResponse = await documentStoreService.saveVectorStoreConfig(appDataSource, componentNodes, body)
+        const apiResponse = await documentStoreService.saveVectorStoreConfig(appDataSource, body)
         return res.json(apiResponse)
     } catch (error) {
         next(error)

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1000,63 +1000,31 @@ const updateVectorStoreConfigOnly = async (data: ICommonObject) => {
 const saveVectorStoreConfig = async (appDataSource: DataSource, data: ICommonObject, isStrictSave = true) => {
     try {
         const entity = await appDataSource.getRepository(DocumentStore).findOneBy({
-            id: data.storeId
+            id: data.id || data.storeId // Support both id and storeId
         })
-        if (!entity) {
-            throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Document store ${data.storeId} not found`)
+
+        if (!entity) throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `Document Store ${data.id || data.storeId} not found`)
+
+        if (data.embeddingConfig) {
+            entity.embeddingConfig = typeof data.embeddingConfig === 'string' ? data.embeddingConfig : JSON.stringify(data.embeddingConfig)
+        }
+        if (data.vectorStoreConfig) {
+            entity.vectorStoreConfig =
+                typeof data.vectorStoreConfig === 'string' ? data.vectorStoreConfig : JSON.stringify(data.vectorStoreConfig)
+        }
+        if (data.recordManagerConfig) {
+            entity.recordManagerConfig =
+                typeof data.recordManagerConfig === 'string' ? data.recordManagerConfig : JSON.stringify(data.recordManagerConfig)
         }
 
-        if (data.embeddingName) {
-            entity.embeddingConfig = JSON.stringify({
-                config: data.embeddingConfig,
-                name: data.embeddingName
-            })
-        } else if (entity.embeddingConfig && !data.embeddingName && !data.embeddingConfig) {
-            data.embeddingConfig = JSON.parse(entity.embeddingConfig)?.config
-            data.embeddingName = JSON.parse(entity.embeddingConfig)?.name
-            if (isStrictSave) entity.embeddingConfig = null
-        } else if (!data.embeddingName && !data.embeddingConfig) {
-            entity.embeddingConfig = null
-        }
-
-        if (data.vectorStoreName) {
-            entity.vectorStoreConfig = JSON.stringify({
-                config: data.vectorStoreConfig,
-                name: data.vectorStoreName
-            })
-        } else if (entity.vectorStoreConfig && !data.vectorStoreName && !data.vectorStoreConfig) {
-            data.vectorStoreConfig = JSON.parse(entity.vectorStoreConfig)?.config
-            data.vectorStoreName = JSON.parse(entity.vectorStoreConfig)?.name
-            if (isStrictSave) entity.vectorStoreConfig = null
-        } else if (!data.vectorStoreName && !data.vectorStoreConfig) {
-            entity.vectorStoreConfig = null
-        }
-
-        if (data.recordManagerName) {
-            entity.recordManagerConfig = JSON.stringify({
-                config: data.recordManagerConfig,
-                name: data.recordManagerName
-            })
-        } else if (entity.recordManagerConfig && !data.recordManagerName && !data.recordManagerConfig) {
-            data.recordManagerConfig = JSON.parse(entity.recordManagerConfig)?.config
-            data.recordManagerName = JSON.parse(entity.recordManagerConfig)?.name
-            if (isStrictSave) entity.recordManagerConfig = null
-        } else if (!data.recordManagerName && !data.recordManagerConfig) {
-            entity.recordManagerConfig = null
-        }
-
-        if (entity.status !== DocumentStoreStatus.UPSERTED && (data.vectorStoreName || data.recordManagerName || data.embeddingName)) {
-            // if the store is not already in sync, mark it as sync
-            // this also means that the store is not yet sync'ed to vector store
+        if (entity.status !== DocumentStoreStatus.UPSERTED) {
             entity.status = DocumentStoreStatus.SYNC
         }
-        await appDataSource.getRepository(DocumentStore).save(entity)
-        return entity
-    } catch (error) {
-        throw new InternalFlowiseError(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            `Error: documentStoreServices.saveVectorStoreConfig - ${getErrorMessage(error)}`
-        )
+
+        const savedEntity = await appDataSource.getRepository(DocumentStore).save(entity)
+        return savedEntity
+    } catch (e) {
+        throw e
     }
 }
 
@@ -1836,14 +1804,13 @@ const generateDocStoreToolDesc = async (docStoreId: string, selectedChatModel: I
         if (!chunks?.length) {
             throw new InternalFlowiseError(StatusCodes.NOT_FOUND, `DocumentStore ${docStoreId} chunks not found`)
         }
-
         // sort the chunks by chunkNo
-        chunks.sort((a, b) => a.chunkNo - b.chunkNo)
+        chunks.sort((a: DocumentStoreFileChunk, b: DocumentStoreFileChunk) => a.chunkNo - b.chunkNo)
 
         // get the first 4 chunks
         const chunksPageContent = chunks
             .slice(0, 4)
-            .map((chunk) => {
+            .map((chunk: DocumentStoreFileChunk) => {
                 return chunk.pageContent
             })
             .join('\n')


### PR DESCRIPTION
> This PR fixes the issue #4243  of data persistence in document storage 

To Reproduce

Go to 'Document Store' screen
Create new Document Store
Create a basic loader (can be Text File Document Loader) with some random text
Click on "Process".
Go to 'Upsert All Chunks' screen
Configure Embeddings, Vector Store and Record Manager data
Click on 'Save Config'
Go back to previous screen
Go to 'Upsert All Chunks' screen again
Expected behavior
Al the settings would be there, but the config screen is empty.


Below is the image before fix
<img width="1433" alt="Screenshot 2025-04-09 at 11 53 40 PM" src="https://github.com/user-attachments/assets/7bf409f7-ad9a-4cfb-a655-b79d4572a9be" />

after the changes now we can see that the configuration data in persistant, please see it in attachment below
<img width="1433" alt="Screenshot 2025-04-09 at 11 59 04 PM" src="https://github.com/user-attachments/assets/1cd0099c-be8a-4d9f-8822-112abba76407" />

Root Cause:
1)Frontend sent `storeId` but backend expected` id`
2) The configuration objects weren't formatted correctly
3)JSON parsing failures weren't handled gracefully
4)The system couldn't handle both string and object configurations


Solution:
1)Fixed parameter names to ensure proper data transfer between frontend and backend
2)Restructured the configuration data format for consistent handling
3)Improved type handling to work with both string and object configuration formats

