### PR TITLE
fix: allow non-UUID sessionId by changing column type to varchar

### DIFF
--- a/packages/server/src/database/entities/Execution.ts
+++ b/packages/server/src/database/entities/Execution.ts
@@ -18,7 +18,7 @@ export class Execution implements IExecution {
     agentflowId: string
 
     @Index()
-    @Column({ type: 'uuid' })
+    @Column({ type: 'varchar' })
     sessionId: string
 
     @Column({ nullable: true, type: 'text' })


### PR DESCRIPTION
This change updates the sessionId column in the Execution entity from uuid to varchar, allowing strings (e.g. phone number, email, custom IDs) to be used as session identifiers without errors.

While this behavior already works when using a Chatflow, Agentflow relies on the execution table — which previously enforced a UUID type. As a result, sending a string would cause the following error:

QueryFailedError: invalid input syntax for type uuid: "some_string"

This change fixes that inconsistency without breaking any existing functionality.