### PR TITLE
feat: Add GPT-4.1 series models support

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -236,6 +236,10 @@
             "name": "azureChatOpenAI",
             "models": [
                 {
+                    "label": "gpt-4.1",
+                    "name": "gpt-4.1"
+                },
+                {
                     "label": "o3-mini",
                     "name": "o3-mini"
                 },

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -620,6 +620,18 @@
             "name": "chatOpenAI",
             "models": [
                 {
+                    "label": "gpt-4.1",
+                    "name": "gpt-4.1"
+                },
+                {
+                    "label": "gpt-4.1-mini",
+                    "name": "gpt-4.1-mini"
+                },
+                {
+                    "label": "gpt-4.1-nano",
+                    "name": "gpt-4.1-nano"
+                },
+                {
                     "label": "gpt-4.5-preview",
                     "name": "gpt-4.5-preview"
                 },

--- a/packages/ui/src/views/assistants/openai/AssistantDialog.jsx
+++ b/packages/ui/src/views/assistants/openai/AssistantDialog.jsx
@@ -47,6 +47,18 @@ import { maxScroll } from '@/store/constant'
 
 const assistantAvailableModels = [
     {
+        label: 'gpt-4.1',
+        name: 'gpt-4.1'
+    },
+    {
+        label: 'gpt-4.1-mini',
+        name: 'gpt-4.1-mini'
+    },
+    {
+        label: 'gpt-4.1-nano',
+        name: 'gpt-4.1-nano'
+    },
+    {
         label: 'gpt-4.5-preview',
         name: 'gpt-4.5-preview'
     },


### PR DESCRIPTION
This PR adds support for OpenAI's new GPT-4.1 series models in the OpenAI Assistant Dialog. The following models have been added:
- `gpt-4.1`
- `gpt-4.1-mini`
- `gpt-4.1-nano`

## Changes Made
- Added new GPT-4.1 series models to the available models list in AssistantDialog.jsx
- Updated models.json to include the new model options
- Positioned the new models at the top of the list to indicate they are the latest additions

## Testing
- Verified that the new models appear in the dropdown list
- Confirmed that they can be selected when creating or editing an assistant
- Ensured existing functionality remains unchanged

## Additional Notes
These new models represent OpenAI's latest advancements in their model lineup, offering improved capabilities and performance for different use cases:
- `gpt-4.1`: Flagship GPT model for complex tasks
- `gpt-4.1-mini`: Balanced for intelligence, speed, and cost
- `gpt-4.1-nano`: Fastest, most cost-effective GPT-4.1 model

More Details: https://openai.com/index/gpt-4-1/