### PR TITLE
feat(cohere-rerank): add custom API endpoint and model name support

### DIFF
--- a/packages/components/nodes/retrievers/CohereRerankRetriever/CohereRerank.test.ts
+++ b/packages/components/nodes/retrievers/CohereRerankRetriever/CohereRerank.test.ts
@@ -102,6 +102,18 @@ describe('CohereRerank', () => {
                 expect.any(Object)
             )
         })
+
+        it('should trim leading and trailing whitespace from custom baseURL', async () => {
+            const customURL = '  https://custom-cohere.example.com/v1/rerank  '
+            const reranker = new CohereRerank(mockApiKey, defaultModel, topK, maxChunksPerDoc, customURL)
+            await reranker.compressDocuments(mockDocuments, 'test query')
+
+            expect(mockedAxios.post).toHaveBeenCalledWith(
+                'https://custom-cohere.example.com/v1/rerank',
+                expect.any(Object),
+                expect.any(Object)
+            )
+        })
     })
 
     describe('compressDocuments', () => {

--- a/packages/components/nodes/retrievers/CohereRerankRetriever/CohereRerank.ts
+++ b/packages/components/nodes/retrievers/CohereRerankRetriever/CohereRerank.ts
@@ -15,7 +15,7 @@ export class CohereRerank extends BaseDocumentCompressor {
         this.model = model
         this.k = k
         this.maxChunksPerDoc = maxChunksPerDoc
-        this.cohereApiUrl = baseURL ? baseURL.replace(/\/+$/, '') : 'https://api.cohere.ai/v1/rerank'
+        this.cohereApiUrl = baseURL ? baseURL.trim().replace(/\/+$/, '') : 'https://api.cohere.ai/v1/rerank'
     }
     async compressDocuments(
         documents: Document<Record<string, any>>[],

--- a/packages/components/nodes/retrievers/CohereRerankRetriever/CohereRerankRetriever.ts
+++ b/packages/components/nodes/retrievers/CohereRerankRetriever/CohereRerankRetriever.ts
@@ -98,7 +98,7 @@ class CohereRerankRetriever_Retrievers implements INode {
                 optional: true
             },
             {
-                label: 'Base URL',
+                label: 'API Endpoint URL',
                 name: 'baseURL',
                 description: 'Custom API endpoint URL. If not specified, the default Cohere API (https://api.cohere.ai/v1/rerank) will be used.',
                 placeholder: 'https://api.cohere.ai/v1/rerank',
@@ -142,7 +142,7 @@ class CohereRerankRetriever_Retrievers implements INode {
         const baseURL = nodeData.inputs?.baseURL as string
         const output = nodeData.outputs?.output as string
 
-        const selectedModel = customModel || model
+        const selectedModel = customModel?.trim() || model
 
         const cohereCompressor = new CohereRerank(cohereApiKey, selectedModel, k, max_chunks_per_doc, baseURL)
 


### PR DESCRIPTION
## Summary

- Adds **Base URL** input to the Cohere Rerank Retriever node, allowing users to configure custom API endpoints (e.g., for proxied or self-hosted Cohere-compatible services)
- Adds **Custom Model Name** input for fine-tuned rerank models, which overrides the dropdown selection when provided
- Both new inputs appear in the "Additional Parameters" section to keep the default experience clean
- Bumps node version to 2.0

Closes #4086

## Changes

### `CohereRerank.ts` (compressor class)
- Added optional `baseURL` constructor parameter
- Uses custom URL when provided, falls back to default `https://api.cohere.ai/v1/rerank`
- Strips trailing slashes from custom URLs

### `CohereRerankRetriever.ts` (node definition)
- Added `Custom Model Name` (`customModel`) string input in Additional Parameters
- Added `Base URL` (`baseURL`) string input in Additional Parameters
- `customModel` overrides dropdown `model` selection when provided
- Passes `baseURL` to `CohereRerank` constructor

### `CohereRerank.test.ts` (new test file)
- 11 unit tests covering:
  - Default URL behavior
  - Custom URL usage
  - Trailing slash stripping
  - Custom model name support
  - Request payload structure
  - Error handling fallback
  - Authorization headers

## Test plan
- [x] All 11 unit tests pass (`npx jest CohereRerank.test.ts`)
- [ ] Manual test: verify node loads correctly in Flowise UI with new Additional Parameters fields
- [ ] Manual test: verify custom model name overrides dropdown selection
- [ ] Manual test: verify custom Base URL is used for API calls