### PR TITLE
Fix: Add reset timeout option for MCP tool requests

### DIFF
--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -91,7 +91,8 @@ export class MCPToolkit extends BaseToolkit {
             this.client = await this.createClient()
 
             this._tools = await this.client.request({ method: 'tools/list' }, ListToolsResultSchema, {
-                resetTimeoutOnProgress: RESET_TIMEOUT_ON_PROGRESS
+                resetTimeoutOnProgress: RESET_TIMEOUT_ON_PROGRESS,
+                onprogress: RESET_TIMEOUT_ON_PROGRESS ? () => {} : undefined
             })
 
             this.tools = await this.get_tools()


### PR DESCRIPTION
Refactor tool initialization and request handling to include reset timeout on progress (resetTimeoutOnProgress=true) when a new env variable MCP_RESET_TIMEOUT_ON_PROGRESS=true.

Some MCP servers with long-running processes provide progress feedback that allows the client to know that the server is still working on the request, this progress resets the timeout counter allowing for longer calls.  To support this we need to provide resetTimeoutOnProgress=true and a callback method, when making calls to MCP tools.

To ensure backwards compatibility we have wrapped this change with an environment variable called MCP_RESET_TIMEOUT_ON_PROGRESS, which defaults to false (no effect on existing implementations), but when set to 'true' it will allow timeout resets for MCP servers that provide progress reports.