### PR TITLE
add history chat timestamp in mongodb

### DIFF
--- a/packages/components/nodes/memory/MongoDBMemory/MongoDBMemory.ts
+++ b/packages/components/nodes/memory/MongoDBMemory/MongoDBMemory.ts
@@ -155,7 +155,10 @@ class BufferMemoryExtended extends FlowiseMemory implements MemoryMethods {
 
         if (input) {
             const newInputMessage = new HumanMessage(input.text)
-            const messageToAdd = [newInputMessage].map((msg) => msg.toDict())
+            const messageToAdd = [newInputMessage].map((msg) => ({
+                ...msg.toDict(),
+                timestamp: new Date() // Add timestamp to the message
+            }))
             await collection.updateOne(
                 { sessionId: id },
                 {
@@ -167,7 +170,10 @@ class BufferMemoryExtended extends FlowiseMemory implements MemoryMethods {
 
         if (output) {
             const newOutputMessage = new AIMessage(output.text)
-            const messageToAdd = [newOutputMessage].map((msg) => msg.toDict())
+            const messageToAdd = [newOutputMessage].map((msg) => ({
+                ...msg.toDict(),
+                timestamp: new Date() // Add timestamp to the message
+            }))
             await collection.updateOne(
                 { sessionId: id },
                 {


### PR DESCRIPTION
Adding chat history timestamp in mongodb for timeseries data monitoring.
<img width="730" alt="image" src="https://github.com/user-attachments/assets/d1e698a2-e42d-402a-9782-63e1ae686bbd" />
