### PR TITLE
bugfix: change field to be optional

### DIFF
--- a/packages/components/nodes/chatmodels/ChatGoogleVertexAI/ChatGoogleVertexAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleVertexAI/ChatGoogleVertexAI.ts
@@ -99,7 +99,8 @@ class GoogleVertexAI_ChatModels implements INode {
                 type: 'string',
                 placeholder: 'gemini-1.5-pro-exp-0801',
                 description: 'Custom model name to use. If provided, it will override the model selected',
-                additionalParams: true
+                additionalParams: true,
+                optional: true
             },
             {
                 label: 'Temperature',


### PR DESCRIPTION
Today, the customModelName field is not optional, despite the message indicating that it should be. This PR makes this field optional.

How it is currently before this PR:
![image](https://github.com/user-attachments/assets/3ce1cbf3-fcad-4446-a865-dff6f87afc6e)
