### PR TITLE
fix: ensure Gemini always receives a non-empty contents array

### DIFF
--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
@@ -770,6 +770,12 @@ export class LangchainChatGoogleGenerativeAI
             this.client.systemInstruction = systemInstruction
             actualPrompt = prompt.slice(1)
         }
+
+        // Ensure actualPrompt is never empty
+        if (actualPrompt.length === 0) {
+            actualPrompt = [{ role: 'user', parts: [{ text: '...' }] }]
+        }
+
         const parameters = this.invocationParams(options)
 
         // Handle streaming
@@ -834,6 +840,12 @@ export class LangchainChatGoogleGenerativeAI
             this.client.systemInstruction = systemInstruction
             actualPrompt = prompt.slice(1)
         }
+
+        // Ensure actualPrompt is never empty
+        if (actualPrompt.length === 0) {
+            actualPrompt = [{ role: 'user', parts: [{ text: '...' }] }]
+        }
+
         const parameters = this.invocationParams(options)
         const request = {
             ...parameters,


### PR DESCRIPTION
If you disable memory from an agent when using Gemini models, it gets bugged.
`[400 Bad Request] * GenerateContentRequest.contents: contents is not specified`

Converting system messages as user input if memory is disabled will not work this time, since the Gemini will perform very differently without system prompt. The trick would be to inject a placeholder, like 3 dots (...), as chat history when memory is disabled for this model.