### PR TITLE
Bugfix/Create Index Chatflow Name

### DIFF
--- a/packages/server/src/database/migrations/mariadb/1755748356008-AddChatFlowNameIndex.ts
+++ b/packages/server/src/database/migrations/mariadb/1755748356008-AddChatFlowNameIndex.ts
@@ -4,7 +4,7 @@ export class AddChatFlowNameIndex1755748356008 implements MigrationInterface {
     name = 'AddChatFlowNameIndex1755748356008'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE INDEX \`IDX_chatflow_name\` ON \`chat_flow\` (\`name\`)`)
+        await queryRunner.query(`CREATE INDEX \`IDX_chatflow_name\` ON \`chat_flow\` (LEFT(\`name\`, 255))`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/server/src/database/migrations/mysql/1755748356008-AddChatFlowNameIndex.ts
+++ b/packages/server/src/database/migrations/mysql/1755748356008-AddChatFlowNameIndex.ts
@@ -4,7 +4,7 @@ export class AddChatFlowNameIndex1755748356008 implements MigrationInterface {
     name = 'AddChatFlowNameIndex1755748356008'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE INDEX \`IDX_chatflow_name\` ON \`chat_flow\` (\`name\`)`)
+        await queryRunner.query(`CREATE INDEX \`IDX_chatflow_name\` ON \`chat_flow\` (LEFT(\`name\`, 255))`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/server/src/database/migrations/postgres/1755748356008-AddChatFlowNameIndex.ts
+++ b/packages/server/src/database/migrations/postgres/1755748356008-AddChatFlowNameIndex.ts
@@ -4,7 +4,7 @@ export class AddChatFlowNameIndex1755748356008 implements MigrationInterface {
     name = 'AddChatFlowNameIndex1755748356008'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE INDEX "IDX_chatflow_name" ON "chat_flow" ("name")`)
+        await queryRunner.query(`CREATE INDEX "IDX_chatflow_name" ON "chat_flow" (substring("name" from 1 for 255))`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/server/src/database/migrations/sqlite/1755748356008-AddChatFlowNameIndex.ts
+++ b/packages/server/src/database/migrations/sqlite/1755748356008-AddChatFlowNameIndex.ts
@@ -4,7 +4,7 @@ export class AddChatFlowNameIndex1755748356008 implements MigrationInterface {
     name = 'AddChatFlowNameIndex1755748356008'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE INDEX "IDX_chatflow_name" ON "chat_flow" ("name")`)
+        await queryRunner.query(`CREATE INDEX "IDX_chatflow_name" ON "chat_flow" (substr("name", 1, 255))`)
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
Refactor index creation for chat_flow name across multiple databases to limit indexed length to 255 characters.

Fix:
```

2025-09-15 15:32:54 [ERROR]: QueryFailedError: index row size 3448 exceeds btree version 4 maximum 2704 for index "IDX_chatflow_name"

at PostgresQueryRunner.query (/usr/src/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.2_mongodb@6.3.0_gcp-metadata@7.0.1_socks@2.8.1__mysql2@3.11._91bb8cebce37e0cf7ba17a39ae30ff6a/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:219:19)

at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

at async AddChatFlowNameIndex1755748356008.up (/usr/src/packages/server/dist/database/migrations/postgres/1755748356008-AddChatFlowNameIndex.js:9:9)

at async MigrationExecutor.executePendingMigrations (/usr/src/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.2_mongodb@6.3.0_gcp-metadata@7.0.1_socks@2.8.1__mysql2@3.11._91bb8cebce37e0cf7ba17a39ae30ff6a/node_modules/typeorm/migration/MigrationExecutor.js:225:17)

at async DataSource.runMigrations (/usr/src/node_modules/.pnpm/typeorm@0.3.20_ioredis@5.4.2_mongodb@6.3.0_gcp-metadata@7.0.1_socks@2.8.1__mysql2@3.11._91bb8cebce37e0cf7ba17a39ae30ff6a/node_modules/typeorm/data-source/DataSource.js:265:35)

at async Worker.prepareData (/usr/src/packages/server/dist/commands/worker.js:51:9)

at async Worker.run (/usr/src/packages/server/dist/commands/worker.js:19:113)

at async Worker._run (/usr/src/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/command.js:302:22)

at async Config.runCommand (/usr/src/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/config/config.js:424:25)

at async Object.run (/usr/src/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/main.js:94:16)

Migration "AddChatFlowNameIndex1755748356008" failed, error: index row size 3448 exceeds btree version 4 maximum 2704 for index "IDX_chatflow_name"

query failed: CREATE INDEX "IDX_chatflow_name" ON "chat_flow" ("name")

error: error: index row size 3448 exceeds btree version 4 maximum 2704 for index "IDX_chatflow_name"
```