### PR TITLE
Fix #5767: 504 Gateway Timeout Error When Upserting Documents into Vect

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,4 +1,7 @@
 PORT=3000
+# HTTP server request timeout in milliseconds (0 = no timeout).
+# Increase this when vector store upserts time out behind a reverse proxy (e.g. Cloudflare 504).
+# SERVER_TIMEOUT_MS=0
 
 ############################################################################################################
 ############################################## DATABASE ####################################################

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -377,6 +377,12 @@ export async function start(): Promise<void> {
     const port = parseInt(process.env.PORT || '', 10) || 3000
     const server = http.createServer(serverApp.app)
 
+    // Allow long-running operations (e.g. vector store upserts) to complete without
+    // hitting Node.js's built-in request timeout, which would surface as a 504 when
+    // Cloudflare or another reverse-proxy sits in front of Flowise.
+    // Operators can override via SERVER_TIMEOUT_MS (0 = no timeout).
+    server.requestTimeout = parseInt(process.env.SERVER_TIMEOUT_MS || '0', 10)
+
     await serverApp.initDatabase()
     await serverApp.config()
 


### PR DESCRIPTION
Fixes #5767

## Summary
This PR addresses: 504 Gateway Timeout Error When Upserting Documents into Vector Stor

## Changes
```
packages/server/.env.example | 3 +++
 packages/server/src/index.ts | 6 ++++++
 2 files changed, 9 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).