### PR TITLE
fix bug:The enqueueSnackbar Snackbar notification cannot auto-close. …

### DIFF
--- a/packages/ui/src/store/actions.js
+++ b/packages/ui/src/store/actions.js
@@ -32,6 +32,11 @@ export const enqueueSnackbar = (notification) => {
         type: ENQUEUE_SNACKBAR,
         notification: {
             ...notification,
+            options: {
+                ...notification.options,
+                persist: notification.options?.persist ?? false, // Default: auto-close enabled
+                autoHideDuration: notification.options?.autoHideDuration ?? 5000 // Default auto-close duration: 5 seconds
+            },
             key: key || new Date().getTime() + Math.random()
         }
     }

--- a/packages/ui/src/ui-component/dialog/AgentflowGeneratorDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/AgentflowGeneratorDialog.jsx
@@ -131,7 +131,7 @@ const AgentflowGeneratorDialog = ({ show, dialogProps, onCancel, onConfirm }) =>
                     options: {
                         key: new Date().getTime() + Math.random(),
                         variant: 'error',
-                        persist: true,
+                        persist: false,
                         action: (key) => (
                             <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
                                 <IconX />
@@ -146,7 +146,7 @@ const AgentflowGeneratorDialog = ({ show, dialogProps, onCancel, onConfirm }) =>
                 options: {
                     key: new Date().getTime() + Math.random(),
                     variant: 'error',
-                    persist: true,
+                    persist: false,
                     action: (key) => (
                         <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
                             <IconX />


### PR DESCRIPTION
…#4608

The enqueueSnackbar notification does not auto-close by default.  I configure it to dismiss after a specific duration.

[bug address](https://github.com/FlowiseAI/Flowise/issues/4608)