### PR TITLE
fix: update import paths for pdf.js to use .mjs extension

### DIFF
--- a/packages/components/nodes/documentloaders/File/File.ts
+++ b/packages/components/nodes/documentloaders/File/File.ts
@@ -236,13 +236,13 @@ class File_DocumentLoaders implements INode {
                           splitPages: false,
                           pdfjs: () =>
                               // @ts-ignore
-                              legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
+                              legacyBuild ? import('pdfjs-dist/legacy/build/pdf.mjs') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
                       })
                     : // @ts-ignore
                       new PDFLoader(blob, {
                           pdfjs: () =>
                               // @ts-ignore
-                              legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
+                              legacyBuild ? import('pdfjs-dist/legacy/build/pdf.mjs') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
                       }),
             '': (blob) => new TextLoader(blob)
         })

--- a/packages/components/nodes/documentloaders/Pdf/Pdf.ts
+++ b/packages/components/nodes/documentloaders/Pdf/Pdf.ts
@@ -196,7 +196,7 @@ class Pdf_DocumentLoaders implements INode {
                 splitPages: false,
                 pdfjs: () =>
                     // @ts-ignore
-                    legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
+                    legacyBuild ? import('pdfjs-dist/legacy/build/pdf.mjs') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
             })
             if (textSplitter) {
                 let splittedDocs = await loader.load()
@@ -209,7 +209,7 @@ class Pdf_DocumentLoaders implements INode {
             const loader = new PDFLoader(new Blob([bf]), {
                 pdfjs: () =>
                     // @ts-ignore
-                    legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
+                    legacyBuild ? import('pdfjs-dist/legacy/build/pdf.mjs') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
             })
             if (textSplitter) {
                 let splittedDocs = await loader.load()

--- a/packages/components/nodes/tools/Arxiv/core.ts
+++ b/packages/components/nodes/tools/Arxiv/core.ts
@@ -184,7 +184,7 @@ export class ArxivTool extends DynamicStructuredTool {
             splitPages: false,
             pdfjs: () =>
                 // @ts-ignore
-                this.legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
+                this.legacyBuild ? import('pdfjs-dist/legacy/build/pdf.mjs') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
         })
 
         const docs = await loader.load()


### PR DESCRIPTION
# Fix: Correct PDF.js legacy build import path
## Problem
The PDF loader components were importing the legacy PDF.js build using an incorrect path (pdf.js) instead of the correct ESM module path (pdf.mjs). This caused issues when users enabled the "Use Legacy Build" option for PDF compatibility.

<img width="1250" height="701" alt="image" src="https://github.com/user-attachments/assets/6520e2e3-69da-4e07-96d5-a5b0de53953f" />


## Ticket: https://github.com/FlowiseAI/Flowise/issues/5584

## Testing:

https://github.com/user-attachments/assets/e6878793-ef81-474b-8729-8d070049dc1a

