### PR TITLE
fix: [FLOWISE-1] Unstable Redis, ECONNREFUSED 127.0.0.1

### DIFF
--- a/packages/server/src/CachePool.ts
+++ b/packages/server/src/CachePool.ts
@@ -1,6 +1,6 @@
 import { IActiveCache, MODE } from './Interface'
 import { Redis } from 'ioredis'
-import { RedisConnector } from '../../components/src/RedisConnector'
+import { RedisConnector } from './RedisConnector'
 
 /**
  * This pool is to keep track of in-memory cache used for LLM and Embeddings

--- a/packages/server/src/RedisConnector.ts
+++ b/packages/server/src/RedisConnector.ts
@@ -1,6 +1,6 @@
-import { InternalFlowiseError } from '../../server/src/errors/internalFlowiseError'
-import logger from '../../server/src/utils/logger'
-import { MODE } from '../../server/src/Interface'
+import { InternalFlowiseError } from './errors/internalFlowiseError'
+import logger from './utils/logger'
+import { MODE } from './Interface'
 import { Redis } from 'ioredis'
 import { StatusCodes } from 'http-status-codes'
 
@@ -34,7 +34,7 @@ export class RedisConnector {
 
     /**
      * Sync constructor
-     * 
+     *
      * @constructor
      */
     constructor() {}

--- a/packages/server/src/enterprise/middleware/passport/SessionPersistance.ts
+++ b/packages/server/src/enterprise/middleware/passport/SessionPersistance.ts
@@ -1,5 +1,5 @@
 import Redis from 'ioredis'
-import { RedisConnector } from '../../../../../components/src/RedisConnector'
+import { RedisConnector } from '../../../RedisConnector'
 import { RedisStore } from 'connect-redis'
 import { getDatabaseSSLFromEnv } from '../../../DataSource'
 import path from 'path'

--- a/packages/server/src/utils/rateLimit.ts
+++ b/packages/server/src/utils/rateLimit.ts
@@ -4,7 +4,7 @@ import { IChatFlow, MODE } from '../Interface'
 import { Mutex } from 'async-mutex'
 import { RedisStore } from 'rate-limit-redis'
 import Redis from 'ioredis'
-import { RedisConnector } from '../../../components/src/RedisConnector'
+import { RedisConnector } from '../RedisConnector'
 import { QueueEvents, QueueEventsListener, QueueEventsProducer } from 'bullmq'
 
 interface CustomListener extends QueueEventsListener {


### PR DESCRIPTION
## Description

Added dedicated class `RedisConnector` to initialize and connect to Redis while supporting sync and async usages, as well reconnections in case of failures.

Updated the following files with its usage:
- packages/server/src/CachePool.ts
- packages/server/src/enterprise/middleware/passport/SessionPersistance.ts
- packages/server/src/utils/rateLimit.ts
