### PR TITLE
fix: normalize Milvus similarity scores for threshold filtering

### DIFF
--- a/packages/components/nodes/vectorstores/Milvus/Milvus.ts
+++ b/packages/components/nodes/vectorstores/Milvus/Milvus.ts
@@ -395,7 +395,19 @@ const similaritySearchVectorWithScore = async (query: number[], k: number, vecto
                 }
             }
         })
-        results.push([new Document(fields), result.score])
+        
+        let normalizedScore = result.score
+        switch (vectorStore.indexCreateParams.metric_type) {
+            case 'L2':
+                normalizedScore = 1 / (1 + result.score)
+                break
+            case 'IP':
+            case 'COSINE':
+                normalizedScore = (result.score + 1) / 2
+                break
+        }
+
+        results.push([new Document(fields), normalizedScore])
     })
     return results
 }


### PR DESCRIPTION
## 🐛 Fix: Normalize Milvus similarity scores for SimilarityThresholdRetriever

### Summary
Added score normalization logic to Milvus vector store to ensure SimilarityThresholdRetriever works correctly across different metric types.

### Changes
- Added normalization logic for L2, IP, and COSINE metric types
- L2 distances converted to similarity scores using `1/(1+distance)`
- IP and COSINE scores normalized from `[-1,1]` to `[0,1]` range

### Problem Solved
- SimilarityThresholdRetriever was not working properly with Milvus due to unnormalized scores
- Different metric types returned scores in different ranges, causing inconsistent threshold filtering
- Raw distance/similarity values were passed directly without proper normalization

### Testing
- Tested with L2, IP, and COSINE metric types
- Verified SimilarityThresholdRetriever now works consistently across all metric types
- Confirmed scores are properly normalized to 0-1 range

### Files Modified
- `packages/components/nodes/vectorstores/Milvus/Milvus.ts`