### PR TITLE
Feature: Add dot notation support for nested output variable resolution

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -325,6 +325,30 @@ export const resolveVariables = async (
                 }
             }
 
+            // Check if the variable is an output reference like `nodeId.output.path`
+            const outputMatch = variableFullPath.match(/^(.*?)\.output\.(.+)$/)
+            if (outputMatch && agentFlowExecutedData) {
+                // Extract nodeId and outputPath from the match
+                const [, nodeIdPart, outputPath] = outputMatch
+                // Clean nodeId (handle escaped underscores)
+                const cleanNodeId = nodeIdPart.replace('\\', '')
+                // Find the last (most recent) matching node data instead of the first one
+                const nodeData = [...agentFlowExecutedData].reverse().find((d) => d.nodeId === cleanNodeId)
+                if (nodeData?.data?.output && outputPath.trim()) {
+                    const variableValue = get(nodeData.data.output, outputPath)
+                    if (variableValue !== undefined) {
+                        // Replace the reference with actual value
+                        const formattedValue =
+                            Array.isArray(variableValue) || (typeof variableValue === 'object' && variableValue !== null)
+                                ? JSON.stringify(variableValue)
+                                : String(variableValue)
+                        resolvedValue = resolvedValue.replace(match, formattedValue)
+                        // Skip fallback logic
+                        continue
+                    }
+                }
+            }
+
             // Find node data in executed data
             // sometimes turndown value returns a backslash like `llmAgentflow\_1`, remove the backslash
             const cleanNodeId = variableFullPath.replace('\\', '')


### PR DESCRIPTION
This PR updates the variable resolution system in buildAgentflow.ts to support dot notation for accessing nested properties in node outputs. Users can now reference specific nested values using the format nodeId.output.path instead of only accessing the entire output content.

**Examples**

**Before**
{{nodeId}}  // Returns entire output.content or output object

**After**
{{nodeId.output.result.summary}}          // Access nested summary property
{{nodeId.output.metadata.timestamp}} // Access nested timestamp
{{nodeId}}                                                 // Still works - backwards compatible