### PR TITLE
Chore deprecate importChatflows method

### DIFF
--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -157,32 +157,6 @@ const saveChatflow = async (req: Request, res: Response, next: NextFunction) => 
     }
 }
 
-const importChatflows = async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const chatflows: Partial<ChatFlow>[] = req.body.Chatflows
-        const orgId = req.user?.activeOrganizationId
-        if (!orgId) {
-            throw new InternalFlowiseError(
-                StatusCodes.NOT_FOUND,
-                `Error: chatflowsController.saveChatflow - organization ${orgId} not found!`
-            )
-        }
-        const workspaceId = req.user?.activeWorkspaceId
-        if (!workspaceId) {
-            throw new InternalFlowiseError(
-                StatusCodes.NOT_FOUND,
-                `Error: chatflowsController.saveChatflow - workspace ${workspaceId} not found!`
-            )
-        }
-        const subscriptionId = req.user?.activeOrganizationSubscriptionId || ''
-        req.body.workspaceId = req.user?.activeWorkspaceId
-        const apiResponse = await chatflowsService.importChatflows(chatflows, orgId, workspaceId, subscriptionId)
-        return res.json(apiResponse)
-    } catch (error) {
-        next(error)
-    }
-}
-
 const updateChatflow = async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (typeof req.params === 'undefined' || !req.params.id) {
@@ -281,7 +255,6 @@ export default {
     getChatflowByApiKey,
     getChatflowById,
     saveChatflow,
-    importChatflows,
     updateChatflow,
     getSinglePublicChatflow,
     getSinglePublicChatbotConfig,

--- a/packages/server/src/routes/chatflows/index.ts
+++ b/packages/server/src/routes/chatflows/index.ts
@@ -5,7 +5,6 @@ const router = express.Router()
 
 // CREATE
 router.post('/', checkAnyPermission('chatflows:create,chatflows:update'), chatflowsController.saveChatflow)
-router.post('/importchatflows', checkPermission('chatflows:import'), chatflowsController.importChatflows)
 
 // READ
 router.get('/', checkAnyPermission('chatflows:view,chatflows:update'), chatflowsController.getAllChatflows)

--- a/packages/ui/src/api/chatflows.js
+++ b/packages/ui/src/api/chatflows.js
@@ -10,8 +10,6 @@ const getSpecificChatflowFromPublicEndpoint = (id) => client.get(`/public-chatfl
 
 const createNewChatflow = (body) => client.post(`/chatflows`, body)
 
-const importChatflows = (body) => client.post(`/chatflows/importchatflows`, body)
-
 const updateChatflow = (id, body) => client.put(`/chatflows/${id}`, body)
 
 const deleteChatflow = (id) => client.delete(`/chatflows/${id}`)
@@ -30,7 +28,6 @@ export default {
     getSpecificChatflow,
     getSpecificChatflowFromPublicEndpoint,
     createNewChatflow,
-    importChatflows,
     updateChatflow,
     deleteChatflow,
     getIsChatflowStreaming,


### PR DESCRIPTION
## Description
This PR removes the `importChatflow` method from "packages/server/src/services/chatflows/index.ts" as it has been replaced by the implementation in "packages/server/src/services/export-import/index.ts".

## Result
**Load Chatflow**
<img width="1329" height="413" alt="Screenshot 2025-07-29 153224" src="https://github.com/user-attachments/assets/3b768142-4b3c-4e1c-874b-2ef1700693c8" />
<img width="2557" height="1266" alt="Screenshot 2025-07-29 153201" src="https://github.com/user-attachments/assets/cd87f457-10a4-47dd-9e1c-91fadcc796fa" />

**Import Chatflow**
<img width="1292" height="951" alt="Screenshot 2025-07-29 153939" src="https://github.com/user-attachments/assets/2ad77513-36eb-47aa-b88c-da762c523669" />
