### PR TITLE
Add neo4j-driver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "lint-staged": {
         "*.{js,jsx,ts,tsx,json,md}": "eslint --fix"
     },
+    "dependencies": {
+        "neo4j-driver": "^6.0.0"
+    },
     "devDependencies": {
         "@babel/preset-env": "^7.19.4",
         "@babel/preset-typescript": "7.18.6",


### PR DESCRIPTION
Description:
This PR adds the official neo4j-driver package to enable direct Neo4J database queries from custom tools.

Changes Made:

Added "neo4j-driver": "^6.0.0" to dependencies in package.json

This enables creating custom tools that can connect directly to Neo4J databases without relying on the built-in Neo4J node

Impact:

No breaking changes to existing functionality

Enables new integration capabilities for Neo4J databases

Allows developers to create custom Neo4J query tools in Flowise

Testing:

Package will be installed automatically during next deployment/build

Can be verified by creating custom tools that require neo4j-driver

This is a straightforward dependency addition that expands Flowise's integration capabilities with Neo4J graph databases.