### PR TITLE
fix: improve tag visibility in dark mode when disabled (#4675)

### DIFF
--- a/packages/ui/src/views/marketplaces/index.jsx
+++ b/packages/ui/src/views/marketplaces/index.jsx
@@ -645,9 +645,25 @@ const Marketplace = () => {
                                                                 : selectedUsecases.filter((item) => item !== usecase)
                                                         )
                                                     }}
+                                                    sx={{
+                                                        '& .MuiSvgIcon-root': {
+                                                            color:
+                                                                eligibleUsecases.length === 0 || !eligibleUsecases.includes(usecase)
+                                                                    ? '#888 !important'
+                                                                    : undefined
+                                                        }
+                                                    }}
                                                 />
                                             }
                                             label={usecase}
+                                            sx={{
+                                                '& .MuiFormControlLabel-label': {
+                                                    color:
+                                                        eligibleUsecases.length === 0 || !eligibleUsecases.includes(usecase)
+                                                            ? '#888 !important'
+                                                            : undefined
+                                                }
+                                            }}
                                         />
                                     ))}
                                 </Stack>


### PR DESCRIPTION
### What I did

- Fixed the issue where disabled marketplace tags were barely visible in dark mode.
- Applied custom `sx` styling to override default MUI colors:
  - Changed the checkbox icon color to `#888` when disabled.
  - Matched the label color to `#888` for consistency.
- The update ensures disabled tags are still visibly distinct without clashing with the overall theme.

---

### Before (Dark Mode)

> Disabled tags were almost invisible — icon and label were too dim.

![image](https://github.com/user-attachments/assets/b43f7606-1344-407b-bd93-4a35974f7392)



---

### After (Dark Mode)

> Disabled tags are now clearly visible using a readable gray color (`#888`).

![image](https://github.com/user-attachments/assets/499eced0-1edb-4468-9a37-9591deb0b23c)


---

### How to test

1. Switch to dark mode.
2. Go to the Marketplace view.
3. Trigger a condition where some use case tags become disabled.
4. Verify the disabled tags are now visible and styled appropriately.

---

### Related Issue

Fixes #4675
