### PR TITLE
Fix Agent node structured output not updating flow state variables

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -1394,7 +1394,9 @@ class Agent_Agentflow implements INode {
             }
 
             // Process template variables in state
-            newState = processTemplateVariables(newState, finalResponse)
+            const outputForStateProcessing =
+                isStructuredOutput && typeof response === 'object' ? JSON.stringify(response, null, 2) : finalResponse
+            newState = processTemplateVariables(newState, outputForStateProcessing)
 
             /**
              * Remove the temporarily added image artifact messages before storing


### PR DESCRIPTION
### Description

#### Problem
The Agent node's structured output was not properly updating flow state template variables like `{{output.decision}}`. Variables remained as literal template strings instead of being replaced with actual values.

#### Root Cause
When structured output is enabled in Agent.ts, `finalResponse` is wrapped in markdown code blocks for display:
```typescript
finalResponse = '```json\n' + JSON.stringify(response, null, 2) + '\n```'
```

This markdown-wrapped string was passed to `processTemplateVariables()`, which failed to parse it as JSON due to the markdown markers, leaving template variables unprocessed.

#### Solution
Create a separate `outputForStateProcessing` variable that contains clean JSON (without markdown wrapping) when structured output is enabled.

This ensures `processTemplateVariables` receives valid JSON that can:
1. Be parsed for nested property access (e.g., `{{output.decision}}`)
2. Be used in string replacements (e.g., `"Result: {{ output }}"`) without `[object Object]` coercion

#### Changes
- **`packages/components/nodes/agentflow/Agent/Agent.ts`**: Pass clean JSON string to `processTemplateVariables` when structured output is enabled, instead of the markdown-wrapped `finalResponse`

#### Testing
- Verified structured output values now correctly replace template variables in flow state
- Verified both full replacement (`{{output}}`) and nested property access (`{{output.decision}}`) work
- Verified partial string templates (`"Result: {{ output }}"`) work without `[object Object]` issues