### PR TITLE
Potential fix for code scanning alert no. 58: Double escaping or unescaping

### DIFF
--- a/packages/components/nodes/agentflow/Tool/Tool.ts
+++ b/packages/components/nodes/agentflow/Tool/Tool.ts
@@ -236,11 +236,11 @@ class Tool_Agentflow implements INode {
             // ex: \["a", "b", "c", "d", "e"\]
             let cleanedValue = value
                 .replace(/\\"/g, '"') // \" -> "
-                .replace(/\\\\/g, '\\') // \\ -> \
                 .replace(/\\\[/g, '[') // \[ -> [
                 .replace(/\\\]/g, ']') // \] -> ]
                 .replace(/\\\{/g, '{') // \{ -> {
                 .replace(/\\\}/g, '}') // \} -> }
+                .replace(/\\\\/g, '\\') // \\ -> \ (unescape backslash last)
 
             // Try to parse as JSON if it looks like JSON/array
             if (


### PR DESCRIPTION
Potential fix for [https://github.com/FlowiseAI/Flowise/security/code-scanning/58](https://github.com/FlowiseAI/Flowise/security/code-scanning/58)

To fix this issue, we need to ensure that the unescaping of the escape character (backslash, `\\`) happens *after* all other unescaping steps, not before. This means we should delay the `.replace(/\\\\/g, '\\')` line until we've already unescaped special characters (quotes, brackets, braces, etc.). In other words, rearrange the replacement sequence so every backslash-unescape happens after all other unescapes. The fix is to move `.replace(/\\\\/g, '\\')` to the end of the chain (after lines 238, 240, 241, 242, 243). This can be implemented by editing the function in the relevant code block in packages/components/nodes/agentflow/Tool/Tool.ts, on lines 237-244.

No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
