### PR TITLE
feat: add config override for langwatch to allow passing metadata as well

### DIFF
--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -591,6 +591,15 @@ export const additionalCallbacks = async (nodeData: INodeData, options: ICommonO
                     })
 
                     const trace = langwatch.getTrace()
+
+                    if (nodeData?.inputs?.analytics?.langWatch) {
+                        trace.update({
+                            metadata: {
+                                ...nodeData?.inputs?.analytics?.langWatch
+                            }
+                        })
+                    }
+
                     callbacks.push(trace.getLangChainCallback())
                 } else if (provider === 'arize') {
                     const arizeApiKey = getCredentialParam('arizeApiKey', credentialData, nodeData)


### PR DESCRIPTION
This allows passing metadata like userId into LangWatch for analytics as documented:

<img width="830" height="406" alt="Screenshot 2025-08-21 at 19 09 39" src="https://github.com/user-attachments/assets/b11fd1d1-ba71-42d5-a276-48cdcb18d150" />
