### PR TITLE
feature/organization-status

### DIFF
--- a/packages/server/src/database/migrations/mariadb/index.ts
+++ b/packages/server/src/database/migrations/mariadb/index.ts
@@ -48,6 +48,7 @@ import { AddSSOColumns1730519457880 } from '../../../enterprise/database/migrati
 import { AddPersonalWorkspace1734074497540 } from '../../../enterprise/database/migrations/mariadb/1734074497540-AddPersonalWorkspace'
 import { RefactorEnterpriseDatabase1737076223692 } from '../../../enterprise/database/migrations/mariadb/1737076223692-RefactorEnterpriseDatabase'
 import { ExecutionLinkWorkspaceId1746862866554 } from '../../../enterprise/database/migrations/mariadb/1746862866554-ExecutionLinkWorkspaceId'
+import { AddStatusInOrganization1749714174104 } from '../../../enterprise/database/migrations/mariadb/1749714174104-AddStatusInOrganization'
 
 export const mariadbMigrations = [
     Init1693840429259,
@@ -98,5 +99,6 @@ export const mariadbMigrations = [
     FixOpenSourceAssistantTable1743758056188,
     AddErrorToEvaluationRun1744964560174,
     ExecutionLinkWorkspaceId1746862866554,
-    ModifyExecutionDataColumnType1747902489801
+    ModifyExecutionDataColumnType1747902489801,
+    AddStatusInOrganization1749714174104
 ]

--- a/packages/server/src/database/migrations/mysql/index.ts
+++ b/packages/server/src/database/migrations/mysql/index.ts
@@ -49,6 +49,7 @@ import { AddSSOColumns1730519457880 } from '../../../enterprise/database/migrati
 import { AddPersonalWorkspace1734074497540 } from '../../../enterprise/database/migrations/mysql/1734074497540-AddPersonalWorkspace'
 import { RefactorEnterpriseDatabase1737076223692 } from '../../../enterprise/database/migrations/mysql/1737076223692-RefactorEnterpriseDatabase'
 import { ExecutionLinkWorkspaceId1746862866554 } from '../../../enterprise/database/migrations/mysql/1746862866554-ExecutionLinkWorkspaceId'
+import { AddStatusInOrganization1749714174104 } from '../../../enterprise/database/migrations/mysql/1749714174104-AddStatusInOrganization'
 
 export const mysqlMigrations = [
     Init1693840429259,
@@ -100,5 +101,6 @@ export const mysqlMigrations = [
     AddErrorToEvaluationRun1744964560174,
     FixErrorsColumnInEvaluationRun1746437114935,
     ExecutionLinkWorkspaceId1746862866554,
-    ModifyExecutionDataColumnType1747902489801
+    ModifyExecutionDataColumnType1747902489801,
+    AddStatusInOrganization1749714174104
 ]

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -48,6 +48,7 @@ import { AddSSOColumns1730519457880 } from '../../../enterprise/database/migrati
 import { AddPersonalWorkspace1734074497540 } from '../../../enterprise/database/migrations/postgres/1734074497540-AddPersonalWorkspace'
 import { RefactorEnterpriseDatabase1737076223692 } from '../../../enterprise/database/migrations/postgres/1737076223692-RefactorEnterpriseDatabase'
 import { ExecutionLinkWorkspaceId1746862866554 } from '../../../enterprise/database/migrations/postgres/1746862866554-ExecutionLinkWorkspaceId'
+import { AddStatusInOrganization1749714174104 } from '../../../enterprise/database/migrations/postgres/1749714174104-AddStatusInOrganization'
 
 export const postgresMigrations = [
     Init1693891895163,
@@ -98,5 +99,6 @@ export const postgresMigrations = [
     FixOpenSourceAssistantTable1743758056188,
     AddErrorToEvaluationRun1744964560174,
     ExecutionLinkWorkspaceId1746862866554,
-    ModifyExecutionSessionIdFieldType1748450230238
+    ModifyExecutionSessionIdFieldType1748450230238,
+    AddStatusInOrganization1749714174104
 ]

--- a/packages/server/src/database/migrations/sqlite/index.ts
+++ b/packages/server/src/database/migrations/sqlite/index.ts
@@ -46,6 +46,7 @@ import { AddSSOColumns1730519457880 } from '../../../enterprise/database/migrati
 import { AddPersonalWorkspace1734074497540 } from '../../../enterprise/database/migrations/sqlite/1734074497540-AddPersonalWorkspace'
 import { RefactorEnterpriseDatabase1737076223692 } from '../../../enterprise/database/migrations/sqlite/1737076223692-RefactorEnterpriseDatabase'
 import { ExecutionLinkWorkspaceId1746862866554 } from '../../../enterprise/database/migrations/sqlite/1746862866554-ExecutionLinkWorkspaceId'
+import { AddStatusInOrganization1749714174104 } from '../../../enterprise/database/migrations/sqlite/1749714174104-AddStatusInOrganization'
 
 export const sqliteMigrations = [
     Init1693835579790,
@@ -94,5 +95,6 @@ export const sqliteMigrations = [
     AddExecutionEntity1738090872625,
     FixOpenSourceAssistantTable1743758056188,
     AddErrorToEvaluationRun1744964560174,
-    ExecutionLinkWorkspaceId1746862866554
+    ExecutionLinkWorkspaceId1746862866554,
+    AddStatusInOrganization1749714174104
 ]

--- a/packages/server/src/enterprise/database/entities/organization.entity.ts
+++ b/packages/server/src/enterprise/database/entities/organization.entity.ts
@@ -5,6 +5,12 @@ export enum OrganizationName {
     DEFAULT_ORGANIZATION = 'Default Organization'
 }
 
+export enum OrganizationStatus {
+    ACTIVE = 'active',
+    UNDER_REVIEW = 'under_review',
+    PAST_DUE = 'past_due'
+}
+
 @Entity()
 export class Organization {
     @PrimaryGeneratedColumn('uuid')
@@ -18,6 +24,9 @@ export class Organization {
 
     @Column({ type: 'varchar', length: 100, nullable: true })
     subscriptionId?: string
+
+    @Column({ type: 'varchar', length: 20, default: OrganizationStatus.ACTIVE })
+    status: string
 
     @CreateDateColumn()
     createdDate?: Date

--- a/packages/server/src/enterprise/database/migrations/mariadb/1749714174104-AddStatusInOrganization.ts
+++ b/packages/server/src/enterprise/database/migrations/mariadb/1749714174104-AddStatusInOrganization.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { OrganizationStatus } from '../../entities/organization.entity'
+
+export class AddStatusInOrganization1749714174104 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`alter table \`organization\` add \`status\` varchar(20) default "${OrganizationStatus.ACTIVE}" not null ;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`alter table \`organization\` drop column \`status\` ;`)
+    }
+}

--- a/packages/server/src/enterprise/database/migrations/mysql/1749714174104-AddStatusInOrganization.ts
+++ b/packages/server/src/enterprise/database/migrations/mysql/1749714174104-AddStatusInOrganization.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { OrganizationStatus } from '../../entities/organization.entity'
+
+export class AddStatusInOrganization1749714174104 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`alter table \`organization\` add \`status\` varchar(20) default "${OrganizationStatus.ACTIVE}" not null ;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`alter table \`organization\` drop column \`status\` ;`)
+    }
+}

