### PR TITLE
fix: Improve error message for 401 / invalid API key (avoid "local ...

### DIFF
--- a/packages/server/src/middlewares/errors/index.ts
+++ b/packages/server/src/middlewares/errors/index.ts
@@ -7,7 +7,7 @@ import { InternalFlowiseError } from '../../errors/internalFlowiseError'
 async function errorHandlerMiddleware(err: InternalFlowiseError, req: Request, res: Response, next: NextFunction) {
     const statusCode = err.statusCode || StatusCodes.INTERNAL_SERVER_ERROR
     if (err.message.includes('401 Incorrect API key provided'))
-        err.message = '401 Invalid model key or Incorrect local model configuration.'
+        err.message = '401 Unauthorized – check your API key and ensure it has access to the requested model.'
     let displayedError = {
         statusCode,
         success: false,

--- a/packages/server/src/utils/SSEStreamer.ts
+++ b/packages/server/src/utils/SSEStreamer.ts
@@ -206,7 +206,8 @@ export class SSEStreamer implements IServerSideEventStreamer {
     }
 
     streamErrorEvent(chatId: string, msg: string) {
-        if (msg.includes('401 Incorrect API key provided')) msg = '401 Invalid model key or Incorrect local model configuration.'
+        if (msg.includes('401 Incorrect API key provided'))
+            msg = '401 Unauthorized – check your API key and ensure it has access to the requested model.'
         const client = this.clients[chatId]
         if (client) {
             const clientResponse = {


### PR DESCRIPTION
## Summary

Improves the error message shown when a 401 Unauthorized error occurs due to an invalid or missing API key. The previous message mentioning "local model configuration" was confusing users, as this error typically indicates an API key issue rather than a local model configuration problem.

## Issue

Fixes #5776

## Changes

- Updated error message in `errorHandlerMiddleware` from "Invalid model key or Incorrect local model configuration" to "Unauthorized – check your API key and ensure it has access to the requested model"
- Updated the same error message in `SSEStreamer.streamErrorEvent` for consistency across both error handling paths

## Testing

- Verified the error message changes are applied in both the middleware and SSE streamer error handlers
- The new message clearly directs users to check their API key configuration