### PR TITLE
fix: apply search filter to tools list view (#5469)

### DIFF
--- a/packages/ui/src/views/tools/index.jsx
+++ b/packages/ui/src/views/tools/index.jsx
@@ -245,7 +245,11 @@ const Tools = () => {
                                         ))}
                                     </Box>
                                 ) : (
-                                    <ToolsTable data={getAllToolsApi.data?.data?.filter(filterTools) || []} isLoading={isLoading} onSelect={edit} />
+                                    <ToolsTable
+                                        data={getAllToolsApi.data?.data?.filter(filterTools) || []}
+                                        isLoading={isLoading}
+                                        onSelect={edit}
+                                    />
                                 )}
                                 {/* Pagination and Page Size Controls */}
                                 <TablePagination currentPage={currentPage} limit={pageLimit} total={total} onChange={onChange} />


### PR DESCRIPTION
## Description

This PR fixes the issue where the search box in the tools overview was not working in **list view**.  

Fixes #5469

## Before
- Typing in list view did not filter tools
- 
<img width="2928" height="906" alt="image" src="https://github.com/user-attachments/assets/4217aa1d-9c39-41fd-b283-383b5d8af0ea" />


## After
- Typing in the search box filters tools correctly regardless of view mode
- 
<img width="2852" height="856" alt="image" src="https://github.com/user-attachments/assets/6514cc58-c59f-4afa-ab4b-365ed20485c9" />


## Notes
- The fix modifies the search filter logic to apply in list view
- No changes to other functionality