### PR TITLE
Google Calendar Tool Missing sendUpdates Parameter

### DIFF
--- a/packages/components/nodes/tools/GoogleCalendar/GoogleCalendar.ts
+++ b/packages/components/nodes/tools/GoogleCalendar/GoogleCalendar.ts
@@ -273,6 +273,22 @@ class GoogleCalendar_Tools implements INode {
                 optional: true
             },
             {
+                label: 'Send Updates to',
+                name: 'sendUpdates',
+                type: 'options',
+                description: 'Send Updates to attendees',
+                options: [
+                    { label: 'All', name: 'all' },
+                    { label: 'External Only', name: 'externalOnly' },
+                    { label: 'None', name: 'none' }
+                ],
+                show: {
+                    eventActions: ['createEvent', 'updateEvent']
+                },
+                additionalParams: true,
+                optional: true
+            },
+            {
                 label: 'Recurrence Rules',
                 name: 'recurrence',
                 type: 'string',
@@ -560,7 +576,6 @@ class GoogleCalendar_Tools implements INode {
         }
 
         const defaultParams = this.transformNodeInputsToToolArgs(nodeData)
-
         const tools = createGoogleCalendarTools({
             accessToken,
             actions,
@@ -587,6 +602,7 @@ class GoogleCalendar_Tools implements INode {
         if (nodeData.inputs?.startDate) defaultParams.startDate = nodeData.inputs.startDate
         if (nodeData.inputs?.endDate) defaultParams.endDate = nodeData.inputs.endDate
         if (nodeData.inputs?.attendees) defaultParams.attendees = nodeData.inputs.attendees
+        if (nodeData.inputs?.sendUpdates) defaultParams.sendUpdates = nodeData.inputs.sendUpdates
         if (nodeData.inputs?.recurrence) defaultParams.recurrence = nodeData.inputs.recurrence
         if (nodeData.inputs?.reminderMinutes) defaultParams.reminderMinutes = nodeData.inputs.reminderMinutes
         if (nodeData.inputs?.visibility) defaultParams.visibility = nodeData.inputs.visibility

--- a/packages/components/nodes/tools/GoogleCalendar/core.ts
+++ b/packages/components/nodes/tools/GoogleCalendar/core.ts
@@ -48,6 +48,7 @@ const CreateEventSchema = z.object({
     endDate: z.string().optional().describe('End date for all-day events (YYYY-MM-DD)'),
     timeZone: z.string().optional().describe('Time zone (e.g., America/New_York)'),
     attendees: z.string().optional().describe('Comma-separated list of attendee emails'),
+    sendUpdates: z.enum(['all', 'externalOnly', 'none']).optional().default('all').describe('Whether to send notifications to attendees'),
     recurrence: z.string().optional().describe('Recurrence rules (RRULE format)'),
     reminderMinutes: z.number().optional().describe('Minutes before event to send reminder'),
     visibility: z.enum(['default', 'public', 'private', 'confidential']).optional().describe('Event visibility')
@@ -70,6 +71,7 @@ const UpdateEventSchema = z.object({
     endDate: z.string().optional().describe('Updated end date for all-day events (YYYY-MM-DD)'),
     timeZone: z.string().optional().describe('Updated time zone'),
     attendees: z.string().optional().describe('Updated comma-separated list of attendee emails'),
+    sendUpdates: z.enum(['all', 'externalOnly', 'none']).optional().default('all').describe('Whether to send notifications to attendees'),
     recurrence: z.string().optional().describe('Updated recurrence rules'),
     reminderMinutes: z.number().optional().describe('Updated reminder minutes'),
     visibility: z.enum(['default', 'public', 'private', 'confidential']).optional().describe('Updated event visibility')
@@ -286,8 +288,10 @@ class CreateEventTool extends BaseGoogleCalendarTool {
             }
 
             if (params.visibility) eventData.visibility = params.visibility
+            const sendUpdates = params?.sendUpdates || 'all'
+            const query = new URLSearchParams({ sendUpdates })
 
-            const endpoint = `calendars/${encodeURIComponent(params.calendarId)}/events`
+            const endpoint = `calendars/${encodeURIComponent(params.calendarId)}/events?${query.toString()}`
             const response = await this.makeGoogleCalendarRequest({ endpoint, method: 'POST', body: eventData, params })
             return response
         } catch (error) {
@@ -395,8 +399,12 @@ class UpdateEventTool extends BaseGoogleCalendarTool {
             }
 
             if (params.visibility) updateData.visibility = params.visibility
+            const sendUpdates = params?.sendUpdates || 'all'
+            const queryParams = new URLSearchParams({ sendUpdates })
 
-            const endpoint = `calendars/${encodeURIComponent(params.calendarId)}/events/${encodeURIComponent(params.eventId)}`
+            const endpoint = `calendars/${encodeURIComponent(params.calendarId)}/events/${encodeURIComponent(
+                params.eventId
+            )}?${queryParams.toString()}`
             const response = await this.makeGoogleCalendarRequest({ endpoint, method: 'PUT', body: updateData, params })
             return response
         } catch (error) {


### PR DESCRIPTION
Fixes #5222
When creating or updating calendar events with attendees, email notifications should be sent to all attendees regardless of their email domain. 

"all" - Send notifications to all guests (required for external emails)
"externalOnly" - Send notifications only to non-Google Calendar guests
"none" - Don't send notifications