### PR TITLE
Use secureFetch in WebScraperTool

### DIFF
--- a/packages/components/nodes/tools/WebScraperTool/WebScraperTool.ts
+++ b/packages/components/nodes/tools/WebScraperTool/WebScraperTool.ts
@@ -1,10 +1,10 @@
 import { INode, INodeParams, INodeData, ICommonObject } from '../../../src/Interface'
 import { getBaseClasses } from '../../../src/utils'
 import { Tool } from '@langchain/core/tools'
-import fetch from 'node-fetch'
 import * as cheerio from 'cheerio'
 import { URL } from 'url'
 import { xmlScrape } from '../../../src/utils'
+import { secureFetch } from '../../../src/httpSecurity'
 
 interface ScrapedPageData {
     url: string
@@ -60,7 +60,7 @@ class WebScraperRecursiveTool extends Tool {
 
     private async scrapeSingleUrl(url: string): Promise<Omit<ScrapedPageData, 'url'> & { foundLinks: string[] }> {
         try {
-            const response = await fetch(url, { timeout: this.timeoutMs, redirect: 'follow', follow: 5 })
+            const response = await secureFetch(url, { timeout: this.timeoutMs, redirect: 'follow', follow: 5 })
             if (!response.ok) {
                 const errorText = await response.text()
                 return {


### PR DESCRIPTION
This code was using `node-fetch` instead of the custom-built `secureFetch` method. `secureFetch` has SSRF protection built in and should be the standard used in Flowise when making fetch calls.