### PR TITLE
fix: default mcp tool desc to tool name

### DIFF
--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -107,7 +107,7 @@ export class MCPToolkit extends BaseToolkit {
             return await MCPTool({
                 toolkit: this,
                 name: tool.name,
-                description: tool.description || '',
+                description: tool.description || tool.name,
                 argsSchema: createSchemaModel(tool.inputSchema)
             })
         })


### PR DESCRIPTION
## Summary

Custom MCP tools without `description` currently fallback to using the `name` as the `description` in the UI, but not when creating the tool config in the LLM request. Some LLM providers, e.g. AWS Bedrock, do not permit empty strings `''`.

Example docs: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolSpecification.html

Existing fallback behavior: https://github.com/FlowiseAI/Flowise/blob/main/packages/components/nodes/tools/MCP/CustomMCP/CustomMCP.ts#L102

This causes an issue where
- using an LLM on AWS Bedrock
- with a Custom MCP server
- with a tool selected that has no description

causes Bedrock to reject the request.

This change makes the UI and server fallback behavior consistent.