--- a/packages/server/src/enterprise/database/migrations/postgres/1749714174104-AddStatusInOrganization.ts
+++ b/packages/server/src/enterprise/database/migrations/postgres/1749714174104-AddStatusInOrganization.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { OrganizationStatus } from '../../entities/organization.entity'
+
+export class AddStatusInOrganization1749714174104 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`alter table "organization" add column "status" varchar(20) default '${OrganizationStatus.ACTIVE}' not null;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`alter table "organization" drop column "status";`)
+    }
+}

--- a/packages/server/src/enterprise/database/migrations/sqlite/1749714174104-AddStatusInOrganization.ts
+++ b/packages/server/src/enterprise/database/migrations/sqlite/1749714174104-AddStatusInOrganization.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { OrganizationStatus } from '../../entities/organization.entity'
+
+export class AddStatusInOrganization1749714174104 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`alter table "organization" add column "status" varchar(20) default '${OrganizationStatus.ACTIVE}' not null;`)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`alter table "organization" drop column "status";`)
+    }
+}


### PR DESCRIPTION
## Description
Add organization level status control:
- `active`:  Default state; Indicates the organization is in good standing with no restrictions.
- `under_review`: Indicates the organization is under investigation due to high traffic or activity that may disrupt services.
- `past_due`: Indicates the organization with outstanding payments.

## Test Step
1. Register a user before migration
2. Perform migration 
3. Invite a non register user into a workspace
4. Perform registration for invited user

## Migration Script Result
**SQLite:**
|Existing User Before|Existing User After|Migrations|Properties|New User|
| -------- | -------- | -------- | -------- | -------- |
|![sqlite_existingUser_before](https://github.com/user-attachments/assets/eba611e9-c3d7-4c83-8af1-b1a54f75fcd3)|![sqlite_existingUser_after](https://github.com/user-attachments/assets/eb5a9d9d-a6bb-4648-aafc-30b5d2677cd5)|![sqlite_migrations](https://github.com/user-attachments/assets/7b8630c7-d6fb-4502-b0f6-494b929d5086)|![sqlite_properties](https://github.com/user-attachments/assets/11e08524-cc9b-4389-a358-d22732440dac)|![sqlite_newUser](https://github.com/user-attachments/assets/8a58f0ef-081a-4dff-8e2d-d344517db46d)|

**PostgreSQL:**
|Existing User Before|Existing User After|Migrations|Properties|New User|
| -------- | -------- | -------- | -------- | -------- |
|![postgre_existingUser_before](https://github.com/user-attachments/assets/28d8758a-c135-4d68-abc7-23485fa86134)|![postgre_existingUser_after](https://github.com/user-attachments/assets/1e8d2b63-85c7-4cf4-a83e-a28e8444aaec)|![postgre_migrations](https://github.com/user-attachments/assets/5ec7fff9-24a4-43ab-8374-1165b24e6482)|![postgre_properties](https://github.com/user-attachments/assets/dfbdb354-aad6-4d7c-90d7-555e65077989)|![postgre_newUser](https://github.com/user-attachments/assets/39ddf062-c145-4dce-b89d-44f5510ca468)|

**MySQL:**
|Existing User Before|Existing User After|Migrations|Properties|New User|
| -------- | -------- | -------- | -------- | -------- |
|![mysql_existingUser_before](https://github.com/user-attachments/assets/b70f338c-bd72-4a8e-986b-b8856292527f)|![mysql_existingUser_after](https://github.com/user-attachments/assets/345f1c91-556a-4301-bb2b-839088c15f54)|![mysql_migrations](https://github.com/user-attachments/assets/078ce084-9857-40ff-b73d-5be922690b4e)|![mysql_properties](https://github.com/user-attachments/assets/f8a51a1d-4b9f-479c-a572-97f241146f3d)|![mysql_newUser](https://github.com/user-attachments/assets/eaf97e11-baf9-44ba-ac80-8ffed8e2e18a)|

**MariaDB:**
|Existing User Before|Existing User After|Migrations|Properties|New User|
| -------- | -------- | -------- | -------- | -------- |
|![mariadb_existingUser_before](https://github.com/user-attachments/assets/d8317c94-aa3d-40b9-b9a9-59c5248a3073)|![mariadb_existingUser_after](https://github.com/user-attachments/assets/47ffad62-effc-425a-81bd-66f5b78dbb73)|![mariadb_migrations](https://github.com/user-attachments/assets/e7c507df-7fbe-45da-bf00-a09f5c41ee89)|![mariadb_properties](https://github.com/user-attachments/assets/4dfcae7e-4d71-4c09-97ee-a47bfbf11243)|![mariadb_newUser](https://github.com/user-attachments/assets/4df598b2-f951-4b88-8c18-ffe4017b714d)|
