### PR TITLE
feat(embeddings): add Matryoshka Embeddings node

### DIFF
--- a/packages/components/nodes/embeddings/MatryoshkaEmbedding/MatryoshkaEmbedding.test.ts
+++ b/packages/components/nodes/embeddings/MatryoshkaEmbedding/MatryoshkaEmbedding.test.ts
@@ -1,0 +1,130 @@
+jest.mock('../../../src/utils', () => ({
+    getBaseClasses: jest.fn(() => ['Embeddings'])
+}))
+
+const { nodeClass: MatryoshkaEmbeddingNode } = require('./MatryoshkaEmbedding')
+
+describe('MatryoshkaEmbedding Node', () => {
+    let node: InstanceType<typeof MatryoshkaEmbeddingNode>
+    let mockEmbeddings: { embedDocuments: jest.Mock; embedQuery: jest.Mock }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        node = new MatryoshkaEmbeddingNode()
+        mockEmbeddings = {
+            embedDocuments: jest.fn().mockResolvedValue([[0.1, 0.2, 0.3, 0.4]]),
+            embedQuery: jest.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4])
+        }
+    })
+
+    describe('constructor', () => {
+        it('should have correct metadata', () => {
+            expect(node.label).toBe('Matryoshka Embeddings')
+            expect(node.name).toBe('matryoshkaEmbeddings')
+            expect(node.category).toBe('Embeddings')
+            expect(node.type).toBe('MatryoshkaEmbeddings')
+            expect(node.baseClasses).toContain('MatryoshkaEmbeddings')
+            expect(node.baseClasses).toContain('Embeddings')
+        })
+
+        it('should require embeddings and dimensions inputs', () => {
+            const embeddingsInput = node.inputs.find((i: any) => i.name === 'embeddings')
+            const dimensionsInput = node.inputs.find((i: any) => i.name === 'dimensions')
+
+            expect(embeddingsInput).toBeDefined()
+            expect(embeddingsInput.type).toBe('Embeddings')
+
+            expect(dimensionsInput).toBeDefined()
+            expect(dimensionsInput.type).toBe('number')
+        })
+    })
+
+    describe('init', () => {
+        it('should create a MatryoshkaEmbeddings instance with valid inputs', async () => {
+            const nodeData = {
+                inputs: {
+                    embeddings: mockEmbeddings,
+                    dimensions: '256'
+                }
+            }
+
+            const result = await node.init(nodeData, '', {})
+
+            expect(result).toBeDefined()
+
+            // Verify it works by calling embedQuery
+            const vector = await result.embedQuery('test')
+            expect(mockEmbeddings.embedQuery).toHaveBeenCalledWith('test')
+            expect(vector).toHaveLength(4) // min(256, 4) = 4 since mock returns 4-dim vector
+        })
+
+        it('should truncate embeddings to specified dimensions', async () => {
+            mockEmbeddings.embedQuery.mockResolvedValue([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+
+            const nodeData = {
+                inputs: {
+                    embeddings: mockEmbeddings,
+                    dimensions: '3'
+                }
+            }
+
+            const result = await node.init(nodeData, '', {})
+            const vector = await result.embedQuery('test')
+
+            expect(vector).toEqual([0.1, 0.2, 0.3])
+        })
+
+        it('should throw error when embeddings input is missing', async () => {
+            const nodeData = {
+                inputs: {
+                    dimensions: '256'
+                }
+            }
+
+            await expect(node.init(nodeData, '', {})).rejects.toThrow('Embeddings input is required')
+        })
+
+        it('should throw error when dimensions input is missing', async () => {
+            const nodeData = {
+                inputs: {
+                    embeddings: mockEmbeddings
+                }
+            }
+
+            await expect(node.init(nodeData, '', {})).rejects.toThrow('Dimensions input is required')
+        })
+
+        it('should throw error when dimensions is not a valid number', async () => {
+            const nodeData = {
+                inputs: {
+                    embeddings: mockEmbeddings,
+                    dimensions: 'abc'
+                }
+            }
+
+            await expect(node.init(nodeData, '', {})).rejects.toThrow('Dimensions must be a positive integer')
+        })
+
+        it('should throw error when dimensions is zero', async () => {
+            const nodeData = {
+                inputs: {
+                    embeddings: mockEmbeddings,
+                    dimensions: '0'
+                }
+            }
+
+            await expect(node.init(nodeData, '', {})).rejects.toThrow('Dimensions must be a positive integer')
+        })
+
+        it('should throw error when dimensions is negative', async () => {
+            const nodeData = {
+                inputs: {
+                    embeddings: mockEmbeddings,
+                    dimensions: '-5'
+                }
+            }
+
+            await expect(node.init(nodeData, '', {})).rejects.toThrow('Dimensions must be a positive integer')
+        })
+    })
+})

