### PR TITLE
String Escaping/Encoding Bug Fixes

### DIFF
--- a/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts
@@ -199,7 +199,7 @@ class ExecuteFlow_SeqAgents implements INode {
             if (seqExecuteFlowInput === 'userQuestion') {
                 flowInput = input
             } else if (seqExecuteFlowInput && seqExecuteFlowInput.startsWith('{{') && seqExecuteFlowInput.endsWith('}}')) {
-                const nodeId = seqExecuteFlowInput.replace('{{', '').replace('}}', '').replace('$', '').trim()
+                const nodeId = seqExecuteFlowInput.replace('{{', '').replace('}}', '').replace(/\$/g, '').trim()
                 const messageOutputs = ((state.messages as unknown as BaseMessage[]) ?? []).filter(
                     (message) => message.additional_kwargs && message.additional_kwargs?.nodeId === nodeId
                 )

--- a/packages/components/nodes/tools/Searxng/Searxng.ts
+++ b/packages/components/nodes/tools/Searxng/Searxng.ts
@@ -324,7 +324,7 @@ class SearxngSearch extends Tool {
         } else if (res.answers.length) {
             return res.answers[0]
         } else if (res.infoboxes.length) {
-            return res.infoboxes[0]?.content.replaceAll(/<[^>]+>/gi, '')
+            return res.infoboxes[0]?.content ?? ''
         } else if (res.suggestions.length) {
             let suggestions = 'Suggestions: '
             res.suggestions.forEach((s) => {

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -361,7 +361,7 @@ export const resolveVariables = async (
                 // Extract nodeId and outputPath from the match
                 const [, nodeIdPart, outputPath] = outputMatch
                 // Clean nodeId (handle escaped underscores)
-                const cleanNodeId = nodeIdPart.replace('\\', '')
+                const cleanNodeId = nodeIdPart.replace(/\\/g, '')
 
                 // Find the last (most recent) matching node data instead of the first one
                 const nodeData = [...agentFlowExecutedData].reverse().find((d) => d.nodeId === cleanNodeId)
@@ -389,7 +389,7 @@ export const resolveVariables = async (
 
             // Find node data in executed data
             // sometimes turndown value returns a backslash like `llmAgentflow\_1`, remove the backslash
-            const cleanNodeId = variableFullPath.replace('\\', '')
+            const cleanNodeId = variableFullPath.replace(/\\/g, '')
             // Find the last (most recent) matching node data instead of the first one
             const nodeData = agentFlowExecutedData
                 ? [...agentFlowExecutedData].reverse().find((data) => data.nodeId === cleanNodeId)


### PR DESCRIPTION
Related to CodeQL findings
- 59: packages/components/nodes/sequentialagents/ExecuteFlow/ExecuteFlow.ts:202
- 61: packages/server/src/utils/buildAgentflow.ts:364
- 62: packages/server/src/utils/buildAgentflow.ts:392
- 63: packages/components/nodes/tools/Searxng/Searxng.ts:327

59, 61, 62 are not security issues, more so code smells and potential minor bugs.

For 63 we can remove our own HTML stripping because `ReactMarkdown` handles all of the stripping/sanitizing already.