### PR TITLE
fix: preserve flow content when renaming a flow

### DIFF
--- a/packages/ui/src/ui-component/button/FlowListMenu.jsx
+++ b/packages/ui/src/ui-component/button/FlowListMenu.jsx
@@ -22,7 +22,6 @@ import { IconX } from '@tabler/icons-react'
 
 import chatflowsApi from '@/api/chatflows'
 
-import useApi from '@/hooks/useApi'
 import useConfirm from '@/hooks/useConfirm'
 import { uiBaseURL } from '@/store/constant'
 import { closeSnackbar as closeSnackbarAction, enqueueSnackbar as enqueueSnackbarAction } from '@/store/actions'
@@ -77,8 +76,6 @@ const StyledMenu = styled((props) => (
 export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, setError, updateFlowsApi, currentPage, pageLimit }) {
     const { confirm } = useConfirm()
     const dispatch = useDispatch()
-    const updateChatflowApi = useApi(chatflowsApi.updateChatflow)
-
     useNotifier()
     const enqueueSnackbar = (...args) => dispatch(enqueueSnackbarAction(...args))
     const closeSnackbar = (...args) => dispatch(closeSnackbarAction(...args))
@@ -178,12 +175,9 @@ export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, s
     }
 
     const saveFlowRename = async (chatflowName) => {
-        const updateBody = {
-            name: chatflowName,
-            chatflow
-        }
         try {
-            await updateChatflowApi.request(chatflow.id, updateBody)
+            await chatflowsApi.updateChatflow(chatflow.id, { name: chatflowName })
+            setFlowDialogOpen(false)
             const params = {
                 page: currentPage,
                 limit: pageLimit
@@ -198,7 +192,7 @@ export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, s
         } catch (error) {
             if (setError) setError(error)
             enqueueSnackbar({
-                message: typeof error.response.data === 'object' ? error.response.data.message : error.response.data,
+                message: typeof error.response?.data === 'object' ? error.response.data.message : error.response?.data,
                 options: {
                     key: new Date().getTime() + Math.random(),
                     variant: 'error',
@@ -227,12 +221,8 @@ export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, s
         setCategoryDialogOpen(false)
         // save categories as string
         const categoryTags = categories.join(';')
-        const updateBody = {
-            category: categoryTags,
-            chatflow
-        }
         try {
-            await updateChatflowApi.request(chatflow.id, updateBody)
+            await chatflowsApi.updateChatflow(chatflow.id, { category: categoryTags })
             const params = {
                 page: currentPage,
                 limit: pageLimit
@@ -245,7 +235,7 @@ export default function FlowListMenu({ chatflow, isAgentCanvas, isAgentflowV2, s
         } catch (error) {
             if (setError) setError(error)
             enqueueSnackbar({
-                message: typeof error.response.data === 'object' ? error.response.data.message : error.response.data,
+                message: typeof error.response?.data === 'object' ? error.response.data.message : error.response?.data,
                 options: {
                     key: new Date().getTime() + Math.random(),
                     variant: 'error',


### PR DESCRIPTION
## Summary

Fixes #5736 - Renaming a flow from the list view caused the flow overview to appear empty.

**Root cause:** `saveFlowRename` and `saveFlowCategory` in `FlowListMenu` used the `useApi` hook to call `updateChatflow`. The `useApi` hook's internal error handling calls `ErrorContext.setError()`, which shares state with the parent Chatflows page. If the update triggered any error (even transient), it would cause the page to render an `ErrorBoundary` instead of the flow list, making it appear empty.

**Changes:**
- **Call `chatflowsApi.updateChatflow` directly** instead of through `useApi`, so errors are caught locally in try/catch without polluting the page-level error state
- **Close the rename dialog on success** (`setFlowDialogOpen(false)`) — previously it stayed open after confirming
- **Send only the changed field** (`{ name }` or `{ category }`) in the request body — previously the entire `chatflow` object was unnecessarily included
- **Add optional chaining** on `error.response?.data` to prevent crashes when the error lacks a response property

## Test plan

- [ ] Open Chatflows list view (table mode)
- [ ] Click Options > Rename on any flow
- [ ] Enter a new name and confirm
- [ ] Verify the dialog closes and the list refreshes with the updated name
- [ ] Verify the flow content is preserved (open the renamed flow in canvas)
- [ ] Repeat for Update Category from the same menu
- [ ] Repeat the above steps for Agentflows (both V1 and V2)