### PR TITLE
Increase salt rounds for new passwords, and update hash with more salt rounds for old passwords

### DIFF
--- a/packages/server/src/enterprise/utils/encryption.util.ts
+++ b/packages/server/src/enterprise/utils/encryption.util.ts
@@ -2,6 +2,10 @@ import bcrypt from 'bcryptjs'
 import { AES, enc } from 'crypto-js'
 import { getEncryptionKey } from '../../utils'
 
+export function getPasswordSaltRounds(): number {
+    return parseInt(process.env.PASSWORD_SALT_HASH_ROUNDS || '10', 10)
+}
+
 /**
  * Extracts the cost factor (salt rounds) from a bcrypt hash using bcrypt.getRounds().
  * @returns The number of rounds used, or null if the string is not a valid bcrypt hash.
@@ -26,7 +30,7 @@ export function hashNeedsUpgrade(storedHash: string, minRounds: number): boolean
 }
 
 export function getHash(value: string) {
-    const salt = bcrypt.genSaltSync(parseInt(process.env.PASSWORD_SALT_HASH_ROUNDS || '10'))
+    const salt = bcrypt.genSaltSync(getPasswordSaltRounds())
     return bcrypt.hashSync(value, salt)
 }
 


### PR DESCRIPTION
### Overview
Today, the application defaults to 5 salt rounds, increasing to 10 which is suggested by OWASP.

Additionally, adding a check to the login method to see if the existing has uses 10 rounds or not using the `bcrypt.getRounds()` method, and updating the hash if it is less than 10 rounds.

### Testing Details
1. Booted up Flowise locally and signed up (using 5 salt rounds)
2. Made code updates to use 10 rounds, but made a temporary change to the code to throw an exception after the check (`if (hashNeedsUpgrade(user.credential!, minRounds))`) confirming that the check worked and determined there were insufficient salt rounds
3. Removes the exception from the code, login succeeded and so did subsequent logins