### PR TITLE
fix: handle humanInputAgentflow conditions in resolved value

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -398,6 +398,15 @@ export const resolveVariables = async (
                 // Replace the reference with actual value
                 const nodeOutput = nodeData.data['output'] as ICommonObject
                 const actualValue = nodeOutput?.content ?? nodeOutput?.http?.data
+
+                if (nodeData.data.name === 'humanInputAgentflow') {
+                    const conditions = (nodeOutput?.conditions as Partial<ICondition>[] & Partial<IHumanInput>[]) || []
+                    const fulfilledOutcome = conditions.find((condition) => condition.isFulfilled === true)
+                    const formattedValue = fulfilledOutcome?.type ?? match
+                    resolvedValue = resolvedValue.replace(match, formattedValue)
+                    continue
+                }
+
                 // For arrays and objects, stringify them to prevent toString() conversion issues
                 const formattedValue =
                     Array.isArray(actualValue) || (typeof actualValue === 'object' && actualValue !== null)


### PR DESCRIPTION
# Fix: Resolve humanInputAgentflow variables in subsequent nodes

## Problem
When referencing humanInputAgentflow node outputs in subsequent nodes using handlebars syntax (e.g., `{{ humanInputAgentflow_0 }}`), the variables were not being interpolated. Instead, the literal handlebars string was passed through, making it impossible to use human input values in downstream nodes.

## Ticket: https://github.com/FlowiseAI/Flowise/issues/5704

## Testing

### Current

https://github.com/user-attachments/assets/0a4ec578-6252-45c7-9fa6-9511dc3f6b91

### After fixing

https://github.com/user-attachments/assets/28d74d1f-79c0-49d6-b2f1-529057053b3e
