### PR TITLE
Bugfix: add missing getLabel prop to AgentReasoningCard

### DIFF
--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -1882,6 +1882,7 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
                                                         removeDuplicateURL={removeDuplicateURL}
                                                         isValidURL={isValidURL}
                                                         onURLClick={onURLClick}
+                                                        getLabel={getLabel}
                                                     />
                                                 ))}
                                             </div>


### PR DESCRIPTION
Fixes a missing getLabel prop in the AgentReasoningCard component to prevent render errors and blank screen when restoring chat history. #4821 
