### PR TITLE
fix: handle empty input and missing clipboard API in Format Prompt Values dialog

### DIFF
--- a/packages/ui/src/views/agentexecutions/NodeExecutionDetails.jsx
+++ b/packages/ui/src/views/agentexecutions/NodeExecutionDetails.jsx
@@ -156,11 +156,21 @@ export const NodeExecutionDetails = ({ data, label, status, metadata, isPublic, 
     }
 
     const onClipboardCopy = (e) => {
-        const src = e.src
-        if (Array.isArray(src) || typeof src === 'object') {
-            navigator.clipboard.writeText(JSON.stringify(src, null, '  '))
-        } else {
-            navigator.clipboard.writeText(src)
+        // Check if clipboard API is available
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+            console.warn('Clipboard API not available')
+            return
+        }
+
+        try {
+            const src = e.src
+            if (Array.isArray(src) || typeof src === 'object') {
+                navigator.clipboard.writeText(JSON.stringify(src, null, '  '))
+            } else {
+                navigator.clipboard.writeText(src || '')
+            }
+        } catch (error) {
+            console.error('Error copying to clipboard:', error)
         }
     }
 

--- a/packages/ui/src/views/docstore/ExpandedChunkDialog.jsx
+++ b/packages/ui/src/views/docstore/ExpandedChunkDialog.jsx
@@ -26,11 +26,21 @@ const ExpandedChunkDialog = ({ show, dialogProps, onCancel, onChunkEdit, onDelet
     const [metadata, setMetadata] = useState({})
 
     const onClipboardCopy = (e) => {
-        const src = e.src
-        if (Array.isArray(src) || typeof src === 'object') {
-            navigator.clipboard.writeText(JSON.stringify(src, null, '  '))
-        } else {
-            navigator.clipboard.writeText(src)
+        // Check if clipboard API is available
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+            console.warn('Clipboard API not available')
+            return
+        }
+
+        try {
+            const src = e.src
+            if (Array.isArray(src) || typeof src === 'object') {
+                navigator.clipboard.writeText(JSON.stringify(src, null, '  '))
+            } else {
+                navigator.clipboard.writeText(src || '')
+            }
+        } catch (error) {
+            console.error('Error copying to clipboard:', error)
         }
     }
 


### PR DESCRIPTION
Problem

- When leaving the input field empty in the Format Prompt Values dialog and clicking on Copy to clipboard, the app:
Throws a console error:
TypeError: Cannot read properties of undefined (reading 'writeText')

- Turns the page blank

- Causes unsaved flow data to be lost

Root Cause

- navigator.clipboard.writeText was being called without checking if the Clipboard API was available
- Empty string values ("") were not being handled safely, leading to JSON parsing and clipboard issues

Solution

This PR improves clipboard handling across components by:

- Adding Clipboard API availability checks (if (navigator?.clipboard?.writeText))

- Wrapping copy operations in try/catch blocks for safer error handling

- Gracefully handling empty values ("") without breaking the UI

- Applying the same safety pattern consistently across components:
       JsonEditor.jsx
       ExpandedChunkDialog.jsx
       NodeExecutionDetails.jsx
       
Result

No more crashes or blank pages when copying empty/invalid input
Consistent clipboard handling across the app
Better browser compatibility and error resilience