### PR TITLE
fix: Resolve custom tool edit not working

### DIFF
--- a/packages/ui/src/views/tools/ToolDialog.jsx
+++ b/packages/ui/src/views/tools/ToolDialog.jsx
@@ -90,27 +90,23 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
 
     const deleteItem = useCallback(
         (id) => () => {
-            setTimeout(() => {
-                setToolSchema((prevRows) => prevRows.filter((row) => row.id !== id))
-            })
+            setToolSchema((prevRows) => prevRows.filter((row) => row.id !== id))
         },
         []
     )
 
     const addNewRow = () => {
-        setTimeout(() => {
-            setToolSchema((prevRows) => {
-                let allRows = [...cloneDeep(prevRows)]
-                const lastRowId = allRows.length ? allRows[allRows.length - 1].id + 1 : 1
-                allRows.push({
-                    id: lastRowId,
-                    property: '',
-                    description: '',
-                    type: '',
-                    required: false
-                })
-                return allRows
+        setToolSchema((prevRows) => {
+            let allRows = [...cloneDeep(prevRows)]
+            const lastRowId = allRows.length ? allRows[allRows.length - 1].id + 1 : 1
+            allRows.push({
+                id: lastRowId,
+                property: '',
+                description: '',
+                type: '',
+                required: false
             })
+            return allRows
         })
     }
 
@@ -129,15 +125,13 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     }
 
     const onRowUpdate = (newRow) => {
-        setTimeout(() => {
-            setToolSchema((prevRows) => {
-                let allRows = [...cloneDeep(prevRows)]
-                const indexToUpdate = allRows.findIndex((row) => row.id === newRow.id)
-                if (indexToUpdate >= 0) {
-                    allRows[indexToUpdate] = { ...newRow }
-                }
-                return allRows
-            })
+        setToolSchema((prevRows) => {
+            let allRows = [...cloneDeep(prevRows)]
+            const indexToUpdate = allRows.findIndex((row) => row.id === newRow.id)
+            if (indexToUpdate >= 0) {
+                allRows[indexToUpdate] = { ...newRow }
+            }
+            return allRows
         })
     }
 


### PR DESCRIPTION
Fixes #5761

## Summary
The `onRowUpdate`, `deleteItem`, and `addNewRow` handlers in `ToolDialog.jsx` wrapped their state updates in `setTimeout`, causing a race condition: when a user edits a schema cell and clicks Save before the deferred state update fires, the save serializes stale schema data. This removes the unnecessary `setTimeout` wrappers so state updates happen synchronously, matching the pattern used in the working `DataGrid.jsx` component.

## Test plan
- [ ] Create a custom tool with input schema properties
- [ ] Edit a property (rename, change type, toggle required) and immediately click Save
- [ ] Reopen the tool and verify edits persisted
- [ ] Test adding/deleting schema rows still works

*This PR was created with the assistance of Claude by Anthropic. Happy to make any adjustments!*