### PR TITLE
fix: implement Regex operation in Condition node backend

### DIFF
--- a/packages/components/nodes/agentflow/Condition/Condition.ts
+++ b/packages/components/nodes/agentflow/Condition/Condition.ts
@@ -270,6 +270,7 @@ class Condition_Agentflow implements INode {
             endsWith: (value1: CommonType, value2: CommonType) => (value1 as string).endsWith(value2 as string),
             equal: (value1: CommonType, value2: CommonType) => value1 === value2,
             notEqual: (value1: CommonType, value2: CommonType) => value1 !== value2,
+            regex: (value1: CommonType, value2: CommonType) => new RegExp((value2 || '').toString()).test((value1 || '').toString()),
             larger: (value1: CommonType, value2: CommonType) => (Number(value1) || 0) > (Number(value2) || 0),
             largerEqual: (value1: CommonType, value2: CommonType) => (Number(value1) || 0) >= (Number(value2) || 0),
             smaller: (value1: CommonType, value2: CommonType) => (Number(value1) || 0) < (Number(value2) || 0),


### PR DESCRIPTION
## Summary
- The Condition node UI offered a "Regex" operation but the backend never implemented the matching logic
- Added regex matching support to the condition evaluation function

Closes #5650

## Test plan
- Verified Regex condition matches correctly in condition node evaluation