### PR TITLE
doc: Add links to translated README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@
 [![GitHub star chart](https://img.shields.io/github/stars/FlowiseAI/Flowise?style=social)](https://star-history.com/#FlowiseAI/Flowise)
 [![GitHub fork](https://img.shields.io/github/forks/FlowiseAI/Flowise?style=social)](https://github.com/FlowiseAI/Flowise/fork)
 
-English | [繁體中文](./i18n/README-TW.md) | [简体中文](./i18n/README-ZH.md) | [日本語](./i18n/README-JA.md) | [한국어](./i18n/README-KR.md)
+English | [繁體中文](./i18n/README-TW.md) | [简体中文](./i18n/README-ZH.md) | [日本語](./i18n/README-JA.md) | [한국어](./i18n/README-KR.md) | 
+[Deutsch](https://www.readme-i18n.com/FlowiseAI/Flowise?lang=de) | 
+[Español](https://www.readme-i18n.com/FlowiseAI/Flowise?lang=es) | 
+[français](https://www.readme-i18n.com/FlowiseAI/Flowise?lang=fr) | 
+[Português](https://www.readme-i18n.com/FlowiseAI/Flowise?lang=pt) | 
+[Русский](https://www.readme-i18n.com/FlowiseAI/Flowise?lang=ru) | 
 
 <h3>Build AI Agents, Visually</h3>
 <a href="https://github.com/FlowiseAI/Flowise">


### PR DESCRIPTION
Allowing users around the world to read the documentation in their native languages — including German, Spanish, French, Portuguese, and Russian. 

This helps improve accessibility and understanding of the project for a global audience.

The updated links can be previewed in my forked repository: https://github.com/dowithless/Flowise/tree/patch-1

> Keep these links. Translations will automatically update with the README.