### PR TITLE
fix: allow Unicode characters in document store tool names

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -21,6 +21,7 @@ import { flatten } from 'lodash'
 import zodToJsonSchema from 'zod-to-json-schema'
 import { getErrorMessage } from '../../../src/error'
 import { DataSource } from 'typeorm'
+import { randomBytes } from 'crypto'
 import {
     addImageArtifactsToMessages,
     extractArtifactsFromResponse,
@@ -79,7 +80,7 @@ const sanitizeToolName = (name: string): string => {
 
     // If the result is empty (e.g., non-ASCII only input), generate a unique fallback name
     if (!sanitized) {
-        return `tool_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`
+        return `tool_${Date.now()}_${randomBytes(4).toString('hex').slice(0, 5)}`
     }
 
     // Enforce 64 character limit common for tool names


### PR DESCRIPTION
This PR fixes the 'Invalid tools[0].function.name: empty string' error that occurs with non-ASCII document store titles. Instead of allowing Unicode characters (which would cause LLM API errors), it sanitizes tool names to ASCII-only and generates unique fallback names for non-ASCII titles.

Fixes #5598 