### PR TITLE
Feat/replace infinite loading with save prompt

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -396,6 +396,18 @@
                     "name": "gpt-4.5-preview",
                     "input_cost": 0.000075,
                     "output_cost": 0.00015
+                },
+                {
+                    "label": "gpt-4.1-mini",
+                    "name": "gpt-4.1-mini",
+                    "input_cost": 0.0000004,
+                    "output_cost": 0.0000016
+                },
+                {
+                    "label": "gpt-5-chat-latest",
+                    "name": "gpt-5-chat-latest",
+                    "input_cost": 0.00000125,
+                    "output_cost": 0.00001
                 }
             ]
         },
@@ -455,6 +467,18 @@
                     "name": "gpt-4-1106-preview",
                     "input_cost": 0.00001,
                     "output_cost": 0.00003
+                },
+                {
+                    "label": "gpt-4.1-mini",
+                    "name": "gpt-4.1-mini",
+                    "input_cost": 0.0000004,
+                    "output_cost": 0.0000016
+                },
+                {
+                    "label": "gpt-5-chat-latest",
+                    "name": "gpt-5-chat-latest",
+                    "input_cost": 0.00000125,
+                    "output_cost": 0.00001
                 }
             ]
         },
@@ -1682,6 +1706,18 @@
                     "name": "gpt-4-32k",
                     "input_cost": 0.00006,
                     "output_cost": 0.00012
+                },
+                {
+                    "label": "gpt-4.1-mini",
+                    "name": "gpt-4.1-mini",
+                    "input_cost": 0.0000004,
+                    "output_cost": 0.0000016
+                },
+                {
+                    "label": "gpt-5-chat-latest",
+                    "name": "gpt-5-chat-latest",
+                    "input_cost": 0.00000125,
+                    "output_cost": 0.00001
                 }
             ]
         },

--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -31,6 +31,7 @@ import ConfirmDialog from '@/ui-component/dialog/ConfirmDialog'
 import EditNodeDialog from '@/views/agentflowsv2/EditNodeDialog'
 import ChatPopUp from '@/views/chatmessage/ChatPopUp'
 import ValidationPopUp from '@/views/chatmessage/ValidationPopUp'
+import SaveChatflowDialog from '@/ui-component/dialog/SaveChatflowDialog'
 import { flowContext } from '@/store/context/ReactFlowContext'
 
 // API
@@ -100,6 +101,7 @@ const AgentflowCanvas = () => {
     const [isSyncNodesButtonEnabled, setIsSyncNodesButtonEnabled] = useState(false)
     const [editNodeDialogOpen, setEditNodeDialogOpen] = useState(false)
     const [editNodeDialogProps, setEditNodeDialogProps] = useState({})
+    const [flowDialogOpen, setFlowDialogOpen] = useState(false)
     const [isSnappingEnabled, setIsSnappingEnabled] = useState(false)
 
     const reactFlowWrapper = useRef(null)
@@ -238,6 +240,15 @@ const AgentflowCanvas = () => {
                 updateChatflowApi.request(chatflow.id, updateBody)
             }
         }
+    }
+
+    const onConfirmSaveName = (flowName) => {
+        setFlowDialogOpen(false)
+        handleSaveFlow(flowName)
+    }
+
+    const openSaveDialog = () => {
+        setFlowDialogOpen(true)
     }
 
     // eslint-disable-next-line
@@ -785,13 +796,23 @@ const AgentflowCanvas = () => {
                                         <IconRefreshAlert />
                                     </Fab>
                                 )}
-                                <ChatPopUp isAgentCanvas={true} chatflowid={chatflowId} onOpenChange={setChatPopupOpen} />
+                                <ChatPopUp isAgentCanvas={true} chatflowid={chatflowId} onOpenChange={setChatPopupOpen} onOpenSaveDialog={openSaveDialog} />
                                 {!chatPopupOpen && <ValidationPopUp isAgentCanvas={true} chatflowid={chatflowId} />}
                             </ReactFlow>
                         </div>
                     </div>
                 </Box>
                 <ConfirmDialog />
+                <SaveChatflowDialog
+                    show={flowDialogOpen}
+                    dialogProps={{
+                        title: 'Save New Agent Flow',
+                        confirmButtonName: 'Save',
+                        cancelButtonName: 'Cancel'
+                    }}
+                    onCancel={() => setFlowDialogOpen(false)}
+                    onConfirm={onConfirmSaveName}
+                />
             </Box>
         </>
     )

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -24,6 +24,7 @@ import StickyNote from './StickyNote'
 import CanvasHeader from './CanvasHeader'
 import AddNodes from './AddNodes'
 import ConfirmDialog from '@/ui-component/dialog/ConfirmDialog'