--- a/packages/components/nodes/embeddings/MatryoshkaEmbedding/MatryoshkaEmbedding.ts
+++ b/packages/components/nodes/embeddings/MatryoshkaEmbedding/MatryoshkaEmbedding.ts
@@ -1,0 +1,69 @@
+import { Embeddings } from '@langchain/core/embeddings'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses } from '../../../src/utils'
+import { MatryoshkaEmbeddings } from '../../../src/matryoshkaEmbeddings'
+
+class MatryoshkaEmbedding_Embeddings implements INode {
+    label: string
+    name: string
+    version: number
+    type: string
+    icon: string
+    category: string
+    description: string
+    baseClasses: string[]
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'Matryoshka Embeddings'
+        this.name = 'matryoshkaEmbeddings'
+        this.version = 1.0
+        this.type = 'MatryoshkaEmbeddings'
+        this.icon = 'matryoshka.svg'
+        this.category = 'Embeddings'
+        this.description = 'Truncate embedding dimensions for Matryoshka embedding models to reduce storage while preserving quality'
+        this.baseClasses = [this.type, ...getBaseClasses(MatryoshkaEmbeddings)]
+        this.inputs = [
+            {
+                label: 'Embeddings',
+                name: 'embeddings',
+                type: 'Embeddings'
+            },
+            {
+                label: 'Dimensions',
+                name: 'dimensions',
+                type: 'number',
+                description:
+                    'The number of dimensions to truncate the embedding vectors to. Must be less than the original embedding dimensions. Lower values reduce storage but may decrease quality.',
+                placeholder: '256'
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, _options: ICommonObject): Promise<any> {
+        const embeddings = nodeData.inputs?.embeddings as Embeddings
+        const dimensionsStr = nodeData.inputs?.dimensions as string
+
+        if (!embeddings) {
+            throw new Error('Embeddings input is required')
+        }
+
+        if (!dimensionsStr) {
+            throw new Error('Dimensions input is required')
+        }
+
+        const dimensions = parseInt(dimensionsStr, 10)
+        if (isNaN(dimensions) || dimensions <= 0) {
+            throw new Error('Dimensions must be a positive integer')
+        }
+
+        const matryoshkaEmbeddings = new MatryoshkaEmbeddings({
+            embeddings,
+            dimensions
+        })
+
+        return matryoshkaEmbeddings
+    }
+}
+
+module.exports = { nodeClass: MatryoshkaEmbedding_Embeddings }

--- a/packages/components/nodes/embeddings/MatryoshkaEmbedding/matryoshka.svg
+++ b/packages/components/nodes/embeddings/MatryoshkaEmbedding/matryoshka.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <ellipse cx="12" cy="12" rx="10" ry="11" fill="#E57373" stroke="#C62828"/>
+  <ellipse cx="12" cy="12.5" rx="7" ry="8" fill="#EF9A9A" stroke="#C62828"/>
+  <ellipse cx="12" cy="13" rx="4.5" ry="5.5" fill="#FFCDD2" stroke="#C62828"/>
+  <ellipse cx="12" cy="13.5" rx="2.5" ry="3" fill="#FFFFFF" stroke="#C62828"/>
+  <circle cx="10.5" cy="10" r="0.8" fill="#C62828"/>
+  <circle cx="13.5" cy="10" r="0.8" fill="#C62828"/>
+</svg>

--- a/packages/components/src/matryoshkaEmbeddings.test.ts
+++ b/packages/components/src/matryoshkaEmbeddings.test.ts
@@ -1,0 +1,130 @@
+import { MatryoshkaEmbeddings } from './matryoshkaEmbeddings'
+
+describe('MatryoshkaEmbeddings', () => {
+    let mockEmbeddings: { embedDocuments: jest.Mock; embedQuery: jest.Mock }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockEmbeddings = {
+            embedDocuments: jest.fn(),
+            embedQuery: jest.fn()
+        }
+    })
+
+    describe('embedQuery', () => {
+        it('should truncate a single embedding vector to the specified dimensions', async () => {
+            const fullVector = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+            mockEmbeddings.embedQuery.mockResolvedValue(fullVector)
+
+            const matryoshka = new MatryoshkaEmbeddings({
+                embeddings: mockEmbeddings as any,
+                dimensions: 3
+            })
+
+            const result = await matryoshka.embedQuery('test text')
+
+            expect(mockEmbeddings.embedQuery).toHaveBeenCalledWith('test text')
+            expect(result).toEqual([0.1, 0.2, 0.3])
+            expect(result).toHaveLength(3)
+        })
+
+        it('should return the full vector when dimensions equals vector length', async () => {
+            const fullVector = [0.1, 0.2, 0.3]
+            mockEmbeddings.embedQuery.mockResolvedValue(fullVector)
+
+            const matryoshka = new MatryoshkaEmbeddings({
+                embeddings: mockEmbeddings as any,
+                dimensions: 3
+            })
+
+            const result = await matryoshka.embedQuery('test')
+
+            expect(result).toEqual([0.1, 0.2, 0.3])
+        })
+
+        it('should return the full vector when dimensions exceeds vector length', async () => {
+            const fullVector = [0.1, 0.2, 0.3]
+            mockEmbeddings.embedQuery.mockResolvedValue(fullVector)
+
+            const matryoshka = new MatryoshkaEmbeddings({
+                embeddings: mockEmbeddings as any,
+                dimensions: 10
+            })
+
+            const result = await matryoshka.embedQuery('test')
+
+            expect(result).toEqual([0.1, 0.2, 0.3])
+            expect(result).toHaveLength(3)
+        })
+    })
+
+    describe('embedDocuments', () => {
+        it('should truncate multiple embedding vectors to the specified dimensions', async () => {
+            const fullVectors = [
+                [0.1, 0.2, 0.3, 0.4, 0.5],
+                [0.6, 0.7, 0.8, 0.9, 1.0],
+                [1.1, 1.2, 1.3, 1.4, 1.5]
+            ]
+            mockEmbeddings.embedDocuments.mockResolvedValue(fullVectors)
+
+            const matryoshka = new MatryoshkaEmbeddings({
+                embeddings: mockEmbeddings as any,
+                dimensions: 2
+            })
+
+            const result = await matryoshka.embedDocuments(['doc1', 'doc2', 'doc3'])
+
+            expect(mockEmbeddings.embedDocuments).toHaveBeenCalledWith(['doc1', 'doc2', 'doc3'])
+            expect(result).toEqual([
+                [0.1, 0.2],
+                [0.6, 0.7],
+                [1.1, 1.2]
+            ])
+        })
+
+        it('should handle empty document list', async () => {
+            mockEmbeddings.embedDocuments.mockResolvedValue([])
+
+            const matryoshka = new MatryoshkaEmbeddings({
+                embeddings: mockEmbeddings as any,
+                dimensions: 3
+            })
+
+            const result = await matryoshka.embedDocuments([])
+
+            expect(result).toEqual([])
+        })
+
+        it('should truncate to dimension 1', async () => {
+            const fullVectors = [[0.5, 0.3, 0.1]]
+            mockEmbeddings.embedDocuments.mockResolvedValue(fullVectors)
+
+            const matryoshka = new MatryoshkaEmbeddings({
+                embeddings: mockEmbeddings as any,
+                dimensions: 1
+            })
+
+            const result = await matryoshka.embedDocuments(['doc'])
+
+            expect(result).toEqual([[0.5]])
+        })
+    })
+
+    describe('delegation', () => {
+        it('should pass through to the underlying embeddings instance', async () => {
+            mockEmbeddings.embedQuery.mockResolvedValue([1, 2, 3, 4])
+            mockEmbeddings.embedDocuments.mockResolvedValue([[1, 2, 3, 4]])
+
+            const matryoshka = new MatryoshkaEmbeddings({
+                embeddings: mockEmbeddings as any,
+                dimensions: 2
+            })
+
+            await matryoshka.embedQuery('query')
+            await matryoshka.embedDocuments(['doc'])
+
+            expect(mockEmbeddings.embedQuery).toHaveBeenCalledTimes(1)
+            expect(mockEmbeddings.embedDocuments).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/packages/components/src/matryoshkaEmbeddings.ts
+++ b/packages/components/src/matryoshkaEmbeddings.ts
@@ -1,0 +1,46 @@
+import { Embeddings, EmbeddingsParams } from '@langchain/core/embeddings'
+
+/**
+ * Truncates an embedding vector to the specified number of dimensions.
+ * Used for Matryoshka embedding models where the most important information
+ * is concentrated in the first dimensions of the vector.
+ */
+function truncateVector(vector: number[], dimensions: number): number[] {
+    return vector.slice(0, dimensions)
+}
+
+export interface MatryoshkaEmbeddingsParams extends EmbeddingsParams {
+    /** The underlying embeddings instance to wrap */
+    embeddings: Embeddings
+    /** The target number of dimensions to truncate to */
+    dimensions: number
+}
+
+/**
+ * Wrapper around any Embeddings instance that truncates the output vectors
+ * to a specified number of dimensions. This enables Matryoshka embedding
+ * support for models that produce embeddings where the most significant
+ * information is stored in the first dimensions of the vector.
+ *
+ * @see https://huggingface.co/blog/matryoshka
+ */
+export class MatryoshkaEmbeddings extends Embeddings {
+    private embeddings: Embeddings
+    private dimensions: number
+
+    constructor(params: MatryoshkaEmbeddingsParams) {
+        super(params)
+        this.embeddings = params.embeddings
+        this.dimensions = params.dimensions
+    }
+
+    async embedDocuments(texts: string[]): Promise<number[][]> {
+        const vectors = await this.embeddings.embedDocuments(texts)
+        return vectors.map((vector) => truncateVector(vector, this.dimensions))
+    }
+
+    async embedQuery(text: string): Promise<number[]> {
+        const vector = await this.embeddings.embedQuery(text)
+        return truncateVector(vector, this.dimensions)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new **Matryoshka Embeddings** node that wraps any existing embeddings model and truncates output vectors to a user-specified number of dimensions
- Enables efficient storage and retrieval with embedding models trained using the [Matryoshka loss function](https://huggingface.co/blog/matryoshka), where the most significant information is concentrated in the first dimensions of the vector
- Implemented as a composable wrapper node: users connect any Embeddings node as input and specify the target dimension count, with no changes needed to existing embedding or vector store nodes

## How It Works

The node takes two inputs:
1. **Embeddings** - Any existing embeddings node (OpenAI, Cohere, HuggingFace, Ollama, etc.)
2. **Dimensions** - The target number of dimensions to truncate to

After the underlying model generates full-dimensional vectors, the wrapper truncates them by keeping only the first N dimensions via `vector.slice(0, dimensions)`.

### New Files
- `packages/components/src/matryoshkaEmbeddings.ts` - Core `MatryoshkaEmbeddings` wrapper class extending LangChain's `Embeddings`
- `packages/components/nodes/embeddings/MatryoshkaEmbedding/MatryoshkaEmbedding.ts` - Flowise node implementation
- `packages/components/nodes/embeddings/MatryoshkaEmbedding/matryoshka.svg` - Node icon

## Test Plan

- [x] Unit tests for `MatryoshkaEmbeddings` class (vector truncation, edge cases, delegation)
- [x] Unit tests for the node's `init()` method (validation, integration)
- [x] All 16 tests passing

```
PASS nodes/embeddings/MatryoshkaEmbedding/MatryoshkaEmbedding.test.ts
PASS src/matryoshkaEmbeddings.test.ts
Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
```

Closes #4361