### PR TITLE
Bugfix/Human Input As First Node

### DIFF
--- a/packages/components/nodes/agentflow/HumanInput/HumanInput.ts
+++ b/packages/components/nodes/agentflow/HumanInput/HumanInput.ts
@@ -208,7 +208,7 @@ class HumanInput_Agentflow implements INode {
                 humanInputDescription = (nodeData.inputs?.humanInputDescription as string) || 'Do you want to proceed?'
                 const messages = [...pastChatHistory, ...runtimeChatHistory]
                 // Find the last message in the messages array
-                const lastMessage = (messages[messages.length - 1] as any).content || ''
+                const lastMessage = messages.length > 0 ? (messages[messages.length - 1] as any).content || '' : ''
                 humanInputDescription = `${lastMessage}\n\n${humanInputDescription}`
                 if (isStreamable) {
                     const sseStreamer: IServerSideEventStreamer = options.sseStreamer as IServerSideEventStreamer


### PR DESCRIPTION
Updated logic to ensure that the last message is retrieved safely, preventing potential errors when the messages array is empty for Human Input Node

<img width="1657" height="957" alt="image" src="https://github.com/user-attachments/assets/89b3b582-a961-403f-b3f7-e2ba5b15bfec" />
