### PR TITLE
fix: improve form value resolution in executeNode

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -1102,10 +1102,16 @@ const executeNode = async ({
         }
 
         // Resolve variables in node data
+        let formValue: Record<string, any> = {}
+        if (isObjectNotEmpty(incomingInput.form)) {
+            formValue = incomingInput.form as Record<string, any>
+        } else if (isObjectNotEmpty(agentflowRuntime.form)) {
+            formValue = agentflowRuntime.form as Record<string, any>
+        }
         const reactFlowNodeData: INodeData = await resolveVariables(
             flowNodeData,
             incomingInput.question ?? '',
-            incomingInput.form ?? agentflowRuntime.form ?? {},
+            formValue,
             flowConfig,
             availableVariables,
             variableOverrides,
@@ -2334,4 +2340,11 @@ export const executeAgentFlow = async ({
     }
 
     return result
+}
+
+/**
+ * Utility function to check if an object is not empty, null, or undefined
+ */
+export const isObjectNotEmpty = (obj: any): boolean => {
+    return obj && Object.keys(obj).length > 0 && obj.constructor === Object
 }


### PR DESCRIPTION
# Fix: Improve form value resolution in executeNode
## Problem
The original code used the nullish coalescing operator (??) to resolve form values:

`incomingInput.form ?? agentflowRuntime.form ?? {}`

This approach has a critical flaw: it doesn't check for empty objects {}. The nullish coalescing operator only checks for null or undefined, so if incomingInput.form is an empty object, it would still be used instead of falling back to agentflowRuntime.form or a proper default.

## Ticket: https://github.com/FlowiseAI/Flowise/issues/5756

## Testing

### Current:


https://github.com/user-attachments/assets/3696c23c-73d6-4bdc-91dd-e1a0e221fec9



### After fixing:

https://github.com/user-attachments/assets/7dbccb4c-deb7-449f-a9f8-902bd8139976

