### PR TITLE
fix(ui): move click handlers from Avatar to ButtonBase for keyboard a…

### DIFF
--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -253,7 +253,17 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
             <Stack flexDirection='row' justifyContent='space-between' sx={{ width: '100%' }}>
                 <Stack flexDirection='row' sx={{ width: '100%', maxWidth: '50%' }}>
                     <Box>
-                        <ButtonBase title='Back' sx={{ borderRadius: '50%' }}>
+                        <ButtonBase
+                            title='Back'
+                            sx={{ borderRadius: '50%' }}
+                            onClick={() => {
+                                if (window.history.state && window.history.state.idx > 0) {
+                                    navigate(-1)
+                                } else {
+                                    navigate('/', { replace: true })
+                                }
+                            }}
+                        >
                             <Avatar
                                 variant='rounded'
                                 sx={{
@@ -268,13 +278,6 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                     }
                                 }}
                                 color='inherit'
-                                onClick={() => {
-                                    if (window.history.state && window.history.state.idx > 0) {
-                                        navigate(-1)
-                                    } else {
-                                        navigate('/', { replace: true })
-                                    }
-                                }}
                             >
                                 <IconChevronLeft stroke={1.5} size='1.3rem' />
                             </Avatar>
@@ -297,7 +300,7 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                 </Typography>
                                 {chatflow?.id && (
                                     <Available permission={savePermission}>
-                                        <ButtonBase title='Edit Name' sx={{ borderRadius: '50%' }}>
+                                        <ButtonBase title='Edit Name' sx={{ borderRadius: '50%' }} onClick={() => setEditingFlowName(true)}>
                                             <Avatar
                                                 variant='rounded'
                                                 sx={{
@@ -313,7 +316,6 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                                     }
                                                 }}
                                                 color='inherit'
-                                                onClick={() => setEditingFlowName(true)}
                                             >
                                                 <IconPencil stroke={1.5} size='1.3rem' />
                                             </Avatar>
@@ -341,7 +343,7 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                         }
                                     }}
                                 />
-                                <ButtonBase title='Save Name' sx={{ borderRadius: '50%' }}>
+                                <ButtonBase title='Save Name' sx={{ borderRadius: '50%' }} onClick={submitFlowName}>
                                     <Avatar
                                         variant='rounded'
                                         sx={{
@@ -357,12 +359,11 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                             }
                                         }}
                                         color='inherit'
-                                        onClick={submitFlowName}
                                     >
                                         <IconCheck stroke={1.5} size='1.3rem' />
                                     </Avatar>
                                 </ButtonBase>
-                                <ButtonBase title='Cancel' sx={{ borderRadius: '50%' }}>
+                                <ButtonBase title='Cancel' sx={{ borderRadius: '50%' }} onClick={() => setEditingFlowName(false)}>
                                     <Avatar
                                         variant='rounded'
                                         sx={{
@@ -378,7 +379,6 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                             }
                                         }}
                                         color='inherit'
-                                        onClick={() => setEditingFlowName(false)}
                                     >
                                         <IconX stroke={1.5} size='1.3rem' />
                                     </Avatar>
@@ -389,7 +389,7 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                 </Stack>
                 <Box>
                     {chatflow?.id && (
-                        <ButtonBase title='API Endpoint' sx={{ borderRadius: '50%', mr: 2 }}>
+                        <ButtonBase title='API Endpoint' sx={{ borderRadius: '50%', mr: 2 }} onClick={onAPIDialogClick}>
                             <Avatar
                                 variant='rounded'
                                 sx={{
@@ -404,14 +404,13 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                     }
                                 }}
                                 color='inherit'
-                                onClick={onAPIDialogClick}
                             >
                                 <IconCode stroke={1.5} size='1.3rem' />
                             </Avatar>
                         </ButtonBase>
                     )}
                     <Available permission={savePermission}>
-                        <ButtonBase title={`Save ${title}`} sx={{ borderRadius: '50%', mr: 2 }}>
+                        <ButtonBase title={`Save ${title}`} sx={{ borderRadius: '50%', mr: 2 }} onClick={onSaveChatflowClick}>
                             <Avatar
                                 variant='rounded'
                                 sx={{
@@ -426,13 +425,12 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                     }
                                 }}
                                 color='inherit'
-                                onClick={onSaveChatflowClick}
                             >
                                 <IconDeviceFloppy stroke={1.5} size='1.3rem' />
                             </Avatar>
                         </ButtonBase>
                     </Available>
-                    <ButtonBase ref={settingsRef} title='Settings' sx={{ borderRadius: '50%' }}>
+                    <ButtonBase ref={settingsRef} title='Settings' sx={{ borderRadius: '50%' }} onClick={() => setSettingsOpen(!isSettingsOpen)}>
                         <Avatar
                             variant='rounded'
                             sx={{
@@ -446,7 +444,6 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                     color: theme.palette.canvasHeader.settingsLight
                                 }
                             }}
-                            onClick={() => setSettingsOpen(!isSettingsOpen)}
                         >
                             <IconSettings stroke={1.5} size='1.3rem' />
                         </Avatar>


### PR DESCRIPTION
Description:

Fixes #5819

Problem

In the `CanvasHeader` component, `onClick` event handlers were attached to inner `Avatar` elements, which render as `div` elements in the DOM. Since `div` elements are not keyboard-focusable by default, keyboard users (including screen reader users) could not trigger button actions using Enter or Space keys.

Solution

Moved all `onClick` handlers from inner `Avatar` components to the outer `ButtonBase` components, which render as native `button` elements. Native buttons are focusable and respond to keyboard Enter/Space key presses out of the box.

Affected buttons (7 total)

Back — `navigate(-1)` / `navigate('/')`
Edit Name — `setEditingFlowName(true)`
Save Name — `submitFlowName`
Cancel — `setEditingFlowName(false)`
API Endpoint — `onAPIDialogClick`
Save Chatflow — `onSaveChatflowClick`
Settings — `setSettingsOpen(!isSettingsOpen)`
Changes

File: `CanvasHeader.jsx`
Moved `onClick` from `Avatar` to `ButtonBase` for all 7 toolbar buttons
No behavioral changes — only the event target element changed
Testing

All existing test suites pass (agentflow: 216 tests, components: 241 tests)
Keyboard navigation now correctly triggers all toolbar button actions via Enter/Space keysDescription:

Fixes #5819

Problem

In the `CanvasHeader` component, `onClick` event handlers were attached to inner `Avatar` elements, which render as `div` elements in the DOM. Since `div` elements are not keyboard-focusable by default, keyboard users (including screen reader users) could not trigger button actions using Enter or Space keys.

Solution

Moved all `onClick` handlers from inner `Avatar` components to the outer `ButtonBase` components, which render as native `button` elements. Native buttons are focusable and respond to keyboard Enter/Space key presses out of the box.

Affected buttons (7 total)

Back — `navigate(-1)` / `navigate('/')`
Edit Name — `setEditingFlowName(true)`
Save Name — `submitFlowName`
Cancel — `setEditingFlowName(false)`
API Endpoint — `onAPIDialogClick`
Save Chatflow — `onSaveChatflowClick`
Settings — `setSettingsOpen(!isSettingsOpen)`
Changes

File: `CanvasHeader.jsx`
Moved `onClick` from `Avatar` to `ButtonBase` for all 7 toolbar buttons
No behavioral changes — only the event target element changed
Testing

All existing test suites pass (agentflow: 216 tests, components: 241 tests)
Keyboard navigation now correctly triggers all toolbar button actions via Enter/Space keys