### PR TITLE
fix: update CORS handling for public chatflow requests

### DIFF
--- a/packages/server/src/utils/XSS.ts
+++ b/packages/server/src/utils/XSS.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express'
 import sanitizeHtml from 'sanitize-html'
-import { isPredictionRequest, extractChatflowId, validateChatflowDomain } from './domainValidation'
+import { extractChatflowId, validateChatflowDomain, isPublicChatflowRequest } from './domainValidation'
 
 export function sanitizeMiddleware(req: Request, res: Response, next: NextFunction): void {
     // decoding is necessary as the url is encoded by the browser
@@ -43,7 +43,7 @@ export function getCorsOptions(): any {
         const corsOptions = {
             origin: async (origin: string | undefined, originCallback: (err: Error | null, allow?: boolean) => void) => {
                 const allowedOrigins = getAllowedCorsOrigins()
-                const isPredictionReq = isPredictionRequest(req.url)
+                const isPublicChatflowReq = isPublicChatflowRequest(req.url)
                 const allowedList = parseAllowedOrigins(allowedOrigins)
                 const originLc = origin?.toLowerCase()
 
@@ -53,7 +53,7 @@ export function getCorsOptions(): any {
                 // Global allow: '*' or exact match
                 const globallyAllowed = allowedOrigins === '*' || allowedList.includes(originLc)
 
-                if (isPredictionReq) {
+                if (isPublicChatflowReq) {
                     // Per-chatflow allowlist OR globally allowed
                     const chatflowId = extractChatflowId(req.url)
                     let chatflowAllowed = false


### PR DESCRIPTION
# Fix: Expand CORS validation for public chatflow APIs used for embedded chatbot
## Summary
This PR extends CORS domain validation to cover all public chatflow endpoints, not just the `/prediction/` endpoint. Previously, only prediction requests were validated against per-chatflow allowed origins, leaving other public APIs (`/public-chatbotConfig/ and /chatflows-streaming/`) without proper origin validation.

## Issue: https://github.com/FlowiseAI/Flowise/issues/5691

## Problem:
The existing CORS validation only checked domain restrictions for /prediction/ endpoints. Other public chatflow APIs that should have the same security controls were not being validated, creating an inconsistent security posture.

## Testing:
### Current:

https://github.com/user-attachments/assets/da61e728-7332-4bd2-b95c-4e766cd2a42f

### After fixing:

https://github.com/user-attachments/assets/5f3dc025-76a2-4b91-885b-9d382719491b

