### PR TITLE
fix: correct Lunary tool-error logging

### DIFF
--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -1774,7 +1774,7 @@ export class AnalyticHandler {
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'lunary')) {
-            const toolEventId: string = this.handlers['lunary'].llmEvent[returnIds['lunary'].toolEvent]
+            const toolEventId: string = this.handlers['lunary'].toolEvent[returnIds['lunary'].toolEvent]
             const monitor = this.handlers['lunary'].client
 
             if (monitor && toolEventId) {


### PR DESCRIPTION
Lunary tool-error logs were using the LLM run tracker, so tool call failures showed under the wrong span. This PR points the tool-error handler to the tool tracker so failures tag the correct span. Every other analytics provider (LangSmith, LangFuse, etc) already follows this pattern.