### PR TITLE
Fix(FlowiseChatGoogleGenerativeAI): 400 Bad Request errors from Gemini API when converting tool schemas - MCP tools.

### DIFF
--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
@@ -644,6 +644,8 @@ function convertResponseContentToChatGenerationChunk(
 }
 
 function zodToGeminiParameters(zodObj: any) {
+    // Gemini doesn't accept either the $schema or additionalProperties
+    // attributes, so we need to explicitly remove them.
     const jsonSchema: any = zodToJsonSchema(zodObj)
     // eslint-disable-next-line unused-imports/no-unused-vars
     const { $schema, additionalProperties, ...rest } = jsonSchema

--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
@@ -644,18 +644,42 @@ function convertResponseContentToChatGenerationChunk(
 }
 
 function zodToGeminiParameters(zodObj: any) {
-    // Gemini doesn't accept either the $schema or additionalProperties
-    // attributes, so we need to explicitly remove them.
     const jsonSchema: any = zodToJsonSchema(zodObj)
     // eslint-disable-next-line unused-imports/no-unused-vars
     const { $schema, additionalProperties, ...rest } = jsonSchema
+
+    // Ensure all properties have type specified
     if (rest.properties) {
         Object.keys(rest.properties).forEach((key) => {
-            if (rest.properties[key].enum?.length) {
-                rest.properties[key] = { type: 'string', format: 'enum', enum: rest.properties[key].enum }
+            const prop = rest.properties[key]
+
+            // Handle enum types
+            if (prop.enum?.length) {
+                rest.properties[key] = {
+                    type: 'string',
+                    format: 'enum',
+                    enum: prop.enum
+                }
+            }
+            // Handle missing type
+            else if (!prop.type && !prop.oneOf && !prop.anyOf && !prop.allOf) {
+                // Infer type from other properties
+                if (prop.minimum !== undefined || prop.maximum !== undefined) {
+                    prop.type = 'number'
+                } else if (prop.format === 'date-time') {
+                    prop.type = 'string'
+                } else if (prop.items) {
+                    prop.type = 'array'
+                } else if (prop.properties) {
+                    prop.type = 'object'
+                } else {
+                    // Default to string if type can't be inferred
+                    prop.type = 'string'
+                }
             }
         })
     }
+
     return rest
 }
 


### PR DESCRIPTION
## Issue
This PR fixes the 400 Bad Request errors when using function calling with Gemini API when MCP tools are used. The main issue was that some properties in the tool schemas were missing explicit type definitions when converting from Zod schemas to Gemini's function declarations format.

![image](https://github.com/user-attachments/assets/fd498de6-ce1e-446c-bcca-eb87dd1ccdae)


### Changes
- Enhanced `zodToGeminiParameters` function to properly infer types
- Added explicit handling for enum types
- Improved type inference based on property characteristics
- Added fallback to string type when type cannot be inferred

### Breaking Changes
None. This is a backward compatible enhancement to the existing functionality.