### PR TITLE
docs: refine Traditional Chinese README (zh-TW)

### DIFF
--- a/i18n/README-TW.md
+++ b/i18n/README-TW.md
@@ -13,7 +13,7 @@
 
 [English](../README.md) | 繁體中文 | [简体中文](./README-ZH.md) | [日本語](./README-JA.md) | [한국어](./README-KR.md)
 
-<h3>可視化建構 AI/LLM 流程</h3>
+<h3>可視化建置 AI/LLM 流程</h3>
 <a href="https://github.com/FlowiseAI/Flowise">
 <img width="100%" src="https://github.com/FlowiseAI/Flowise/blob/main/images/flowise_agentflow.gif?raw=true"></a>
 
@@ -37,16 +37,16 @@
 
 ### Docker Compose
 
-1. 克隆 Flowise 項目
-2. 進入項目根目錄的 `docker` 文件夾
-3. 複製 `.env.example` 文件，粘貼到相同位置，並重命名為 `.env` 文件
+1. 複製 Flowise 專案
+2. 進入專案根目錄的 `docker` 資料夾
+3. 複製 `.env.example` 文件，貼到相同位置，並重新命名為 `.env` 文件
 4. `docker compose up -d`
 5. 打開 [http://localhost:3000](http://localhost:3000)
-6. 您可以通過 `docker compose stop` 停止容器
+6. 您可以透過 `docker compose stop` 停止容器
 
 ### Docker 映像
 
-1. 本地構建映像：
+1. 本地建置映像：
     ```bash
     docker build --no-cache -t flowise .
     ```
@@ -63,7 +63,7 @@
 
 ## 👨‍💻 開發者
 
-Flowise 在單個 mono 存儲庫中有 3 個不同的模塊。
+Flowise 在單個 mono 儲存庫中有 3 個不同的模組。
 
 -   `server`: 提供 API 邏輯的 Node 後端
 -   `ui`: React 前端
@@ -79,33 +79,33 @@ Flowise 在單個 mono 存儲庫中有 3 個不同的模塊。
 
 ### 設置
 
-1.  克隆存儲庫
+1.  複製儲存庫
 
     ```bash
     git clone https://github.com/FlowiseAI/Flowise.git
     ```
 
-2.  進入存儲庫文件夾
+2.  進入儲存庫文件夾
 
     ```bash
     cd Flowise
     ```
 
-3.  安裝所有模塊的所有依賴項：
+3.  安裝所有模組的所有依賴項：
 
     ```bash
     pnpm install
     ```
 
-4.  構建所有代碼：
+4.  建置所有程式碼：
 
     ```bash
     pnpm build
     ```
 
     <details>
-    <summary>退出代碼 134（JavaScript 堆內存不足）</summary>  
-      如果在運行上述 `build` 腳本時遇到此錯誤，請嘗試增加 Node.js 堆大小並重新運行腳本：
+    <summary>Exit code 134（JavaScript heap out of memory）</summary>  
+      如果在運行上述 `build` 腳本時遇到此錯誤，請嘗試增加 Node.js 中的 Heap 記憶體大小並重新運行腳本：
 
         export NODE_OPTIONS="--max-old-space-size=4096"
         pnpm build
@@ -118,9 +118,9 @@ Flowise 在單個 mono 存儲庫中有 3 個不同的模塊。
     pnpm start
     ```
 
-    您現在可以訪問 [http://localhost:3000](http://localhost:3000)
+    您現在可以開啟 [http://localhost:3000](http://localhost:3000)
 
-6.  對於開發構建：
+6.  對於開發建置：
 
     -   在 `packages/ui` 中創建 `.env` 文件並指定 `VITE_PORT`（參考 `.env.example`）
     -   在 `packages/server` 中創建 `.env` 文件並指定 `PORT`（參考 `.env.example`）
@@ -130,19 +130,19 @@ Flowise 在單個 mono 存儲庫中有 3 個不同的模塊。
         pnpm dev
         ```
 
-    任何代碼更改都會自動重新加載應用程序 [http://localhost:8080](http://localhost:8080)
+    任何程式碼更改都會自動重新加載應用程式 [http://localhost:8080](http://localhost:8080)
 
-## 🌱 環境變量
+## 🌱 環境變數
 
-Flowise 支持不同的環境變量來配置您的實例。您可以在 `packages/server` 文件夾中的 `.env` 文件中指定以下變量。閱讀 [更多](https://github.com/FlowiseAI/Flowise/blob/main/CONTRIBUTING.md#-env-variables)
+Flowise 支持不同的環境變數來配置您的實例。您可以在 `packages/server` 文件夾中的 `.env` 文件中指定以下變數。閱讀 [更多](https://github.com/FlowiseAI/Flowise/blob/main/CONTRIBUTING.md#-env-variables)
 
 ## 📖 文檔
 
 [Flowise 文檔](https://docs.flowiseai.com/)
 
-## 🌐 自我托管
+## 🌐 自行架設
 
-在您現有的基礎設施中部署 Flowise 自我托管，我們支持各種 [部署](https://docs.flowiseai.com/configuration/deployment)
+在您現有的基礎設施中部署 Flowise，我們支持各種自行架設選項 [部署](https://docs.flowiseai.com/configuration/deployment)
 
 -   [AWS](https://docs.flowiseai.com/configuration/deployment/aws)
 -   [Azure](https://docs.flowiseai.com/configuration/deployment/azure)
@@ -178,9 +178,9 @@ Flowise 支持不同的環境變量來配置您的實例。您可以在 `package
 
       </details>
 
-## ☁️ Flowise 雲
+## ☁️ Flowise 雲端平台
 
-[開始使用 Flowise 雲](https://flowiseai.com/)
+[開始使用 Flowise 雲端平台](https://flowiseai.com/)
 
 ## 🙋 支持
 
@@ -194,9 +194,9 @@ Flowise 支持不同的環境變量來配置您的實例。您可以在 `package
 <img src="https://contrib.rocks/image?repo=FlowiseAI/Flowise" />
 </a>
 
-請參閱 [貢獻指南](../CONTRIBUTING.md)。如果您有任何問題或問題，請通過 [Discord](https://discord.gg/jbaHfsRVBW) 與我們聯繫。
+請參閱 [貢獻指南](../CONTRIBUTING.md)。如果您有任何問題或問題，請透過 [Discord](https://discord.gg/jbaHfsRVBW) 與我們聯繫。
 [![Star History Chart](https://api.star-history.com/svg?repos=FlowiseAI/Flowise&type=Timeline)](https://star-history.com/#FlowiseAI/Flowise&Date)
 
 ## 📄 許可證
 
-此存儲庫中的源代碼根據 [Apache 許可證版本 2.0](../LICENSE.md) 提供。
+此儲存庫中的原始碼根據 [Apache 2.0 授權條款](../LICENSE.md) 授權使用。


### PR DESCRIPTION
This PR improves the Traditional Chinese README (`README-TW.md`) by refining translations and terminology to better fit the zh-TW developer community.

Changes:
- Updated terms such as "環境變量" → "環境變數", "雲" → "雲端平台"
- Improved natural phrasing in multiple sections
- Made the deployment instructions easier to understand for Traditional Chinese users.

Let me know if any adjustments are needed. Happy to revise based on feedback!
