### PR TITLE
feat: add DuckDuckGo Search tool node

### DIFF
--- a/packages/components/nodes/tools/DuckDuckGo/DuckDuckGoSearch.ts
+++ b/packages/components/nodes/tools/DuckDuckGo/DuckDuckGoSearch.ts
@@ -1,0 +1,46 @@
+import { INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses } from '../../../src/utils'
+import { DuckDuckGoSearch } from './core'
+
+class DuckDuckGoSearch_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    author: string
+    baseClasses: string[]
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'DuckDuckGo Search'
+        this.name = 'duckDuckGoSearch'
+        this.version = 1.0
+        this.type = 'DuckDuckGoSearch'
+        this.icon = 'duckduckgo.svg'
+        this.category = 'Tools'
+        this.author = 'rawstack'
+        this.description = 'Free web search tool using DuckDuckGo. No API key required.'
+        this.baseClasses = [this.type, 'Tool', ...getBaseClasses(DuckDuckGoSearch)]
+        this.inputs = [
+            {
+                label: 'Max Results',
+                name: 'maxResults',
+                type: 'number',
+                optional: true,
+                additionalParams: true,
+                description: 'Maximum number of search results to return',
+                default: 4
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData): Promise<any> {
+        const maxResults = nodeData.inputs?.maxResults as number
+        return new DuckDuckGoSearch({ maxResults: maxResults || 4 })
+    }
+}
+
+module.exports = { nodeClass: DuckDuckGoSearch_Tools }

--- a/packages/components/nodes/tools/DuckDuckGo/core.ts
+++ b/packages/components/nodes/tools/DuckDuckGo/core.ts
@@ -1,0 +1,100 @@
+import { Tool } from '@langchain/core/tools'
+
+export interface DuckDuckGoSearchParams {
+    maxResults?: number
+}
+
+export class DuckDuckGoSearch extends Tool {
+    name = 'duckduckgo-search'
+    description = 'Useful for when you need to search the internet for current information. Input should be a search query string. Returns relevant search results from DuckDuckGo. This tool does not require an API key.'
+
+    private maxResults: number
+
+    constructor(params?: DuckDuckGoSearchParams) {
+        super()
+        this.maxResults = params?.maxResults ?? 4
+    }
+
+    async _call(input: string): Promise<string> {
+        try {
+            const results = await this.fetchSearchResults(input)
+            if (!results || results.length === 0) {
+                return 'No results found.'
+            }
+            return JSON.stringify(results)
+        } catch (error) {
+            return `Error performing search: ${(error as Error).message}`
+        }
+    }
+
+    private async fetchSearchResults(query: string): Promise<{ title: string; link: string; snippet: string }[]> {
+        // DuckDuckGo HTML lite endpoint - no API key required
+        const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`
+
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+            }
+        })
+
+        if (!response.ok) {
+            throw new Error(`DuckDuckGo search failed with status ${response.status}`)
+        }
+
+        const html = await response.text()
+        return this.parseResults(html)
+    }
+
+    private parseResults(html: string): { title: string; link: string; snippet: string }[] {
+        const results: { title: string; link: string; snippet: string }[] = []
+
+        // Parse result blocks from DDG HTML lite
+        const resultBlocks = html.split('class="result__body"')
+
+        for (let i = 1; i < resultBlocks.length && results.length < this.maxResults; i++) {
+            const block = resultBlocks[i]
+
+            // Extract title
+            const titleMatch = block.match(/class="result__a"[^>]*>([^<]+)</)
+            const title = titleMatch ? this.decodeHtmlEntities(titleMatch[1].trim()) : ''
+
+            // Extract URL
+            const urlMatch = block.match(/class="result__url"[^>]*href="([^"]*)"/)
+            let link = ''
+            if (urlMatch) {
+                link = urlMatch[1]
+                // DDG uses redirect URLs, extract the actual URL
+                const uddgMatch = link.match(/uddg=([^&]+)/)
+                if (uddgMatch) {
+                    link = decodeURIComponent(uddgMatch[1])
+                }
+            }
+
+            // Extract snippet
+            const snippetMatch = block.match(/class="result__snippet"[^>]*>([\s\S]*?)<\/a>/)
+            const snippet = snippetMatch ? this.stripHtmlTags(this.decodeHtmlEntities(snippetMatch[1].trim())) : ''
+
+            if (title && link) {
+                results.push({ title, link, snippet })
+            }
+        }
+
+        return results
+    }
+
+    private stripHtmlTags(str: string): string {
+        return str.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim()
+    }
+
+    private decodeHtmlEntities(str: string): string {
+        return str
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, "'")
+            .replace(/&#x27;/g, "'")
+            .replace(/&#x2F;/g, '/')
+    }
+}

--- a/packages/components/nodes/tools/DuckDuckGo/duckduckgo.svg
+++ b/packages/components/nodes/tools/DuckDuckGo/duckduckgo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <circle cx="24" cy="24" r="22" fill="#DE5833"/>
+  <circle cx="24" cy="24" r="18" fill="#FFF"/>
+  <circle cx="24" cy="24" r="14" fill="#65BC46"/>
+  <circle cx="20" cy="20" r="3" fill="#FFF"/>
+  <circle cx="20" cy="20" r="1.5" fill="#333"/>
+  <ellipse cx="28" cy="26" rx="6" ry="4" fill="#EDCA45"/>
+  <ellipse cx="28" cy="26" rx="4" ry="2.5" fill="#E8A52B"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds a new **DuckDuckGo Search** tool node that allows agents to search the web without requiring any API key or credentials.

## Motivation

Currently, all search tools in Flowise (Serper, SerpAPI, BraveSearch, Tavily, Google Custom Search, SearchApi, Exa) require paid API keys. This creates a barrier for:

- New users trying out Flowise for the first time
- Students and hobbyists building personal projects
- Development and testing environments
- Self-hosted instances where minimizing external API dependencies is preferred

DuckDuckGo Search fills this gap as a **zero-config, free** alternative.

## Changes

**New files:**
- `packages/components/nodes/tools/DuckDuckGo/DuckDuckGoSearch.ts` — Flowise node definition
- `packages/components/nodes/tools/DuckDuckGo/core.ts` — DuckDuckGo search tool class extending `@langchain/core/tools`
- `packages/components/nodes/tools/DuckDuckGo/duckduckgo.svg` — Node icon

## Implementation Details

- Extends `Tool` from `@langchain/core/tools` (already a project dependency)
- Uses DuckDuckGo's HTML lite endpoint — no API key, no additional npm packages
- Parses search results (title, link, snippet) from HTML response
- Configurable `maxResults` parameter (default: 4)
- Proper error handling with user-friendly messages
- **No new dependencies added**

## Node Configuration

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| Max Results | number | 4 | Maximum number of search results to return |