+import SaveChatflowDialog from '@/ui-component/dialog/SaveChatflowDialog'
 import ChatPopUp from '@/views/chatmessage/ChatPopUp'
 import VectorStorePopUp from '@/views/vectorstore/VectorStorePopUp'
 import { flowContext } from '@/store/context/ReactFlowContext'
@@ -104,6 +105,7 @@ const Canvas = () => {
     const [lastUpdatedDateTime, setLasUpdatedDateTime] = useState('')
     const [chatflowName, setChatflowName] = useState('')
     const [flowData, setFlowData] = useState('')
+    const [flowDialogOpen, setFlowDialogOpen] = useState(false)
 
     // ==============================|| Chatflow API ||============================== //
 
@@ -240,6 +242,16 @@ const Canvas = () => {
                 setFlowData(flowData)
                 getHasChatflowChangedApi.request(chatflow.id, lastUpdatedDateTime)
             }
+        }
+    }
+
+    const openSaveDialog = () => {
+        if (chatflow?.id) {
+            // If chatflow has an ID, save directly using the flow name
+            handleSaveFlow(chatflow.name)
+        } else {
+            // If no ID, open the save dialog
+            setFlowDialogOpen(true)
         }
     }
 
@@ -431,7 +443,8 @@ const Canvas = () => {
             const chatflow = createNewChatflowApi.data
             dispatch({ type: SET_CHATFLOW, chatflow })
             saveChatflowSuccess()
-            window.history.replaceState(state, null, `/${isAgentCanvas ? 'agentcanvas' : 'canvas'}/${chatflow.id}`)
+            setFlowDialogOpen(false) // Close the save dialog
+            navigate(`/${isAgentCanvas ? 'agentcanvas' : 'canvas'}/${chatflow.id}`)
         } else if (createNewChatflowApi.error) {
             errorFailed(`Failed to retrieve ${canvasTitle}: ${createNewChatflowApi.error.response.data.message}`)
         }
@@ -645,12 +658,22 @@ const Canvas = () => {
                                     </Fab>
                                 )}
                                 {isUpsertButtonEnabled && <VectorStorePopUp chatflowid={chatflowId} />}
-                                <ChatPopUp isAgentCanvas={isAgentCanvas} chatflowid={chatflowId} />
+                                <ChatPopUp isAgentCanvas={isAgentCanvas} chatflowid={chatflowId} onOpenSaveDialog={openSaveDialog} />
                             </ReactFlow>
                         </div>
                     </div>
                 </Box>
                 <ConfirmDialog />
+                <SaveChatflowDialog
+                    show={flowDialogOpen}
+                    dialogProps={{
+                        title: 'Save Flow',
+                        cancelButtonName: 'Cancel',
+                        confirmButtonName: 'Save'
+                    }}
+                    onCancel={() => setFlowDialogOpen(false)}
+                    onConfirm={(name) => handleSaveFlow(name)}
+                />
             </Box>
         </>
     )

--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -1705,7 +1705,7 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
                     Save Flow to Continue
                 </Typography>
                 <Typography variant="body2" color="text.secondary" align="center" sx={{ mb: 3 }}>
-                    You need to save this agent flow before you can test it with messages.
+                    You need to save this {isAgentCanvas ? 'agent flow' : 'chatflow'} before you can test it with messages.
                 </Typography>
                 <Button 
                     variant="contained" 

--- a/packages/ui/src/views/chatmessage/ChatMessage.jsx
+++ b/packages/ui/src/views/chatmessage/ChatMessage.jsx
@@ -38,7 +38,8 @@ import {
     IconSquareFilled,
     IconCheck,
     IconPaperclip,
-    IconSparkles
+    IconSparkles,
+    IconDeviceFloppy
 } from '@tabler/icons-react'
 import robotPNG from '@/assets/images/robot.png'
 import userPNG from '@/assets/images/account.png'
@@ -162,7 +163,7 @@ CardWithDeleteOverlay.propTypes = {
     onDelete: PropTypes.func
 }
 
-const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setPreviews }) => {
+const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setPreviews, onOpenSaveDialog }) => {
     const theme = useTheme()
     const customization = useSelector((state) => state.customization)
 
@@ -250,6 +251,10 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
     const [formInputParams, setFormInputParams] = useState([])
 
     const [isConfigLoading, setIsConfigLoading] = useState(true)
+    const [showSaveDialog, setShowSaveDialog] = useState(false)
+    const [pendingMessage, setPendingMessage] = useState('')
+    const [pendingMessageAction, setPendingMessageAction] = useState(null)
+    const [pendingHumanInput, setPendingHumanInput] = useState(null)
 
     const isFileAllowedForUpload = (file) => {
         const constraints = getAllowChatFlowUploads.data
@@ -1672,6 +1677,48 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
         }
     }
 
