### PR TITLE
fix(embeddings): remove deprecated Google embedding models, keep only gemini-embedding-001

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -2198,14 +2198,6 @@
                 {
                     "label": "gemini-embedding-001",
                     "name": "gemini-embedding-001"
-                },
-                {
-                    "label": "embedding-001",
-                    "name": "embedding-001"
-                },
-                {
-                    "label": "text-embedding-004",
-                    "name": "text-embedding-004"
                 }
             ]
         },

--- a/packages/components/nodes/embeddings/GoogleGenerativeAIEmbedding/GoogleGenerativeAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/GoogleGenerativeAIEmbedding/GoogleGenerativeAIEmbedding.ts
@@ -58,7 +58,7 @@ class GoogleGenerativeAIEmbedding_Embeddings implements INode {
                 name: 'modelName',
                 type: 'asyncOptions',
                 loadMethod: 'listModels',
-                default: 'embedding-001'
+                default: 'gemini-embedding-001'
             },
             {
                 label: 'Task Type',


### PR DESCRIPTION
## Summary
- Remove deprecated `embedding-001` (retired Aug 2025), `text-embedding-004` (shut down Jan 2026), and `gemini-embedding-exp-03-07` (retired Aug 2025) from Google Generative AI Embeddings model list
- Keep only `gemini-embedding-001` which is the sole supported model as of Feb 2026
- Update default model in GoogleGenerativeAIEmbedding node from `embedding-001` to `gemini-embedding-001`

## References
- https://ai.google.dev/gemini-api/docs/embeddings
- https://ai.google.dev/gemini-api/docs/changelog

## Test plan
- [ ] Verify `gemini-embedding-001` appears in the GoogleGenerativeAI Embeddings node dropdown
- [ ] Verify deprecated models no longer appear
- [ ] Test embedding generation with the new default model