### PR TITLE
Fix stripHTMLFromToolInput conversion escaping

### DIFF
--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -1347,7 +1347,8 @@ export const stripHTMLFromToolInput = (input: string) => {
     const turndownService = new TurndownService()
     let cleanedInput = turndownService.turndown(input)
     // After conversion, replace any escaped underscores with regular underscores
-    cleanedInput = cleanedInput.replace(/\\_/g, '_')
+    // and remove any escaped square brackets
+    cleanedInput = cleanedInput.replace(/\\([_[\]])/g, '$1')
     return cleanedInput
 }
 

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -1346,8 +1346,7 @@ export const refreshOAuth2Token = async (
 export const stripHTMLFromToolInput = (input: string) => {
     const turndownService = new TurndownService()
     let cleanedInput = turndownService.turndown(input)
-    // After conversion, replace any escaped underscores with regular underscores
-    // and remove any escaped square brackets
+    // After conversion, replace any escaped underscores and square brackets with regular unescaped ones
     cleanedInput = cleanedInput.replace(/\\([_[\]])/g, '$1')
     return cleanedInput
 }


### PR DESCRIPTION
When converting HTML-wrapped JSON in the stripHTMLFromToolInput with Turndown, square brackets (and underscores) were being escaped (e.g. \[/\]), breaking JSON parsing. 

This adds an update to the existing post-processing step to unescape [_\[\]], restoring the original characters.

**Example**

```
// Before (incorrect)
stripHTMLFromToolInput('<p>{"targets":["https://test.com/"]}</p>')
//   '{"targets":\\["https://test.com/"\\]}'  

// After (fixed)
stripHTMLFromToolInput('<p>{"targets":["https://test.com/"]}</p>')
//   '{"targets":["https://test.com/"]}'
```