### PR TITLE
fix(postgres): restore sanitizeDocuments call removed in #5536

### DIFF
--- a/packages/components/nodes/vectorstores/Postgres/driver/TypeORM.ts
+++ b/packages/components/nodes/vectorstores/Postgres/driver/TypeORM.ts
@@ -110,13 +110,16 @@ export class TypeORMDriver extends VectorStoreDriver {
             documents: Document[],
             documentOptions?: TypeORMAddDocumentOptions
         ): Promise<void> => {
+            // Sanitize documents to remove NULL characters that cause Postgres errors
+            const sanitizedDocs = this.sanitizeDocuments(documents)
+
             const rows = vectors.map((embedding, idx) => {
                 const embeddingString = `[${embedding.join(',')}]`
                 const documentRow = {
                     id: documentOptions?.ids?.length ? documentOptions.ids[idx] : uuid(),
-                    pageContent: documents[idx].pageContent,
+                    pageContent: sanitizedDocs[idx].pageContent,
                     embedding: embeddingString,
-                    metadata: documents[idx].metadata
+                    metadata: sanitizedDocs[idx].metadata
                 }
                 return documentRow
             })


### PR DESCRIPTION
> Caught by Gemini while merging recent upstream changes.

Issue - PR #5536 accidentally removed the `sanitizeDocuments()` call (originally added in #3367) when rewriting `addVectors`. Without sanitization, documents containing NULL characters (`\0`) cause Postgres insert errors:
```
ERROR: invalid byte sequence for encoding "UTF8": 0x00
```

This is common with PDFs, Word docs, and OCR output. This PR restores the sanitization step.
