### PR TITLE
Fix issu in gpt-5*, o1*, and o3* models as not supporting `stop` to avoid 400 Unsupported parameter errors.

### DIFF
--- a/packages/components/nodes/agents/ConversationalAgent/ConversationalAgent.ts
+++ b/packages/components/nodes/agents/ConversationalAgent/ConversationalAgent.ts
@@ -263,10 +263,11 @@ const prepareAgent = async (
         }
     }
 
-    /** Bind a stop token to the model */
-    const modelWithStop = model.bind({
-        stop: ['\nObservation']
-    })
+    /** Bind a stop token to the model if supported */
+    // Avoid passing `stop` to models that reject it (e.g. gpt-5-nano)
+    const { modelSupportsStop } = await import('../../../src/utils')
+    const modelId = (model as any)?.modelName ?? (model as any)?.model ?? (model as any)?.configuredModel
+    const modelWithStop = modelSupportsStop(modelId) ? model.bind({ stop: ['\nObservation'] }) : model
 
     const runnableAgent = RunnableSequence.from([
         {

--- a/packages/components/nodes/agents/XMLAgent/XMLAgent.ts
+++ b/packages/components/nodes/agents/XMLAgent/XMLAgent.ts
@@ -246,7 +246,11 @@ const prepareAgent = async (
         throw new Error(`Provided prompt is missing required input variables: ${JSON.stringify(missingVariables)}`)
     }
 
-    const llmWithStop = model.bind({ stop: ['</tool_input>', '</final_answer>'] })
+    const { modelSupportsStop } = await import('../../../src/utils')
+    const modelId = (model as any)?.modelName ?? (model as any)?.model ?? (model as any)?.configuredModel
+    const llmWithStop = modelSupportsStop(modelId)
+        ? (model as BaseChatModel).bind({ stop: ['</tool_input>', '</final_answer>'] })
+        : (model as BaseChatModel)
 
     const messages = (await memory.getChatMessages(flowObj.sessionId, false, prependMessages)) as IMessage[]
     let chatHistoryMsgTxt = ''


### PR DESCRIPTION
fix(agents): avoid sending unsupported 'stop' param to models (e.g. gpt-5-nano)

Detect whether a model supports the `stop` parameter and only bind stop sequences when supported. Prevents 400 errors from models that reject `stop`. Files touched: ConversationalAgent, agents utils, XMLAgent (conditional stop binding).