### PR TITLE
fix(components): Improve layout handling in Markdown and ChatMessage components

### DIFF
--- a/packages/ui/src/ui-component/markdown/MemoizedReactMarkdown.jsx
+++ b/packages/ui/src/ui-component/markdown/MemoizedReactMarkdown.jsx
@@ -118,7 +118,18 @@ export const MemoizedReactMarkdown = memo(
                             )
                         },
                         p({ children }) {
-                            return <p style={{ whiteSpace: 'pre-line' }}>{children}</p>
+                            return (
+                                <p
+                                    style={{
+                                        whiteSpace: 'pre-line',
+                                        overflowWrap: 'break-word',
+                                        wordBreak: 'break-word',
+                                        marginRight: '1.5rem' // Awful hack to avoid text overflow issues
+                                    }}
+                                >
+                                    {children}
+                                </p>
+                            )
                         },
                         ...props.components
                     }}

--- a/packages/ui/src/views/chatmessage/AgentExecutedDataCard.jsx
+++ b/packages/ui/src/views/chatmessage/AgentExecutedDataCard.jsx
@@ -653,7 +653,9 @@ const AgentExecutedDataCard = ({ status, execution, agentflowId, sessionId }) =>
         <Box sx={{ display: 'flex', height: '100%', width: '100%', mt: 2 }}>
             <Accordion
                 sx={{
-                    width: '100%'
+                    width: '100%',
+                    maxWidth: '100%',
+                    overflow: 'hidden'
                 }}
             >
                 <AccordionSummary
@@ -683,18 +685,27 @@ const AgentExecutedDataCard = ({ status, execution, agentflowId, sessionId }) =>
                     <Typography>Process Flow</Typography>
                 </AccordionSummary>
                 <Divider />
-                <AccordionDetails>
-                    <RichTreeView
-                        expandedItems={expandedItems}
-                        onExpandedItemsChange={handleExpandedItemsChange}
-                        selectedItems={selectedItem ? [selectedItem.id] : []}
-                        onSelectedItemsChange={handleNodeSelect}
-                        items={executionTree}
-                        slots={{
-                            item: (treeItemProps) => <CustomTreeItem {...treeItemProps} agentflowId={agentflowId} sessionId={sessionId} />
-                        }}
-                        sx={{ width: '100%' }}
-                    />
+                <AccordionDetails
+                    sx={{
+                        overflowX: 'auto',
+                        padding: 0
+                    }}
+                >
+                    <Box sx={{ padding: 2, minWidth: 'fit-content' }}>
+                        <RichTreeView
+                            expandedItems={expandedItems}
+                            onExpandedItemsChange={handleExpandedItemsChange}
+                            selectedItems={selectedItem ? [selectedItem.id] : []}
+                            onSelectedItemsChange={handleNodeSelect}
+                            items={executionTree}
+                            slots={{
+                                item: (treeItemProps) => (
+                                    <CustomTreeItem {...treeItemProps} agentflowId={agentflowId} sessionId={sessionId} />
+                                )
+                            }}
+                            sx={{ width: '100%' }}
+                        />
+                    </Box>
                 </AccordionDetails>
             </Accordion>
         </Box>

--- a/packages/ui/src/views/chatmessage/ChatMessage.css
+++ b/packages/ui/src/views/chatmessage/ChatMessage.css
@@ -2,6 +2,7 @@
     width: 100%;
     height: auto;
     border-radius: 0.5rem;
+    overflow: hidden;
 }
 
 .messagelistloading {


### PR DESCRIPTION
## Description

This PR addresses [#4766](https://github.com/FlowiseAI/Flowise/issues/4766) by fixing the rendering logic of connection lines between nodes in the visual flow editor.

Previously, some connector lines appeared to:
- Extend vertically without being properly anchored to nodes.
- Show phantom connections that did not reflect actual logical links.
- Overlap or stack unnecessarily, reducing readability.

Changes Introduced

- Removed at ChatMessage parent (I.E `.messagelist`) to be capable of overflow
- Added `overflowX` on the accordion content. To enable it to contain its own scrollable and do not disturb the entire chat window until the user opens it

How to Test
1. Create a new `agent flow v2` add multiple nodes and then check that the chat is able to show the buttons in each node.

**IMPORTANT**
Haven't totally check other flows. I'm quite new coding flowise, so probably I will miss some scenarios. Open to receive improves or if you think you can add them **go ahead**.

Screenshots (Before/After)

Before
![image](https://github.com/user-attachments/assets/d951bd02-603c-4840-802b-dcb834c2a984)


After
<img width="452" alt="image" src="https://github.com/user-attachments/assets/5c0c3285-4330-4ff2-a905-4ee3924e3799" />


This PR focuses solely on improving the visual consistency of the flow editor. No changes were made to the core execution or logic of node interaction.