### PR TITLE
Add PostgreSQL schema configuration support via DATABASE_SCHEMA

### DIFF
--- a/packages/server/src/DataSource.ts
+++ b/packages/server/src/DataSource.ts
@@ -70,13 +70,16 @@ export const init = async (): Promise<void> => {
                 username: process.env.DATABASE_USER,
                 password: process.env.DATABASE_PASSWORD,
                 database: process.env.DATABASE_NAME,
+                schema: process.env.DATABASE_SCHEMA || 'public',
                 ssl: getDatabaseSSLFromEnv(),
                 synchronize: false,
                 migrationsRun: false,
                 entities: Object.values(entities),
                 migrations: postgresMigrations,
                 extra: {
-                    idleTimeoutMillis: 120000
+                    idleTimeoutMillis: 120000,
+                    // Ensure search_path includes extensions schema for UUID functions
+                    searchPath: process.env.DATABASE_SCHEMA ? `${process.env.DATABASE_SCHEMA}, public, extensions` : 'public, extensions'
                 },
                 logging: ['error', 'warn', 'info', 'log'],
                 logger: 'advanced-console',


### PR DESCRIPTION
This update enables users to specify a custom PostgreSQL schema for Flowise to use, improving database organization and multi-tenant deployments.

Changes:
- Add schema property to PostgreSQL DataSource configuration using DATABASE_SCHEMA env var
- Configure search_path to include custom schema, public, and extensions schemas
- Ensure UUID functions remain accessible from extensions schema
- Maintain backward compatibility with default 'public' schema when DATABASE_SCHEMA is not set

