### PR TITLE
Ability to support variable in the URL for HTTP Node.

### DIFF
--- a/packages/components/nodes/agentflow/HTTP/HTTP.ts
+++ b/packages/components/nodes/agentflow/HTTP/HTTP.ts
@@ -67,7 +67,8 @@ class HTTP_Agentflow implements INode {
             {
                 label: 'URL',
                 name: 'url',
-                type: 'string'
+                type: 'string',
+                acceptVariable: true
             },
             {
                 label: 'Headers',


### PR DESCRIPTION
Currently HTTP Node doesn't support the URL to be dynamically set from the variables. 

So, enabled this flag