### PR TITLE
fix: implement regex operation handler in Condition node

### DIFF
--- a/packages/components/nodes/agentflow/Condition/Condition.ts
+++ b/packages/components/nodes/agentflow/Condition/Condition.ts
@@ -275,6 +275,13 @@ class Condition_Agentflow implements INode {
             smaller: (value1: CommonType, value2: CommonType) => (Number(value1) || 0) < (Number(value2) || 0),
             smallerEqual: (value1: CommonType, value2: CommonType) => (Number(value1) || 0) <= (Number(value2) || 0),
             startsWith: (value1: CommonType, value2: CommonType) => (value1 as string).startsWith(value2 as string),
+            regex: (value1: CommonType, value2: CommonType) => {
+                try {
+                    return new RegExp(value2 as string).test((value1 || '').toString())
+                } catch {
+                    return false
+                }
+            },
             isEmpty: (value1: CommonType) => [undefined, null, ''].includes(value1 as string),
             notEmpty: (value1: CommonType) => ![undefined, null, ''].includes(value1 as string)
         }


### PR DESCRIPTION
## Summary

Fixes #5650

The Condition Agentflow node defines a **Regex** option in the frontend dropdown (line 101-102), but `compareOperationFunctions` did not include a `regex` handler. This caused:
```
compareOperationFunctions[operation] is not a function
```

## Changes

- `packages/components/nodes/agentflow/Condition/Condition.ts`: Added `regex` handler to `compareOperationFunctions`. The handler uses `new RegExp(value2).test(value1)` wrapped in try/catch to gracefully handle invalid regex patterns.

## Risk Assessment

**Low** - Only adds a missing handler. Existing operations are unchanged.