### PR TITLE
Fixes state interpolation when using {{ output }}

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -957,7 +957,7 @@ class Agent_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = finalResponse
+                        newState[key] = newState[key].replace('{{ output }}', finalResponse)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -957,7 +957,7 @@ class Agent_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = newState[key].replace('{{ output }}', finalResponse)
+                        newState[key] = newState[key].replaceAll('{{ output }}', finalResponse)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/CustomFunction/CustomFunction.ts
+++ b/packages/components/nodes/agentflow/CustomFunction/CustomFunction.ts
@@ -213,7 +213,7 @@ class CustomFunction_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = newState[key].replace('{{ output }}', finalOutput)
+                        newState[key] = newState[key].replaceAll('{{ output }}', finalOutput)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/CustomFunction/CustomFunction.ts
+++ b/packages/components/nodes/agentflow/CustomFunction/CustomFunction.ts
@@ -213,7 +213,7 @@ class CustomFunction_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = finalOutput
+                        newState[key] = newState[key].replace('{{ output }}', finalOutput)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
@@ -217,7 +217,7 @@ class ExecuteFlow_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = newState[key].replace('{{ output }}', resultText)
+                        newState[key] = newState[key].replaceAll('{{ output }}', resultText)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
@@ -217,7 +217,7 @@ class ExecuteFlow_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = resultText
+                        newState[key] = newState[key].replace('{{ output }}', resultText)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/Retriever/Retriever.ts
+++ b/packages/components/nodes/agentflow/Retriever/Retriever.ts
@@ -200,7 +200,7 @@ class Retriever_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = finalOutput
+                        newState[key] = newState[key].replace('{{ output }}', finalOutput)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/Retriever/Retriever.ts
+++ b/packages/components/nodes/agentflow/Retriever/Retriever.ts
@@ -200,7 +200,7 @@ class Retriever_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = newState[key].replace('{{ output }}', finalOutput)
+                        newState[key] = newState[key].replaceAll('{{ output }}', finalOutput)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/Tool/Tool.ts
+++ b/packages/components/nodes/agentflow/Tool/Tool.ts
@@ -275,7 +275,7 @@ class Tool_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = newState[key].replace('{{ output }}', toolOutput)
+                        newState[key] = newState[key].replaceAll('{{ output }}', toolOutput)
                     }
                 }
             }

--- a/packages/components/nodes/agentflow/Tool/Tool.ts
+++ b/packages/components/nodes/agentflow/Tool/Tool.ts
@@ -275,7 +275,7 @@ class Tool_Agentflow implements INode {
             if (newState && Object.keys(newState).length > 0) {
                 for (const key in newState) {
                     if (newState[key].toString().includes('{{ output }}')) {
-                        newState[key] = toolOutput
+                        newState[key] = newState[key].replace('{{ output }}', toolOutput)
                     }
                 }
             }


### PR DESCRIPTION
When a state update includes the {{ output }} variable, the whole value is replaced by the node output.

I assume this is unintentional, so I've used replaceAll instead.