### PR TITLE
Add multilingual response support for Generate Instructions

### DIFF
--- a/packages/server/src/utils/prompt.ts
+++ b/packages/server/src/utils/prompt.ts
@@ -6,6 +6,9 @@ export const ASSISTANT_PROMPT_GENERATOR = `Given a task description, produce a d
 
 # Guidelines
 
+- Language: CRITICAL! You MUST respond in the EXACT SAME LANGUAGE as the input task description.
+    - (e.g., if the task is in Japanese, respond entirely in Japanese; if the task is in English, respond in English. If multiple languages are present, use the primary or dominant one.)
+    - DO NOT translate the task language into English.
 - Understand the Task: Grasp the main objective, goals, requirements, constraints, and expected output.
 - Minimal Changes: If an existing prompt is provided, improve it only if it's simple. For complex prompts, enhance clarity and add missing elements without altering the original structure.
 - Reasoning Before Conclusions**: Encourage reasoning steps before any conclusions are reached. ATTENTION! If the user provides examples where the reasoning happens afterward, REVERSE the order! NEVER START EXAMPLES WITH CONCLUSIONS!


### PR DESCRIPTION
Currently, when you use Generate Instructions, any input in a language other than English is returned in English. This can be inconvenient for no-native-English speakers, so I want the output to be returned in the same language as the input.

To achieve this, I’ve added a note in the prompt specifying this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced AI assistant response guidelines to ensure responses match the input language consistently.
  * Improved response structure with explicit ordering of reasoning and conclusions.
  * Refined guidance for clarity, formatting, and content preservation in AI-generated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->