### PR TITLE
fix(runtime): resolve deadlock on converging conditional paths

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -821,8 +821,7 @@ async function processNodeOutputs({
     if (ignoreNodeIds.length) {
         logger.debug(`  ⏭️  Skipping nodes: [${ignoreNodeIds.join(', ')}]`)
 
-        // Propagar la señal de "salto" a los nodos que dependen de los nodos ignorados
-        // para evitar que se queden esperando indefinidamente.
+        // Propagate a skip signal on downstream nodes
         const nodesToIgnoreQueue = [...ignoreNodeIds]
         const processedIgnoredNodes = new Set<string>()
 


### PR DESCRIPTION
# fix(runtime): resolve deadlock on converging conditional paths
Fixes #5501

## 📝 The Deadlock Problem

The issue described by @Sohorev is a classic **"deadlock"** in graph-based systems, specifically in **Directed Acyclic Graphs (DAGs)** that incorporate conditional branching.

When there was a condition (**IF/Condition Node**) that split the flow into Path A and Path B, and then both paths later converged into a single **Node C**, the following occurred:

* The condition chose **Path A**.
* The system marked **Path B** to be **"skipped"** (ignored).
* **Node C** (the converging node) was prepared and detected that it had two dependencies: one coming from **A** and one from **B**.
* **Node C** waited for inputs from both.
* The input from **A** arrived correctly.
* The input from **B** **never arrived** because Node B was ignored and never executed.
* **Node C** was stuck waiting eternally in *waitingNodes*.
* The execution queue (*nodeExecutionQueue*) emptied, and the process terminated silently because no active nodes remained, but Node C was never executed.
...

---

To avoid this, the **`processNodeOutputs`** function **was modified**, so that when the system determines which nodes should be ignored (*ignoreNodeIds*), it **also "notifies"** the nodes depending on them (the descendant nodes) that the specific input would not arrive, so that they would stop waiting for it.

This was achieved by **simulating a `null` value to propagate within the ignored nodes to its dependents**. This satisfied the dependency and allows the convergence node to execute using only the data from the active branch. (Ignore null value is already implemented so this works like a charm).

## TL;DR
Previously, when conditional branches merged into a single node, execution would silently halt. The merging node would wait indefinitely for input from the "skipped" branch.
<img width="500" height="524" alt="image" src="https://github.com/user-attachments/assets/889371e6-c4d2-4e49-9fb3-e77cabff10aa" />
<img width="500" height="576" alt="image" src="https://github.com/user-attachments/assets/25fc91d0-f077-4ae9-aa82-d2a3b7ad5587" />


This fix propagates the ignored status to downstream dependencies by injecting `null` inputs. This satisfies the waiting condition (`hasReceivedRequiredInputs`) and allows the flow to proceed using data from the active branch only.
<img width="1783" height="640" alt="image" src="https://github.com/user-attachments/assets/fb190acb-d407-4075-966b-7826e8d6d8e7" />
