### PR TITLE
fix(embeddings): replace deprecated gemini-embedding-exp-03-07 with gemini-embedding-001

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -2082,16 +2082,16 @@
             "name": "googleGenerativeAiEmbeddings",
             "models": [
                 {
+                    "label": "gemini-embedding-001",
+                    "name": "gemini-embedding-001"
+                },
+                {
                     "label": "embedding-001",
                     "name": "embedding-001"
                 },
                 {
                     "label": "text-embedding-004",
                     "name": "text-embedding-004"
-                },
-                {
-                    "label": "gemini-embedding-001",
-                    "name": "gemini-embedding-001"
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- Replace deprecated `gemini-embedding-exp-03-07` model with the new `gemini-embedding-001` in Google Generative AI Embeddings node

## Test plan
- [ ] Verify the new model appears in the GoogleGenerativeAI Embeddings node dropdown
- [ ] Test embedding generation with the new model