### PR TITLE
[ BUG #4498] Use Correct Key For Basic Auth and Optional pass

### DIFF
--- a/packages/components/nodes/agentflow/HTTP/HTTP.ts
+++ b/packages/components/nodes/agentflow/HTTP/HTTP.ts
@@ -220,14 +220,14 @@ class HTTP_Agentflow implements INode {
             // Add credentials if provided
             const credentialData = await getCredentialData(nodeData.credential ?? '', options)
             if (credentialData && Object.keys(credentialData).length !== 0) {
-                const basicAuthUsername = getCredentialParam('username', credentialData, nodeData)
-                const basicAuthPassword = getCredentialParam('password', credentialData, nodeData)
+                const basicAuthUsername = getCredentialParam('basicAuthUsername', credentialData, nodeData)
+                const basicAuthPassword = getCredentialParam('basicAuthPassword', credentialData, nodeData)
                 const bearerToken = getCredentialParam('token', credentialData, nodeData)
                 const apiKeyName = getCredentialParam('key', credentialData, nodeData)
                 const apiKeyValue = getCredentialParam('value', credentialData, nodeData)
 
                 // Determine which type of auth to use based on available credentials
-                if (basicAuthUsername && basicAuthPassword) {
+                if (basicAuthUsername || basicAuthPassword) {
                     // Basic Auth
                     const auth = Buffer.from(`${basicAuthUsername}:${basicAuthPassword}`).toString('base64')
                     requestHeaders['Authorization'] = `Basic ${auth}`


### PR DESCRIPTION
This PR introduces the following changes:

1. Corrects the keys used to retrieve the Basic Auth username and password from the credentials.
2. Ensures that either the username or password must be provided to enable Basic Auth in the HTTP node.

#4498 