### PR TITLE
bugfix/Fix SQL syntax error when reverting migration in MariaDB

### DIFF
--- a/packages/server/src/database/migrations/mariadb/1733752119696-AddSeqNoToDatasetRow.ts
+++ b/packages/server/src/database/migrations/mariadb/1733752119696-AddSeqNoToDatasetRow.ts
@@ -7,6 +7,6 @@ export class AddSeqNoToDatasetRow1733752119696 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "dataset_row" DROP COLUMN "sequence_no";`)
+        await queryRunner.query(`ALTER TABLE \`dataset_row\` DROP COLUMN \`sequence_no\``)
     }
 }

--- a/packages/server/src/database/migrations/mariadb/1744964560174-AddErrorToEvaluationRun.ts
+++ b/packages/server/src/database/migrations/mariadb/1744964560174-AddErrorToEvaluationRun.ts
@@ -7,6 +7,6 @@ export class AddErrorToEvaluationRun1744964560174 implements MigrationInterface 
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "evaluation_run" DROP COLUMN "errors";`)
+        await queryRunner.query(`ALTER TABLE \`evaluation_run\` DROP COLUMN \`errors\`;`)
     }
 }

--- a/packages/server/src/enterprise/database/migrations/mariadb/1730519457880-AddSSOColumns.ts
+++ b/packages/server/src/enterprise/database/migrations/mariadb/1730519457880-AddSSOColumns.ts
@@ -9,8 +9,8 @@ export class AddSSOColumns1730519457880 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "organization" DROP COLUMN "sso_config";`)
-        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "user_type";`)
-        await queryRunner.query(`ALTER TABLE "login_activity" DROP COLUMN "login_mode";`)
+        await queryRunner.query(`ALTER TABLE \`organization\` DROP COLUMN \`sso_config\`;`)
+        await queryRunner.query(`ALTER TABLE \`user\` DROP COLUMN \`user_type\`;`)
+        await queryRunner.query(`ALTER TABLE \`login_activity\` DROP COLUMN \`login_mode\`;`)
     }
 }


### PR DESCRIPTION

Fixes a MariaDB-specific SQL syntax error during typeorm migration:revert.

When reverting a migration, TypeORM generates queries using double quotes for identifiers, which is invalid in MariaDB. This PR updates the query to use backticks instead.

Before:

```ALTER TABLE "evaluation_run" DROP COLUMN "errors";```

After:

```ALTER TABLE `evaluation_run` DROP COLUMN `errors`;```

Affects only MariaDB users during migration rollback.
