### PR TITLE
Fix: Possible bug with ChatOpenRouter issue#5610

### DIFF
--- a/packages/components/evaluation/EvaluationRunTracer.ts
+++ b/packages/components/evaluation/EvaluationRunTracer.ts
@@ -82,10 +82,10 @@ export class EvaluationRunTracer extends RunCollectorCallbackHandler {
             const tokenUsage = run.outputs?.llmOutput?.tokenUsage
             if (tokenUsage) {
                 const metric = {
-                    completionTokens: tokenUsage.completionTokens,
-                    promptTokens: tokenUsage.promptTokens,
+                    completionTokens: tokenUsage.completionTokens ?? 0,
+                    promptTokens: tokenUsage.promptTokens ?? 0,
                     model: model,
-                    totalTokens: tokenUsage.totalTokens
+                    totalTokens: tokenUsage.totalTokens ?? ((tokenUsage.completionTokens ?? 0) + (tokenUsage.promptTokens ?? 0))
                 }
                 EvaluationRunner.addMetrics(this.evaluationRunId, JSON.stringify(metric))
             }
@@ -97,10 +97,10 @@ export class EvaluationRunTracer extends RunCollectorCallbackHandler {
             const usage_metadata = run.outputs?.generations[0][0]?.message?.usage_metadata
             if (usage_metadata) {
                 const metric = {
-                    completionTokens: usage_metadata.output_tokens,
-                    promptTokens: usage_metadata.input_tokens,
+                    completionTokens: usage_metadata.output_tokens ?? 0,
+                    promptTokens: usage_metadata.input_tokens ?? 0,
                     model: model || this.model,
-                    totalTokens: usage_metadata.total_tokens
+                    totalTokens: usage_metadata.total_tokens ?? ((usage_metadata.output_tokens ?? 0) + (usage_metadata.input_tokens ?? 0))
                 }
                 EvaluationRunner.addMetrics(this.evaluationRunId, JSON.stringify(metric))
             }

--- a/packages/components/evaluation/EvaluationRunTracerLlama.ts
+++ b/packages/components/evaluation/EvaluationRunTracerLlama.ts
@@ -107,30 +107,30 @@ export class EvaluationRunTracerLlama {
         // Anthropic
         if (event.detail?.payload?.response?.raw?.usage) {
             const usage = event.detail.payload.response.raw.usage
-            if (usage.output_tokens) {
+            if (usage.output_tokens !== undefined) {
                 const metric = {
                     completionTokens: usage.output_tokens,
-                    promptTokens: usage.input_tokens,
+                    promptTokens: usage.input_tokens ?? 0,
                     model: model,
-                    totalTokens: usage.input_tokens + usage.output_tokens
+                    totalTokens: (usage.input_tokens ?? 0) + usage.output_tokens
                 }
                 EvaluationRunner.addMetrics(evalID, JSON.stringify(metric))
-            } else if (usage.completion_tokens) {
+            } else if (usage.completion_tokens !== undefined) {
                 const metric = {
                     completionTokens: usage.completion_tokens,
-                    promptTokens: usage.prompt_tokens,
+                    promptTokens: usage.prompt_tokens ?? 0,
                     model: model,
-                    totalTokens: usage.total_tokens
+                    totalTokens: usage.total_tokens ?? (usage.completion_tokens + (usage.prompt_tokens ?? 0))
                 }
                 EvaluationRunner.addMetrics(evalID, JSON.stringify(metric))
             }
         } else if (event.detail?.payload?.response?.raw['amazon-bedrock-invocationMetrics']) {
             const usage = event.detail?.payload?.response?.raw['amazon-bedrock-invocationMetrics']
             const metric = {
-                completionTokens: usage.outputTokenCount,
-                promptTokens: usage.inputTokenCount,
+                completionTokens: usage.outputTokenCount ?? 0,
+                promptTokens: usage.inputTokenCount ?? 0,
                 model: event.detail?.payload?.response?.raw.model,
-                totalTokens: usage.inputTokenCount + usage.outputTokenCount
+                totalTokens: (usage.inputTokenCount ?? 0) + (usage.outputTokenCount ?? 0)
             }
             EvaluationRunner.addMetrics(evalID, JSON.stringify(metric))
         } else {


### PR DESCRIPTION
OpenRouter API responses have inconsistent token usage fields, causing `Cannot read properties of undefined (reading 'completion_tokens')` errors when evaluation tracers attempt to extract metrics.

## Changes

**EvaluationRunTracerLlama.ts**
- Added null-coalescing operators for all token usage extraction paths (Anthropic, OpenAI, Bedrock formats)
- Changed condition checks from truthy (`if (usage.output_tokens)`) to explicit undefined checks (`if (usage.output_tokens !== undefined)`)
- Added fallback calculation for `totalTokens` when not provided by API

**EvaluationRunTracer.ts**
- Added null-coalescing operators for `tokenUsage` and `usage_metadata` extraction paths
- Ensured consistent defensive handling across both LangChain callback handlers

## Example

```typescript
// Before - crashes if prompt_tokens is undefined
const metric = {
    completionTokens: usage.completion_tokens,
    promptTokens: usage.prompt_tokens,
    totalTokens: usage.total_tokens
}

// After - gracefully handles missing fields
const metric = {
    completionTokens: usage.completion_tokens,
    promptTokens: usage.prompt_tokens ?? 0,
    totalTokens: usage.total_tokens ?? (usage.completion_tokens + (usage.prompt_tokens ?? 0))
}
```

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> create a new branch & then fix the issue mentioned below below:
> 
> https://github.com/FlowiseAI/Flowise/issues/5610
> 
> after fixing raise the PR with changes details


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

💬 We'd love your input! Share your thoughts on Copilot coding agent in our [2 minute survey](https://gh.io/copilot-coding-agent-survey).
