### PR TITLE
Fix: ignored agentflow LLM structuredOutput keys

### DIFF
--- a/packages/components/nodes/agentflow/LLM/LLM.ts
+++ b/packages/components/nodes/agentflow/LLM/LLM.ts
@@ -897,7 +897,7 @@ class LLM_Agentflow implements INode {
         if (isStructuredOutput && typeof response === 'object') {
             const structuredOutput = response as Record<string, any>
             for (const key in structuredOutput) {
-                if (structuredOutput[key]) {
+                if (structuredOutput[key] !== undefined && structuredOutput[key] !== null) {
                     output[key] = structuredOutput[key]
                 }
             }


### PR DESCRIPTION
This pull request fixes the issue where structuredOutput[key] values of 0 or false are ignored