### PR TITLE
fix(components): add missing regex handler to Condition node

### DIFF
--- a/packages/components/nodes/agentflow/Condition/Condition.ts
+++ b/packages/components/nodes/agentflow/Condition/Condition.ts
@@ -8,9 +8,9 @@ import removeMarkdown from 'remove-markdown'
  */
 const unescapeRegexPattern = (escaped: string): string => {
     return escaped
-        .replace(/\\\\/g, '\0')              // Preserve intentional backslashes
-        .replace(/\\([[\]*])/g, '$1')        // Unescape only: [ ] *
-        .replace(/\0/g, '\\')                // Restore preserved backslashes
+        .replace(/\\\\/g, '\0') // Preserve intentional backslashes
+        .replace(/\\([[\]*])/g, '$1') // Unescape only: [ ] *
+        .replace(/\0/g, '\\') // Restore preserved backslashes
 }
 
 class Condition_Agentflow implements INode {


### PR DESCRIPTION
## Summary
Fixes #5650 - The Regex operation in Condition node was not implemented.
## Changes
- Added [regex]
  Flowise/packages/components/nodes/agentflow/Condition/Condition.ts:277:12-297:13) handler to `compareOperationFunctions`
- Added [unescapeRegexPattern]
  Flowise/packages/components/nodes/agentflow/Condition/Condition.ts:278:16-288:17) helper to handle Flowise's escaping of metacharacters
- Gracefully returns `false` for invalid regex patterns (no crashes)
- Added 22 unit tests covering all scenarios
## Test Coverage
- All regex metacharacters: `^ $ [ ] . * + ? { } ( ) |`
- Flowise escaping scenarios
- Invalid patterns (graceful failure)
- Edge cases (null, empty values)
## Known Limitation
Patterns matching markdown link syntax may be affected by existing `removeMarkdown` preprocessing.