### PR TITLE
Use ADC credentials on the gcs storage client

### DIFF
--- a/packages/components/src/storageUtils.ts
+++ b/packages/components/src/storageUtils.ts
@@ -1036,15 +1036,12 @@ export const getGcsClient = () => {
     const projectId = process.env.GOOGLE_CLOUD_STORAGE_PROJ_ID
     const bucketName = process.env.GOOGLE_CLOUD_STORAGE_BUCKET_NAME
 
-    if (!pathToGcsCredential) {
-        throw new Error('GOOGLE_CLOUD_STORAGE_CREDENTIAL env variable is required')
-    }
     if (!bucketName) {
         throw new Error('GOOGLE_CLOUD_STORAGE_BUCKET_NAME env variable is required')
     }
 
     const storageConfig = {
-        keyFilename: pathToGcsCredential,
+        ...(pathToGcsCredential ? { keyFilename: pathToGcsCredential } : {}),
         ...(projectId ? { projectId } : {})
     }
 


### PR DESCRIPTION
This makes the GCS credentials optional, which in turn makes the Google storage client fall back to detection (including ADC).

This makes "Full file upload" compatible with Google Cloud & GKE using Workload Identity.

Tested this on my deployment of flowise.

Fixes: https://github.com/FlowiseAI/Flowise/issues/5101