+    // If no chatflowid and this is an agent canvas, show save prompt
+    if (!chatflowid) {
+        const handleSaveFlow = () => {
+            // Use the proper Flowise save dialog
+            if (onOpenSaveDialog) {
+                onOpenSaveDialog()
+            }
+        }
+        
+        return (
+            <Box
+                sx={{
+                    width: '100%',
+                    height: '100%',
+                    position: 'relative',
+                    backgroundColor: theme.palette.background.paper,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    p: 3
+                }}
+            >
+                <IconDeviceFloppy size={48} style={{ marginBottom: 16, color: theme.palette.text.secondary }} />
+                <Typography variant="h6" gutterBottom>
+                    Save Flow to Continue
+                </Typography>
+                <Typography variant="body2" color="text.secondary" align="center" sx={{ mb: 3 }}>
+                    You need to save this agent flow before you can test it with messages.
+                </Typography>
+                <Button 
+                    variant="contained" 
+                    color="primary" 
+                    onClick={handleSaveFlow}
+                    startIcon={<IconDeviceFloppy size={16} />}
+                >
+                    Save Flow
+                </Button>
+            </Box>
+        )
+        }
+
     if (isConfigLoading) {
         return (
             <Box
@@ -2497,6 +2544,45 @@ const ChatMessage = ({ open, chatflowid, isAgentCanvas, isDialog, previews, setP
                     </Button>
                 </DialogActions>
             </Dialog>
+
+            {/* Save Flow Dialog */}
+            {/* <Dialog open={showSaveDialog} onClose={() => setShowSaveDialog(false)} maxWidth="sm" fullWidth>
+                <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <IconDeviceFloppy size={24} />
+                    Save Flow to Continue
+                </DialogTitle>
+                <DialogContent>
+                    <Typography variant="body1" sx={{ mb: 2 }}>
+                        You need to save this agent flow before you can test it with messages.
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                        Would you like to save the flow and continue with your message?
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setShowSaveDialog(false)}>
+                        Cancel
+                    </Button>
+                    <Button 
+                        onClick={() => {
+                            setShowSaveDialog(false)
+                            // Trigger save flow functionality
+                            // This would need to be connected to the Canvas save function
+                            enqueueSnackbar({
+                                message: 'Please save the flow using Ctrl+S or the Save button first',
+                                options: {
+                                    key: new Date().getTime() + Math.random(),
+                                    variant: 'info'
+                                }
+                            })
+                        }} 
+                        variant="contained"
+                        startIcon={<IconDeviceFloppy />}
+                    >
+                        Save & Continue
+                    </Button>
+                </DialogActions>
+            </Dialog> */}
         </div>
     )
 }

--- a/packages/ui/src/views/chatmessage/ChatPopUp.jsx
+++ b/packages/ui/src/views/chatmessage/ChatPopUp.jsx
@@ -27,7 +27,7 @@ import { enqueueSnackbar as enqueueSnackbarAction, closeSnackbar as closeSnackba
 // Utils
 import { getLocalStorageChatflow, removeLocalStorageChatHistory } from '@/utils/genericHelper'
 
-const ChatPopUp = ({ chatflowid, isAgentCanvas, onOpenChange }) => {
+const ChatPopUp = ({ chatflowid, isAgentCanvas, onOpenChange, onOpenSaveDialog }) => {
     const theme = useTheme()
     const { confirm } = useConfirm()
     const dispatch = useDispatch()
@@ -215,6 +215,7 @@ const ChatPopUp = ({ chatflowid, isAgentCanvas, onOpenChange }) => {
                                         open={open}
                                         previews={previews}
                                         setPreviews={setPreviews}
+                                        onOpenSaveDialog={onOpenSaveDialog}
                                     />
                                 </MainCard>
                             </ClickAwayListener>
@@ -238,7 +239,8 @@ const ChatPopUp = ({ chatflowid, isAgentCanvas, onOpenChange }) => {
 ChatPopUp.propTypes = {
     chatflowid: PropTypes.string,
     isAgentCanvas: PropTypes.bool,
-    onOpenChange: PropTypes.func
+    onOpenChange: PropTypes.func,
+    onOpenSaveDialog: PropTypes.func
 }
 
 export default memo(ChatPopUp)


### PR DESCRIPTION
## 🐛 Problem

When users click the message icon on unsaved chatflows or agent flows, the application would show infinite loading with no indication of what was wrong or how to proceed. This created a frustrating user experience where users were I was confused for a while.

## ✨ Solution

Replace the infinite loading state with a clear, actionable save prompt that:
- Explains why the action cannot proceed (flow needs to be saved first)
- Provides a direct "Save Flow" button to resolve the issue
- Guides users to successful completion of their intended action

## What it looks like now
<img width="1172" height="786" alt="Screenshot 2025-09-16 at 18 55 53" src="https://github.com/user-attachments/assets/a5a0101c-82f4-4405-a128-4baa1687979b" />


