### PR TITLE
feat: Enable Tracing Support For Self-Hosted & Cloud Phoenix Instance

### DIFF
--- a/packages/components/src/handler.test.ts
+++ b/packages/components/src/handler.test.ts
@@ -1,0 +1,51 @@
+import { getPhoenixTracer } from './handler'
+
+jest.mock('@opentelemetry/exporter-trace-otlp-proto', () => {
+    return {
+        ProtoOTLPTraceExporter: jest.fn().mockImplementation((args) => {
+            return { args }
+        })
+    }
+})
+
+import { OTLPTraceExporter as ProtoOTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
+
+describe('URL Handling For Phoenix Tracer', () => {
+    const apiKey = 'test-api-key'
+    const projectName = 'test-project-name'
+
+    const makeOptions = (baseUrl: string) => ({
+        baseUrl,
+        apiKey,
+        projectName,
+        enableCallback: false
+    })
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    const cases: [string, string][] = [
+        ['http://localhost:6006', 'http://localhost:6006/v1/traces'],
+        ['http://localhost:6006/v1/traces', 'http://localhost:6006/v1/traces'],
+        ['https://app.phoenix.arize.com', 'https://app.phoenix.arize.com/v1/traces'],
+        ['https://app.phoenix.arize.com/v1/traces', 'https://app.phoenix.arize.com/v1/traces'],
+        ['https://app.phoenix.arize.com/s/my-space', 'https://app.phoenix.arize.com/s/my-space/v1/traces'],
+        ['https://app.phoenix.arize.com/s/my-space/v1/traces', 'https://app.phoenix.arize.com/s/my-space/v1/traces'],
+        ['https://my-phoenix.com/my-slug', 'https://my-phoenix.com/my-slug/v1/traces'],
+        ['https://my-phoenix.com/my-slug/v1/traces', 'https://my-phoenix.com/my-slug/v1/traces']
+    ]
+
+    it.each(cases)('baseUrl %s - exporterUrl %s', (input, expected) => {
+        getPhoenixTracer(makeOptions(input))
+        expect(ProtoOTLPTraceExporter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: expected,
+                headers: expect.objectContaining({
+                    api_key: apiKey,
+                    authorization: `Bearer ${apiKey}`
+                })
+            })
+        )
+    })
+})

--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -1,4 +1,5 @@
 import { Logger } from 'winston'
+import { URL } from 'url'
 import { v4 as uuidv4 } from 'uuid'
 import { Client } from 'langsmith'
 import CallbackHandler from 'langfuse-langchain'
@@ -94,10 +95,14 @@ interface PhoenixTracerOptions {
 function getPhoenixTracer(options: PhoenixTracerOptions): Tracer | undefined {
     const SEMRESATTRS_PROJECT_NAME = 'openinference.project.name'
     try {
+        const parsed = new URL(options.baseUrl)
+        const baseEndpoint = `${parsed.protocol}//${parsed.host}`
+        const path = parsed.pathname.replace(/\/$/, '')
         const traceExporter = new ProtoOTLPTraceExporter({
-            url: `${options.baseUrl}/v1/traces`,
+            url: `${baseEndpoint}${path}/v1/traces`,
             headers: {
-                api_key: options.apiKey
+                api_key: options.apiKey || '',
+                authorization: `Bearer ${options.apiKey || ''}`
             }
         })
         const tracerProvider = new NodeTracerProvider({


### PR DESCRIPTION
## Summary

This PR adds support for both Self-Hosted & Cloud Phoenix integration. It enables tracing with endpoint URLs that may include space-specific path components. The update also adds validation logic to handle URLs with or without path suffixes, making setup seamless for Phoenix Cloud instances.

## Screenshots

**Phoenix Cloud**
<img width="1920" height="974" alt="Flowise_Phoenix_Cloud" src="https://github.com/user-attachments/assets/7793c92d-d27a-48a3-8dbf-dce6633e8269" />

**Self-Hosted Phoenix**
<img width="1920" height="974" alt="Flowise_Phoenix_Local" src="https://github.com/user-attachments/assets/75415a74-e56e-46c0-bc96-57987e1b5241" />
