### PR TITLE
Potential fix for code scanning alert no. 51: Clear text transmission of sensitive cookie

### DIFF
--- a/packages/server/src/enterprise/middleware/passport/index.ts
+++ b/packages/server/src/enterprise/middleware/passport/index.ts
@@ -35,8 +35,11 @@ const jwtRefreshSecret = process.env.JWT_REFRESH_TOKEN_SECRET || process.env.JWT
 
 // Allow explicit override of cookie security settings
 // This is useful when running behind a reverse proxy/load balancer that terminates SSL
+// In production, always enforce secure cookies to prevent clear-text transmission of session data.
 const secureCookie =
-    process.env.SECURE_COOKIES === 'false'
+    process.env.NODE_ENV === 'production'
+        ? true
+        : process.env.SECURE_COOKIES === 'false'
         ? false
         : process.env.SECURE_COOKIES === 'true'
         ? true


### PR DESCRIPTION
Potential fix for [https://github.com/FlowiseAI/Flowise/security/code-scanning/51](https://github.com/FlowiseAI/Flowise/security/code-scanning/51)

To fix the problem, the session cookie must always be marked as `secure` in any environment where it can contain sensitive information. The safest approach is to (a) default to `secure: true`, (b) only allow overriding to `false` in clearly demarcated non-production / development scenarios, and (c) optionally rely on `trust proxy` plus `cookie.secure: 'auto'` if the app runs behind HTTPS-terminating proxies. Since we can only edit the shown snippet, we should tighten the `secureCookie` logic so that in production-like environments it is always `true` and cannot be disabled by misconfiguration.

The single best minimal-change fix here is to compute `secureCookie` such that it is `true` whenever `NODE_ENV === 'production'` (or when `APP_URL` is HTTPS), and only allow `secure: false` explicitly in non-production settings. We keep the existing env-based configurability but guard the insecure option with `NODE_ENV !== 'production'`. Concretely, we will modify the `secureCookie` constant defined at lines 38–45 to:  
- Default to `true` when `NODE_ENV === 'production'`.  
- Otherwise, respect `SECURE_COOKIES` if explicitly set, or fall back to checking `APP_URL` for HTTPS, or finally `false` for dev without HTTPS.  

This does not require changes elsewhere because `options.cookie.secure` already uses `secureCookie`. No new methods are needed; only the expression for `secureCookie` needs to be updated in `packages/server/src/enterprise/middleware/passport/index.ts`.

Based on this line of code, this appears the proper way to check if it's running in production: https://github.com/FlowiseAI/Flowise/blob/3201257a8273e7efc1912e20c33d9b9ffafa4a10/packages/ui/src/serviceWorker.js#L90


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
