### PR TITLE
feat: add custom endpoint support for Azure Speech-To-Text

### DIFF
--- a/packages/components/src/speechToText.ts
+++ b/packages/components/src/speechToText.ts
@@ -76,7 +76,9 @@ export const convertSpeechToText = async (upload: IFileUpload, speechToTextConfi
             }
             case SpeechToTextType.AZURE_COGNITIVE: {
                 try {
-                    const baseUrl = `https://${credentialData.serviceRegion}.cognitiveservices.azure.com/speechtotext/transcriptions:transcribe`
+                    const defaultEndpoint = `https://${credentialData.serviceRegion}.cognitiveservices.azure.com`
+                    const endpoint = speechToTextConfig.customEndpoint || defaultEndpoint
+                    const baseUrl = `${endpoint.replace(/\/$/, '')}/speechtotext/transcriptions:transcribe`
                     const apiVersion = credentialData.apiVersion || '2024-05-15-preview'
 
                     const formData = new FormData()
@@ -86,10 +88,13 @@ export const convertSpeechToText = async (upload: IFileUpload, speechToTextConfi
                     const channelsStr = speechToTextConfig.channels || '0,1'
                     const channels = channelsStr.split(',').map(Number)
 
-                    const definition = {
+                    const definition: ICommonObject = {
                         locales: [speechToTextConfig.language || 'en-US'],
                         profanityFilterMode: speechToTextConfig.profanityFilterMode || 'Masked',
                         channels
+                    }
+                    if (speechToTextConfig.endpointId) {
+                        definition.customEndpointId = speechToTextConfig.endpointId
                     }
                     formData.append('definition', JSON.stringify(definition))
 

--- a/packages/ui/src/ui-component/extended/SpeechToText.jsx
+++ b/packages/ui/src/ui-component/extended/SpeechToText.jsx
@@ -194,6 +194,23 @@ const speechToTextProviders = {
                 description: 'Comma-separated list of audio channels to process (e.g., "0,1")',
                 placeholder: '0,1',
                 default: '0,1'
+            },
+            {
+                label: 'Endpoint ID',
+                name: 'endpointId',
+                type: 'string',
+                description:
+                    'Custom Speech endpoint ID for using custom speech models (e.g., custom speech recognition trained for specific languages or domains). This sets the endpoint ID on the transcription request.',
+                optional: true
+            },
+            {
+                label: 'Custom Endpoint',
+                name: 'customEndpoint',
+                type: 'string',
+                description:
+                    'Custom endpoint URL for Azure Speech Services. Use this for private endpoints or sovereign clouds. Overrides the default regional endpoint (e.g., "https://my-custom-endpoint.cognitiveservices.azure.com").',
+                placeholder: 'https://my-custom-endpoint.cognitiveservices.azure.com',
+                optional: true
             }
         ]
     },


### PR DESCRIPTION
## Summary
Fixes #3767

Adds custom endpoint URL and endpoint ID configuration for Azure Speech-To-Text, enabling use with:
- **Custom Speech models** (trained for specific languages, dialects, or domains) via the Endpoint ID field
- **Private endpoints or sovereign clouds** via the Custom Endpoint URL field

## Changes
- Added optional **Endpoint ID** field to Azure Speech-To-Text configuration in the UI and backend. When provided, it is included as `customEndpointId` in the transcription request definition, enabling Azure Custom Speech models.
- Added optional **Custom Endpoint** field to Azure Speech-To-Text configuration. When provided, it overrides the default regional endpoint URL (`https://{region}.cognitiveservices.azure.com`), enabling private endpoints and sovereign cloud deployments.
- Both fields are fully backward-compatible; existing configurations continue to work without changes.

### Files modified
- `packages/ui/src/ui-component/extended/SpeechToText.jsx` — Added `endpointId` and `customEndpoint` input fields to the Azure Cognitive Services provider configuration
- `packages/components/src/speechToText.ts` — Updated the `AZURE_COGNITIVE` case to use the custom endpoint URL when provided and include the endpoint ID in the transcription request definition

## Test Plan
- [x] Existing configurations without custom endpoint fields continue to work (backward compatible)
- [x] Brace/bracket balance validated in both modified files
- [ ] Manual test: Configure Azure STT with a custom endpoint URL and verify transcription works
- [ ] Manual test: Configure Azure STT with an endpoint ID for a Custom Speech model and verify transcription works