### PR TITLE
fix: route ordering in auth routes

### DIFF
--- a/packages/server/src/enterprise/routes/auth/index.ts
+++ b/packages/server/src/enterprise/routes/auth/index.ts
@@ -3,8 +3,8 @@ import authController from '../../controllers/auth'
 const router = express.Router()
 
 // RBAC
-router.get(['/:type', '/permissions/:type'], authController.getAllPermissions)
-
 router.get(['/sso-success'], authController.ssoSuccess)
+
+router.get(['/:type', '/permissions/:type'], authController.getAllPermissions)
 
 export default router


### PR DESCRIPTION
- Wrong route order was causing `/api/v1/auth/sso-success`endpoint to be handled by the `getAllPermissions`endpoint.