### PR TITLE
bugfix: set Custom Model Name field as optional

### DIFF
--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/ChatGoogleGenerativeAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/ChatGoogleGenerativeAI.ts
@@ -62,7 +62,8 @@ class GoogleGenerativeAI_ChatModels implements INode {
                 type: 'string',
                 placeholder: 'gemini-1.5-pro-exp-0801',
                 description: 'Custom model name to use. If provided, it will override the model selected',
-                additionalParams: true
+                additionalParams: true,
+                optional: true
             },
             {
                 label: 'Temperature',


### PR DESCRIPTION
This PR sets the Custom Model Name field as optional when using ChatGoogleGenerativeAI in the Custom Assistant feature.

Before this PR:
![image](https://github.com/user-attachments/assets/a25707f9-1117-4c68-a9ae-27580485aac7)
After this PR:
![image](https://github.com/user-attachments/assets/9c30f101-9fa0-4f7f-983f-3b7c7379f88f)


Closes https://github.com/FlowiseAI/Flowise/issues/4322
