### PR TITLE
fix: interpolate {{ variables }} in Agentflow v2 nodes

### DIFF
--- a/packages/components/nodes/agentflow/HumanInput/HumanInput.ts
+++ b/packages/components/nodes/agentflow/HumanInput/HumanInput.ts
@@ -186,7 +186,7 @@ class HumanInput_Agentflow implements INode {
                 }
             ]
             const input = { ...humanInput, messages }
-            const output = { conditions: outcomes }
+            const output = { content: humanInput.feedback || humanInput.type, conditions: outcomes }
 
             const nodeOutput = {
                 id: nodeData.id,

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -399,10 +399,18 @@ export const resolveVariables = async (
                 const nodeOutput = nodeData.data['output'] as ICommonObject
                 const actualValue = nodeOutput?.content ?? nodeOutput?.http?.data
                 // For arrays and objects, stringify them to prevent toString() conversion issues
-                const formattedValue =
-                    Array.isArray(actualValue) || (typeof actualValue === 'object' && actualValue !== null)
-                        ? JSON.stringify(actualValue)
-                        : actualValue?.toString() ?? match
+                let formattedValue: any
+                if (actualValue !== undefined && actualValue !== null) {
+                    formattedValue =
+                        Array.isArray(actualValue) || (typeof actualValue === 'object' && actualValue !== null)
+                            ? JSON.stringify(actualValue)
+                            : actualValue.toString()
+                } else if (nodeOutput && typeof nodeOutput === 'object' && Object.keys(nodeOutput).length > 0) {
+                    // Fallback: stringify the entire output when content/http.data are not available
+                    formattedValue = JSON.stringify(nodeOutput)
+                } else {
+                    formattedValue = match
+                }
                 resolvedValue = resolvedValue.replace(match, formattedValue)
             }
         }


### PR DESCRIPTION
## Summary
- `{{ variable }}` placeholders in Agentflow v2 nodes were not being interpolated with actual values
- Added `content` field to HumanInput node output (user feedback or action type) so `{{ humanInputAgentflow_0 }}` resolves correctly
- Improved fallback in `resolveNodeReference`: when a node is found but has no `content` or `http.data`, the entire output is stringified instead of returning the raw template string

Closes #5704

## Test plan
- Create an agentflow: Start -> Human Input -> (Proceed) -> Direct Reply with `{{ humanInputAgentflow_0 }}`
- Verify the Direct Reply shows the user's feedback text (or "proceed"/"reject" when no feedback)
- Verify other node variable references (e.g., `{{ llmAgentflow_0 }}`) continue to work correctly