### PR TITLE
Feat: add gpt oss models to aws bedrock 

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -4,6 +4,20 @@
             "name": "awsChatBedrock",
             "models": [
                 {
+                    "label": "openai.gpt-oss-20b-1:0",
+                    "name": "openai.gpt-oss-20b-1:0",
+                    "description": "21B parameters model optimized for lower latency, local, and specialized use cases",
+                    "input_cost": 0.000015,
+                    "output_cost": 0.000075
+                },
+                {
+                    "label": "openai.gpt-oss-120b-1:0",
+                    "name": "openai.gpt-oss-120b-1:0",
+                    "description": "120B parameters model optimized for production, general purpose, and high-reasoning use cases",
+                    "input_cost": 0.000015,
+                    "output_cost": 0.000075
+                },
+                {
                     "label": "anthropic.claude-opus-4-1-20250805-v1:0",
                     "name": "anthropic.claude-opus-4-1-20250805-v1:0",
                     "description": "Claude 4.1 Opus",

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -7,15 +7,15 @@
                     "label": "openai.gpt-oss-20b-1:0",
                     "name": "openai.gpt-oss-20b-1:0",
                     "description": "21B parameters model optimized for lower latency, local, and specialized use cases",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 0.00007,
+                    "output_cost": 0.0003
                 },
                 {
                     "label": "openai.gpt-oss-120b-1:0",
                     "name": "openai.gpt-oss-120b-1:0",
                     "description": "120B parameters model optimized for production, general purpose, and high-reasoning use cases",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 0.00015,
+                    "output_cost": 0.0006
                 },
                 {
                     "label": "anthropic.claude-opus-4-1-20250805-v1:0",


### PR DESCRIPTION
## Summary
This PR adds support for OpenAI's new open-weight GPT-OSS models that are now available on AWS Bedrock.

Pricing is based on https://aws.amazon.com/bedrock/pricing/

## Note
only available in us-west-2 region

## Testing
Tested by configuring MODEL_LIST_CONFIG_JSON to local `models.json`.

<img width="689" height="332" alt="Screenshot 2025-08-21 at 4 40 59 PM" src="https://github.com/user-attachments/assets/2971ca57-fdac-467e-bbdb-8822263ce9f4" />

No idea why it pretends to be gpt-4, but it works.

<img width="384" height="325" alt="Screenshot 2025-08-21 at 4 41 04 PM" src="https://github.com/user-attachments/assets/a4a7f8e9-37fd-4d3c-9b8c-6691a50f7a52" />
