### PR TITLE
BugFix/Patch: PostGreSQL Record Manager

### DIFF
--- a/packages/components/nodes/recordmanager/PostgresRecordManager/PostgresRecordManager.ts
+++ b/packages/components/nodes/recordmanager/PostgresRecordManager/PostgresRecordManager.ts
@@ -258,9 +258,9 @@ class PostgresRecordManager implements RecordManagerInterface {
         const dataSource = await this.getDataSource()
         try {
             const queryRunner = dataSource.createQueryRunner()
-            const res = await queryRunner.manager.query('SELECT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) AS now')
+            const res = await queryRunner.manager.query('SELECT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) AS extract')
             await queryRunner.release()
-            return Number.parseFloat(res[0].now)
+            return Number.parseFloat(res[0].extract)
         } catch (error) {
             console.error('Error getting time in PostgresRecordManager:')
             throw error


### PR DESCRIPTION
In #4381 I proposed a fix for time handling and schema creation in PostgresRecordManager.

However, I made a mistake there. The `CREATE EXTENSION IF NOT EXISTS pgcrypto;` line causes failures on Azure Database for PostgreSQL Flexible Server where such commands are blocked, even if the extension is already installed. Therefore, this PR removes that line.

It also updates the `getTime()` query to use `AS extract` instead of `AS now`, in order to preserve 100% backward compatibility with existing code that expects `res[0].extract`.