### PR TITLE
feat: Added acceptVariable to Qdrant Collection name

### DIFF
--- a/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
+++ b/packages/components/nodes/vectorstores/Qdrant/Qdrant.ts
@@ -77,7 +77,8 @@ class Qdrant_VectorStores implements INode {
             {
                 label: 'Qdrant Collection Name',
                 name: 'qdrantCollection',
-                type: 'string'
+                type: 'string',
+                acceptVariable: true
             },
             {
                 label: 'File Upload',


### PR DESCRIPTION
This pull request makes a small improvement to the `Qdrant_VectorStores` node by allowing the `qdrantCollection` field to accept variables. This enhances flexibility when specifying the collection name.