### PR TITLE
Update pdfjs-dist version to ^3.11.174

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -131,7 +131,7 @@
         "openai": "^4.96.0",
         "papaparse": "^5.4.1",
         "pdf-parse": "^1.1.1",
-        "pdfjs-dist": "^5.3.93",
+        "pdfjs-dist": "^3.11.174",
         "pg": "^8.11.2",
         "playwright": "^1.35.0",
         "puppeteer": "^20.7.1",


### PR DESCRIPTION
The file `pdfjs-dist/legacy/build/pdf.js` is only available in version 3.11.174 of `pdfjs-dist`. In later versions, this file is missing. Therefore, the version has been set to 3.11.174