### PR TITLE
Fix import null bytes error

### DIFF
--- a/packages/server/src/services/export-import/index.ts
+++ b/packages/server/src/services/export-import/index.ts
@@ -26,6 +26,7 @@ import marketplacesService from '../marketplaces'
 import toolsService from '../tools'
 import variableService from '../variables'
 import { Platform } from '../../Interface'
+import { sanitizeNullBytes } from '../../utils/sanitize.util'
 
 type ExportInput = {
     agentflow: boolean
@@ -752,6 +753,8 @@ const importData = async (importData: ExportData, orgId: string, activeWorkspace
                 importData.Variable = insertWorkspaceId(importData.Variable, activeWorkspaceId)
                 importData = await replaceDuplicateIdsForVariable(queryRunner, importData, importData.Variable)
             }
+
+            importData = sanitizeNullBytes(importData)
 
             await queryRunner.startTransaction()
 

--- a/packages/server/src/utils/sanitize.util.ts
+++ b/packages/server/src/utils/sanitize.util.ts
@@ -1,0 +1,32 @@
+export function sanitizeNullBytes(obj: any): any {
+    const stack = [obj]
+
+    while (stack.length) {
+        const current = stack.pop()
+
+        if (Array.isArray(current)) {
+            for (let i = 0; i < current.length; i++) {
+                const val = current[i]
+                if (typeof val === 'string') {
+                    // eslint-disable-next-line no-control-regex
+                    current[i] = val.replace(/\u0000/g, '')
+                } else if (val && typeof val === 'object') {
+                    stack.push(val)
+                }
+            }
+        } else if (current && typeof current === 'object') {
+            for (const key in current) {
+                if (!Object.hasOwnProperty.call(current, key)) continue
+                const val = current[key]
+                if (typeof val === 'string') {
+                    // eslint-disable-next-line no-control-regex
+                    current[key] = val.replace(/\u0000/g, '')
+                } else if (val && typeof val === 'object') {
+                    stack.push(val)
+                }
+            }
+        }
+    }
+
+    return obj
+}


### PR DESCRIPTION
## Description
Fix `Invalid byte sequence for encoding "UTF8": 0x00` where importing data from SQLite fails on PostgreSQL/MySQL/MariaDB due to null bytes `\u0000` in text fields.

## Results