### PR TITLE
fix(components): promise.all failed silently when loading MCP tools

### DIFF
--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -112,11 +112,11 @@ export class MCPToolkit extends BaseToolkit {
             })
         })
         const res = await Promise.allSettled(toolsPromises)
-        const errors = res.filter((r) => r.status === "rejected")
+        const errors = res.filter((r) => r.status === 'rejected')
         if (errors.length !== 0) {
-            console.error("MCP Tools falied to be resolved", errors)
+            console.error('MCP Tools falied to be resolved', errors)
         }
-        const successes = res.filter((r) => r.status === "fulfilled")
+        const successes = res.filter((r) => r.status === 'fulfilled')
             .map((r) => r.value);
         return successes
     }

--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -116,8 +116,7 @@ export class MCPToolkit extends BaseToolkit {
         if (errors.length !== 0) {
             console.error('MCP Tools falied to be resolved', errors)
         }
-        const successes = res.filter((r) => r.status === 'fulfilled')
-            .map((r) => r.value);
+        const successes = res.filter((r) => r.status === 'fulfilled').map((r) => r.value)
         return successes
     }
 }
@@ -174,3 +173,4 @@ function createSchemaModel(
 
     return z.object(schemaProperties)
 }
+

--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -173,4 +173,3 @@ function createSchemaModel(
 
     return z.object(schemaProperties)
 }
-

--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -111,7 +111,14 @@ export class MCPToolkit extends BaseToolkit {
                 argsSchema: createSchemaModel(tool.inputSchema)
             })
         })
-        return Promise.all(toolsPromises)
+        const res = await Promise.allSettled(toolsPromises)
+        const errors = res.filter((r) => r.status === "rejected")
+        if (errors.length !== 0) {
+            console.error("MCP Tools falied to be resolved", errors)
+        }
+        const successes = res.filter((r) => r.status === "fulfilled")
+            .map((r) => r.value);
+        return successes
     }
 }
 


### PR DESCRIPTION
When some of tools in custom MCP server have incorrect schema definition, Flowise failed to load that MCP server with zero error indication.

Linked to Issue #4749 

The root cause is when there is any rejected promise the `Promise.all()` will abort all remaining result and fall silently.

This PR replace `Promise.all()` with `Promise.allSettled()`, this change provides two benefits:

1. even some tools failed to resolve, remaining tools that available in that MCP server is still accessible
2. print errors making it easier to debug for Custom MCP users 
