### PR TITLE
redis_keep_alive fix on usagecachemanager using keyv/redis

### DIFF
--- a/packages/server/src/UsageCacheManager.ts
+++ b/packages/server/src/UsageCacheManager.ts
@@ -37,7 +37,19 @@ export class UsageCacheManager {
         if (process.env.MODE === MODE.QUEUE) {
             let redisConfig: string | Record<string, any>
             if (process.env.REDIS_URL) {
-                redisConfig = process.env.REDIS_URL
+                redisConfig = {
+                    url: process.env.REDIS_URL,
+                    socket: {
+                        keepAlive:
+                            process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                                ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                                : undefined
+                    },
+                    pingInterval:
+                        process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                            ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                            : undefined
+                }
             } else {
                 redisConfig = {
                     username: process.env.REDIS_USERNAME || undefined,
@@ -48,8 +60,16 @@ export class UsageCacheManager {
                         tls: process.env.REDIS_TLS === 'true',
                         cert: process.env.REDIS_CERT ? Buffer.from(process.env.REDIS_CERT, 'base64') : undefined,
                         key: process.env.REDIS_KEY ? Buffer.from(process.env.REDIS_KEY, 'base64') : undefined,
-                        ca: process.env.REDIS_CA ? Buffer.from(process.env.REDIS_CA, 'base64') : undefined
-                    }
+                        ca: process.env.REDIS_CA ? Buffer.from(process.env.REDIS_CA, 'base64') : undefined,
+                        keepAlive:
+                            process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                                ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                                : undefined
+                    },
+                    pingInterval:
+                        process.env.REDIS_KEEP_ALIVE && !isNaN(parseInt(process.env.REDIS_KEEP_ALIVE, 10))
+                            ? parseInt(process.env.REDIS_KEEP_ALIVE, 10)
+                            : undefined
                 }
             }
             this.cache = createCache({


### PR DESCRIPTION
### Problem:
The UsageCacheManager.ts file (introduced after v3.0.0) creates a Redis connection via @keyv/redis when running in queue mode (MODE=queue), but does not configure keepAlive or pingInterval options. This causes the Redis connection to be closed by the server after the idle timeout period (e.g., 15 minutes on Azure Cache for Redis), resulting in a fatal Socket closed unexpectedly crash.
This is the same root cause as #4377 and #4431 , which fixed the issue for RedisEventPublisher, RedisEventSubscriber and others. However, UsageCacheManager was added later and was missing the same keepAlive configuration.
The error manifests as:
uncaughtException: Socket closed unexpectedlyError: Socket closed unexpectedly    at Socket.<anonymous> (node_modules/.pnpm/@redis+client@1.5.14/node_modules/@redis/client/dist/lib/client/socket.js:194:118)

This particularly affects Azure Web Apps deployments using Azure Cache for Redis, which has a fixed idle timeout that cannot be disabled.

### Solution:
Added keepAlive and pingInterval configuration to the Redis client options in UsageCacheManager.ts, using the existing REDIS_KEEP_ALIVE environment variable for consistency with the rest of the codebase.
The fix applies to both:
REDIS_URL configuration path
Individual REDIS_HOST/REDIS_PORT configuration path

### Testing:
Deployed to local Docker environment with Redis timeout set to 30 seconds
Verified connection remains stable after multiple idle timeout periods
Confirmed no Socket closed unexpectedly errors after extended idle periods
Tested with REDIS_KEEP_ALIVE=15000 (15 seconds)
Tested and confirmed on Azure Web App with Azure Cache for Redis 