### PR TITLE
Improve logging

### DIFF
--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -202,7 +202,7 @@ export function expressRequestLogger(req: Request, res: Response, next: NextFunc
         if (sanitizedBody.password) {
             sanitizedBody.password = '********'
         }
-        
+
         // Use the shared requestLogger with request-specific metadata
         const requestMetadata = {
             request: {


### PR DESCRIPTION
## Fix for "Too Many Open File Descriptors" Issue

### Changes
- **Refactored request logging implementation**: Replaced global `requestLogger` with per-request logger instances
  - Removed global `requestLogger` variable that was previously initialized once
  - Now creating a new logger instance for each request in [expressRequestLogger](cci:1://file:///Users/json/projects/cuties/git/Flowise2/packages/server/src/utils/logger.ts:195:0-238:1) function
  - This prevents file descriptor accumulation over time

### Technical Details
- The previous implementation used a single shared logger instance for all requests
- The new implementation creates a fresh logger for each request, ensuring proper resource cleanup
- Request metadata is now directly included in the logger's defaultMeta rather than passed as a parameter
- All other logging functionality (S3, GCS, local storage) remains unchanged

### Benefits
- Fixes the "Too many open file descriptors" error in high-traffic environments
- Maintains all existing logging capabilities while improving resource management
- No configuration changes required - works with all existing storage backends

Left is the original version, right is the fixed (simple lsof -w | wc -l)

<img width="729" height="221" alt="image" src="https://github.com/user-attachments/assets/2e006dc3-d76f-4d4d-984d-1baee1adf7e2" />
