### PR TITLE
Improve infra as code support

### DIFF
--- a/packages/server/src/Interface.DocumentStore.ts
+++ b/packages/server/src/Interface.DocumentStore.ts
@@ -299,8 +299,8 @@ export class DocumentStoreDTO {
     static toEntity(body: any): DocumentStore {
         const docStore = new DocumentStore()
         Object.assign(docStore, body)
-        docStore.loaders = '[]'
-        docStore.whereUsed = '[]'
+        docStore.loaders = body.loaders ?? '[]'
+        docStore.whereUsed = body.whereUsed ?? '[]'
         // when a new document store is created, it is empty and in sync
         docStore.status = DocumentStoreStatus.EMPTY_SYNC
         return docStore

--- a/packages/server/src/services/credentials/index.ts
+++ b/packages/server/src/services/credentials/index.ts
@@ -14,6 +14,11 @@ const createCredential = async (requestBody: any) => {
     try {
         const appServer = getRunningExpressApp()
         const newCredential = await transformToCredentialEntity(requestBody)
+
+        if (requestBody.id) {
+            newCredential.id = requestBody.id
+        }
+
         const credential = await appServer.AppDataSource.getRepository(Credential).create(newCredential)
         const dbResponse = await appServer.AppDataSource.getRepository(Credential).save(credential)
         return dbResponse


### PR DESCRIPTION
Hi, 
This small PR fixes a couple of things that stopped me building some custom infra as code support via the api.
Firstly, you couldn't create document stores with loaders, due to loaders being hard coded `[]`. I've changed this to allow it but default to the old behaviour.

Secondly when creating credentials via the api, you could not specify the id, leading to a different id in each environment (thus breaking the relationship to vector stores).  That commit allows you to use the id (which brings it inline with the create api's for chatflows too which accept id).