### PR TITLE
Feature: add missing chat mistral ai models

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1207,6 +1207,18 @@
                     "name": "mistral-large-2402",
                     "input_cost": 0.002,
                     "output_cost": 0.006
+                },
+                {
+                    "label": "codestral-latsest",
+                    "name": "codestral-latest",
+                    "input_cost": 0.0002,
+                    "output_cost": 0.0006
+                },
+                {
+                    "label": "devstral-small-2505",
+                    "name": "devstral-small-2505",
+                    "input_cost": 0.0001,
+                    "output_cost": 0.0003                
                 }
             ]
         },

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1228,7 +1228,7 @@
                     "label": "devstral-small-2505",
                     "name": "devstral-small-2505",
                     "input_cost": 0.0001,
-                    "output_cost": 0.0003                
+                    "output_cost": 0.0003
                 }
             ]
         },


### PR DESCRIPTION
Closes #4484 
**Description:**
This PR adds support for two additional models to the ChatMistralAI integration:

- [x] codestral-latest
- [x] devstral-small-2505

These models are part of [Mistral’s officially released lineup](https://mistral.ai/pricing#api-pricing) but were not previously available in the Flowise UI. Adding them expands the model selection and improves support for various use cases relying on these newer offerings.

**Changes:**
- Extended the list of supported model identifiers for ChatMistralAI

**Motivation:**
This change ensures that users can access the latest Mistral models directly within Flowise without requiring manual configuration or backend modifications.

**Testing:**
- Verified model selection and response flow using each newly added model
- Confirmed that existing functionality remains unaffected

Let me know if any refinements are needed. I'd be happy to make updates.