### PR TITLE
Fix(PostgresRecordManager): Handle time correctly and ensure schema creation

### DIFF
--- a/packages/components/nodes/recordmanager/PostgresRecordManager/PostgresRecordManager.ts
+++ b/packages/components/nodes/recordmanager/PostgresRecordManager/PostgresRecordManager.ts
@@ -227,6 +227,8 @@ class PostgresRecordManager implements RecordManagerInterface {
             const queryRunner = dataSource.createQueryRunner()
             const tableName = this.sanitizeTableName(this.tableName)
 
+            await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pgcrypto;')
+
             await queryRunner.manager.query(`
   CREATE TABLE IF NOT EXISTS "${tableName}" (
     uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -258,9 +260,9 @@ class PostgresRecordManager implements RecordManagerInterface {
         const dataSource = await this.getDataSource()
         try {
             const queryRunner = dataSource.createQueryRunner()
-            const res = await queryRunner.manager.query('SELECT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)')
+            const res = await queryRunner.manager.query('SELECT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) AS now')
             await queryRunner.release()
-            return Number.parseFloat(res[0].extract)
+            return Number.parseFloat(res[0].now)
         } catch (error) {
             console.error('Error getting time in PostgresRecordManager:')
             throw error


### PR DESCRIPTION
**Problem:**

The `PostgresRecordManager` node experienced two main issues:

1.  **Incorrect Time Handling:** The `getTime()` method used the query `SELECT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)` without aliasing the result column. This caused `res[0].now` to be `undefined` in the subsequent code, leading to a`NaN` value in the database. This `NaN` value was then stored in the `updated_at` column, causing incorrect record tracking, cleanup behavior, and indexing issues.
2.  **Schema Creation Failure on Older PostgreSQL:** The `createSchema()` method uses `gen_random_uuid()` in its `CREATE TABLE` statement. On older PostgreSQL versions (prior to v13), this function is only available via the `pgcrypto` extension. The node did not ensure this extension was enabled, leading to failures when initializing the node against such database versions.

This issue is tracked in #4339 

**Solution:**

This PR addresses the identified problems with the following changes to `packages/components/nodes/recordmanager/PostgresRecordManager/PostgresRecordManager.ts`:

1.  **Correct Time Handling:** Added the `AS now` alias to the `EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)` query within the `getTime()` method. This ensures the result column is correctly named, `res[0].now` is populated with the epoch value, and `Number.parseFloat()` returns a valid number instead of `NaN`.
2.  **Ensure `pgcrypto` Extension:** Added the `CREATE EXTENSION IF NOT EXISTS pgcrypto;` command within the `createSchema()` method, executed just before the `CREATE TABLE` statement. This ensures the `gen_random_uuid()` function is available, providing backward compatibility for PostgreSQL versions prior to v13 where the function is not built-in. The `IF NOT EXISTS` clause makes this command safe – it causes no errors or side effects on newer PostgreSQL versions (>=13, where the function is built-in) or if the extension is already enabled for other reasons.

**Testing:**

-   Successfully reproduced the `NaN` value being generated for `updated_at` when the `AS now` alias was missing. Verified that adding the alias correctly produces a numeric timestamp.
-   Confirmed that adding `CREATE EXTENSION IF NOT EXISTS pgcrypto;` allows the node to initialize and create its schema correctly. Tested against PostgreSQL v17.4 where the command executes harmlessly due to `IF NOT EXISTS`. The change ensures compatibility for users on older PostgreSQL versions requiring the extension.

**Closes:**

Fixes #4339
Potentially other ones too.