### PR TITLE
fix: Modify the style of the AsyncDropdown component

### DIFF
--- a/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
+++ b/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
@@ -223,7 +223,7 @@ export const AsyncDropdown = ({
                                         borderColor: theme.palette.grey[900] + 25
                                     }
                                 }
-                            }}                            
+                            }}
                             InputProps={{
                                 ...params.InputProps,
                                 startAdornment: (
@@ -257,10 +257,16 @@ export const AsyncDropdown = ({
                         />
                     )
 
-                    return !multiple ? textField : (
-                        <Tooltip 
-                            title={typeof internalValue === 'string' ? internalValue.replace(/[\[\]"]/g, '').replace(/,/g, ', ') : internalValue} 
-                            placement="top"
+                    return !multiple ? (
+                        textField
+                    ) : (
+                        <Tooltip
+                            title={
+                                typeof internalValue === 'string'
+                                    ? internalValue.replace(/[[\]"]/g, '').replace(/,/g, ', ')
+                                    : internalValue
+                            }
+                            placement='top'
                             arrow
                         >
                             {textField}

--- a/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
+++ b/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
@@ -261,11 +261,9 @@ export const AsyncDropdown = ({
                         textField
                     ) : (
                         <Tooltip
-                            title={
-                                typeof internalValue === 'string'
-                                    ? internalValue.replace(/[[\]"]/g, '').replace(/,/g, ', ')
-                                    : internalValue
-                            }
+                            title={typeof internalValue === 'string'
+                                ? internalValue.replace(/[[\]"]/g, '').replace(/,/g, ', ')
+                                : internalValue}
                             placement='top'
                             arrow
                         >

--- a/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
+++ b/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
@@ -5,7 +5,7 @@ import axios from 'axios'
 
 // Material
 import Autocomplete, { autocompleteClasses } from '@mui/material/Autocomplete'
-import { Popper, CircularProgress, TextField, Box, Typography } from '@mui/material'
+import { Popper, CircularProgress, TextField, Box, Typography, Tooltip } from '@mui/material'
 import { useTheme, styled } from '@mui/material/styles'
 
 // API
@@ -175,7 +175,7 @@ export const AsyncDropdown = ({
                 multiple={multiple}
                 filterSelectedOptions={multiple}
                 size='small'
-                sx={{ mt: 1, width: '100%' }}
+                sx={{ mt: 1, width: multiple ? '90%' : '100%' }}
                 open={open}
                 onOpen={() => {
                     setOpen(true)
@@ -210,7 +210,8 @@ export const AsyncDropdown = ({
                     const matchingOptions = multiple
                         ? findMatchingOptions(options, internalValue)
                         : [findMatchingOptions(options, internalValue)].filter(Boolean)
-                    return (
+
+                    const textField = (
                         <TextField
                             {...params}
                             value={internalValue}
@@ -222,7 +223,7 @@ export const AsyncDropdown = ({
                                         borderColor: theme.palette.grey[900] + 25
                                     }
                                 }
-                            }}
+                            }}                            
                             InputProps={{
                                 ...params.InputProps,
                                 startAdornment: (
@@ -254,6 +255,16 @@ export const AsyncDropdown = ({
                                 )
                             }}
                         />
+                    )
+
+                    return !multiple ? textField : (
+                        <Tooltip 
+                            title={typeof internalValue === 'string' ? internalValue.replace(/[\[\]"]/g, '').replace(/,/g, ', ') : internalValue} 
+                            placement="top"
+                            arrow
+                        >
+                            {textField}
+                        </Tooltip>
                     )
                 }}
                 renderOption={(props, option) => (

--- a/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
+++ b/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
@@ -261,9 +261,9 @@ export const AsyncDropdown = ({
                         textField
                     ) : (
                         <Tooltip
-                            title={typeof internalValue === 'string'
-                                ? internalValue.replace(/[[\]"]/g, '').replace(/,/g, ', ')
-                                : internalValue}
+                            title={
+                                typeof internalValue === 'string' ? internalValue.replace(/[[\]"]/g, '').replace(/,/g, ', ') : internalValue
+                            }
                             placement='top'
                             arrow
                         >


### PR DESCRIPTION
### Changes
- Adjusted the `Autocomplete` component's width to `90%` when `multiple` is true to prevent clipping of the refresh button.
- Added a tooltip on hover for selected action items to display the **full action name**, especially when it overflows.

### Reason
- Long action names were causing UI overflow, making the refresh button partially hidden and selected text unreadable.
- Improved UX by making the layout more responsive and enhancing the visibility of selected items.

### Notes
- This change affects only the `Autocomplete` UI within the affected node and has no side effects on other components.

![image](https://github.com/user-attachments/assets/ae4dd597-b68d-4cee-b4a9-7d4592582536)
