### PR TITLE
fix: #5736 Navigate to canvas after FlowListTable rename

### DIFF
--- a/packages/ui/src/ui-component/button/FlowListMenu.jsx
+++ b/packages/ui/src/ui-component/button/FlowListMenu.jsx
@@ -180,41 +180,27 @@ export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, s
     }
 
     const saveFlowRename = async (chatflowName) => {
-        const updateBody = {
-            name: chatflowName,
-            chatflow
-        }
         try {
-            await updateChatflowApi.request(chatflow.id, { name: chatflowName });  
-            
+            await updateChatflowApi.request(chatflow.id, { name: chatflowName })
+            setFlowDialogOpen(false)
             enqueueSnackbar({
                 message: 'Flow renamed successfully!',
                 options: { variant: 'success' }
-            });
-            
-            
+            })
+
             if (isAgentCanvas && isAgentflowV2) {
-                navigate(`/v2/agentcanvas/${chatflow.id}`, { replace: true });
+                navigate(`/v2/agentcanvas/${chatflow.id}`, { replace: true })
             } else if (isAgentCanvas) {
-                navigate(`/agentcanvas/${chatflow.id}`, { replace: true });
+                navigate(`/agentcanvas/${chatflow.id}`, { replace: true })
             } else {
-                navigate(`/canvas/${chatflow.id}`, { replace: true });
+                navigate(`/canvas/${chatflow.id}`, { replace: true })
             }
         } catch (error) {
-            if (setError) setError(error)
             enqueueSnackbar({
-                message: typeof error.response.data === 'object' ? error.response.data.message : error.response.data,
-                options: {
-                    key: new Date().getTime() + Math.random(),
-                    variant: 'error',
-                    persist: true,
-                    action: (key) => (
-                        <Button style={{ color: 'white' }} onClick={() => closeSnackbar(key)}>
-                            <IconX />
-                        </Button>
-                    )
-                }
+                message: `Rename failed: ${typeof error.response?.data === 'object' ? error.response.data.message : error.response.data}`,
+                options: { variant: 'error', persist: true }
             })
+            if (setError) setError(error)
         }
     }
 

--- a/packages/ui/src/ui-component/button/FlowListMenu.jsx
+++ b/packages/ui/src/ui-component/button/FlowListMenu.jsx
@@ -76,7 +76,7 @@ const StyledMenu = styled((props) => (
 }))
 
 export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, setError, updateFlowsApi, currentPage, pageLimit }) {
-    const navigate = useNavigate();
+    const navigate = useNavigate()
     const { confirm } = useConfirm()
     const dispatch = useDispatch()
     const updateChatflowApi = useApi(chatflowsApi.updateChatflow)

--- a/packages/ui/src/ui-component/button/FlowListMenu.jsx
+++ b/packages/ui/src/ui-component/button/FlowListMenu.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types'
 
 import { styled, alpha } from '@mui/material/styles'
@@ -75,6 +76,7 @@ const StyledMenu = styled((props) => (
 }))
 
 export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, setError, updateFlowsApi, currentPage, pageLimit }) {
+    const navigate = useNavigate();
     const { confirm } = useConfirm()
     const dispatch = useDispatch()
     const updateChatflowApi = useApi(chatflowsApi.updateChatflow)
@@ -183,17 +185,20 @@ export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, s
             chatflow
         }
         try {
-            await updateChatflowApi.request(chatflow.id, updateBody)
-            const params = {
-                page: currentPage,
-                limit: pageLimit
-            }
+            await updateChatflowApi.request(chatflow.id, { name: chatflowName });  
+            
+            enqueueSnackbar({
+                message: 'Flow renamed successfully!',
+                options: { variant: 'success' }
+            });
+            
+            
             if (isAgentCanvas && isAgentflowV2) {
-                await updateFlowsApi.request('AGENTFLOW', params)
+                navigate(`/v2/agentcanvas/${chatflow.id}`, { replace: true });
             } else if (isAgentCanvas) {
-                await updateFlowsApi.request('MULTIAGENT', params)
+                navigate(`/agentcanvas/${chatflow.id}`, { replace: true });
             } else {
-                await updateFlowsApi.request(params)
+                navigate(`/canvas/${chatflow.id}`, { replace: true });
             }
         } catch (error) {
             if (setError) setError(error)

--- a/packages/ui/src/ui-component/button/FlowListMenu.jsx
+++ b/packages/ui/src/ui-component/button/FlowListMenu.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 import { styled, alpha } from '@mui/material/styles'

--- a/packages/ui/src/ui-component/button/FlowListMenu.jsx
+++ b/packages/ui/src/ui-component/button/FlowListMenu.jsx
@@ -189,11 +189,11 @@ export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, s
             })
 
             if (isAgentCanvas && isAgentflowV2) {
-                navigate(`/v2/agentcanvas/${chatflow.id}`, { replace: true })
+                navigate(`/v2/agentcanvas/${chatflow.id}`)
             } else if (isAgentCanvas) {
-                navigate(`/agentcanvas/${chatflow.id}`, { replace: true })
+                navigate(`/v2/agentcanvas/${chatflow.id}`)
             } else {
-                navigate(`/canvas/${chatflow.id}`, { replace: true })
+                navigate(`/canvas/${chatflow.id}`)
             }
         } catch (error) {
             enqueueSnackbar({

--- a/packages/ui/src/ui-component/button/FlowListMenu.jsx
+++ b/packages/ui/src/ui-component/button/FlowListMenu.jsx
@@ -191,7 +191,7 @@ export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, s
             if (isAgentCanvas && isAgentflowV2) {
                 navigate(`/v2/agentcanvas/${chatflow.id}`)
             } else if (isAgentCanvas) {
-                navigate(`/v2/agentcanvas/${chatflow.id}`)
+                navigate(`/agentcanvas/${chatflow.id}`)
             } else {
                 navigate(`/canvas/${chatflow.id}`)
             }


### PR DESCRIPTION
**Before:** Rename from List View → returns to chatflows list 
**After:** Rename from List View → navigates to canvas editor 

### Changes
-  **Removed** `updateFlowsApi.request()` table refresh after rename
-  **Added** `useNavigate()` to `/canvas/${chatflow.id}` (or agentcanvas routes)
-  **Cleaned** API payload: `{ name: chatflowName }` (removed extra `chatflow` prop)
-  **Added** success/error snackbar notifications
-  **Fixed** `useNavigate` hook placement (inside component)
-  **Multi-mode support**: Chatflow + Agentflow V1/V2 routing