### PR TITLE
fix: update correct label for InputLabel component

### DIFF
--- a/packages/ui/src/views/marketplaces/index.jsx
+++ b/packages/ui/src/views/marketplaces/index.jsx
@@ -426,7 +426,7 @@ const Marketplace = () => {
                                             multiple
                                             value={badgeFilter}
                                             onChange={handleBadgeFilterChange}
-                                            input={<OutlinedInput label='Badge' />}
+                                            input={<OutlinedInput label='Tag' />}
                                             renderValue={(selected) => selected.join(', ')}
                                             MenuProps={MenuProps}
                                             sx={SelectStyles}
@@ -462,7 +462,7 @@ const Marketplace = () => {
                                             multiple
                                             value={typeFilter}
                                             onChange={handleTypeFilterChange}
-                                            input={<OutlinedInput label='Badge' />}
+                                            input={<OutlinedInput label='Type' />}
                                             renderValue={(selected) => selected.join(', ')}
                                             MenuProps={MenuProps}
                                             sx={SelectStyles}
@@ -498,7 +498,7 @@ const Marketplace = () => {
                                             multiple
                                             value={frameworkFilter}
                                             onChange={handleFrameworkFilterChange}
-                                            input={<OutlinedInput label='Badge' />}
+                                            input={<OutlinedInput label='Framework' />}
                                             renderValue={(selected) => selected.join(', ')}
                                             MenuProps={MenuProps}
                                             sx={SelectStyles}


### PR DESCRIPTION
Noticed minor UI issue while exploring Flowise.

Issue:
On the Marketplace page, the label provided to the OutlinedInput component is incorrect, which causes the "Framework" label to overlap with the input border. Additionally, for other Select fields like "Tag" and "Type", there is extra spacing between the label and the border. (Please see the attached screenshot for reference.)

**Before**:
<img width="856" alt="Screenshot 2025-05-02 at 7 59 31 AM" src="https://github.com/user-attachments/assets/62cf1310-4935-44f8-9c2a-f93b93188864" />


**After**:
<img width="888" alt="image" src="https://github.com/user-attachments/assets/624f1deb-0416-4065-b96e-317999d63e94" />


