### PR TITLE
Fix chatflow's type null or blank

### DIFF
--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -68,7 +68,7 @@ export interface IChatFlow {
     followUpPrompts?: string
     apiConfig?: string
     category?: string
-    type?: ChatflowType
+    type?: string
     workspaceId?: string
 }
 

--- a/packages/server/src/database/entities/ChatFlow.ts
+++ b/packages/server/src/database/entities/ChatFlow.ts
@@ -1,6 +1,13 @@
 /* eslint-disable */
 import { Entity, Column, CreateDateColumn, UpdateDateColumn, PrimaryGeneratedColumn } from 'typeorm'
-import { ChatflowType, IChatFlow } from '../../Interface'
+import { IChatFlow } from '../../Interface'
+
+export enum ChatflowType {
+    CHATFLOW = 'CHATFLOW',
+    AGENTFLOW = 'AGENTFLOW',
+    MULTIAGENT = 'MULTIAGENT',
+    ASSISTANT = 'ASSISTANT'
+}
 
 @Entity()
 export class ChatFlow implements IChatFlow {
@@ -40,8 +47,8 @@ export class ChatFlow implements IChatFlow {
     @Column({ nullable: true, type: 'text' })
     category?: string
 
-    @Column({ nullable: true, type: 'text' })
-    type?: ChatflowType
+    @Column({ nullable: false, type: 'text', default: ChatflowType.CHATFLOW })
+    type?: string
 
     @Column({ type: 'timestamp' })
     @CreateDateColumn()

--- a/packages/server/src/database/migrations/postgres/1755066758601-ModifyChatflowType.ts
+++ b/packages/server/src/database/migrations/postgres/1755066758601-ModifyChatflowType.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { ChatflowType } from '../../entities/ChatFlow'
+
+export class ModifyChatflowType1755066758601 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE "chat_flow" SET "type" = '${ChatflowType.CHATFLOW}' WHERE "type" IS NULL OR "type" = '';
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "chat_flow" ALTER COLUMN "type" SET DEFAULT '${ChatflowType.CHATFLOW}';
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "chat_flow" ALTER COLUMN "type" SET NOT NULL;
+        `)
+    }
+
+    public async down(): Promise<void> {}
+}

--- a/packages/server/src/database/migrations/postgres/index.ts
+++ b/packages/server/src/database/migrations/postgres/index.ts
@@ -36,6 +36,7 @@ import { AddExecutionEntity1738090872625 } from './1738090872625-AddExecutionEnt
 import { FixOpenSourceAssistantTable1743758056188 } from './1743758056188-FixOpenSourceAssistantTable'
 import { AddErrorToEvaluationRun1744964560174 } from './1744964560174-AddErrorToEvaluationRun'
 import { ModifyExecutionSessionIdFieldType1748450230238 } from './1748450230238-ModifyExecutionSessionIdFieldType'
+import { ModifyChatflowType1755066758601 } from './1755066758601-ModifyChatflowType'
 
 import { AddAuthTables1720230151482 } from '../../../enterprise/database/migrations/postgres/1720230151482-AddAuthTables'
 import { AddWorkspace1720230151484 } from '../../../enterprise/database/migrations/postgres/1720230151484-AddWorkspace'
@@ -98,5 +99,6 @@ export const postgresMigrations = [
     FixOpenSourceAssistantTable1743758056188,
     AddErrorToEvaluationRun1744964560174,
     ExecutionLinkWorkspaceId1746862866554,
-    ModifyExecutionSessionIdFieldType1748450230238
+    ModifyExecutionSessionIdFieldType1748450230238,
+    ModifyChatflowType1755066758601
 ]


### PR DESCRIPTION
## Description
Sets the `type` column in the `chat_flow` table to non-nullable and assigns a default value of `CHATFLOW`.

## Migration Result
### Enterprise
| Database | Before | After |
| --- | --- | --- |
| SQLite | | |
| PostgreSQL | <img width="1332" height="507" alt="agentflow" src="https://github.com/user-attachments/assets/f47496e3-897a-454f-ad24-d217c08609e8" /><img width="1313" height="960" alt="chatflow" src="https://github.com/user-attachments/assets/38e49685-d5cb-41e3-ac79-bca5156fc7b6" /><img width="477" height="324" alt="database-data" src="https://github.com/user-attachments/assets/d3f17147-b3bc-4228-b7e2-1b9cd3c72f28" /><img width="552" height="533" alt="database-migrations" src="https://github.com/user-attachments/assets/10b88e64-48db-49d9-9871-50a454bf5ad0" /><img width="748" height="365" alt="database-properties" src="https://github.com/user-attachments/assets/7392c8f6-93a1-459b-8ede-299a3d1d3f1f" /> | <img width="1416" height="514" alt="agentflow" src="https://github.com/user-attachments/assets/5f53d476-3312-47c6-b520-c7e0e3e9d9f5" /><img width="1374" height="969" alt="chatflow" src="https://github.com/user-attachments/assets/a5fc465e-c4ad-4e0c-a610-aa5cbcf83fbf" /><img width="476" height="325" alt="database-data" src="https://github.com/user-attachments/assets/c0760127-9892-4470-bfcc-f6eb3b03fdeb" /><img width="555" height="537" alt="database-migrations" src="https://github.com/user-attachments/assets/162f0490-5817-4845-aa23-ceb05ad2f18e" /><img width="745" height="341" alt="database-properties" src="https://github.com/user-attachments/assets/76f8d061-1aba-452f-acd1-a97470947c53" /> |
| MySQL | | |
| MariaDB | | |

## Migration Result
### Cloud
| Database | Before | After |
| --- | --- | --- |
| PostgreSQL |  |