### PR TITLE
fixed incorrect ollama embedding api endpoint

### DIFF
--- a/packages/components/nodes/embeddings/OllamaEmbedding/OllamaEmbedding.ts
+++ b/packages/components/nodes/embeddings/OllamaEmbedding/OllamaEmbedding.ts
@@ -85,7 +85,7 @@ class OllamaEmbedding_Embeddings implements INode {
 
         // default useMMap to true
         // Note: @langchain/ollama uses `useMmap` (not `useMMap`) in requestOptions
-        requestOptions.useMmap = useMMap === undefined ? true : useMMap
+        requestOptions.useMmap = useMMap ?? true
 
         if (Object.keys(requestOptions).length) obj.requestOptions = requestOptions
 


### PR DESCRIPTION
fixed: https://github.com/FlowiseAI/Flowise/issues/5637

fixed incorrected ollama embedding api endpoint api/embedding to api/embed

Here is the screenshot of ollama logs after fixing issue:
<img width="1064" height="152" alt="image" src="https://github.com/user-attachments/assets/1dca6c3f-6ec8-4ee3-8765-ed1cf0d8c4a6" />


Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=191128130