### PR TITLE
feat(tools): add CAMB AI integration with 8 tool nodes

### DIFF
--- a/packages/components/credentials/CambAIApi.credential.ts
+++ b/packages/components/credentials/CambAIApi.credential.ts
@@ -1,0 +1,25 @@
+import { INodeParams, INodeCredential } from '../src/Interface'
+
+class CambAIApi implements INodeCredential {
+    label: string
+    name: string
+    version: number
+    description: string
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI API'
+        this.name = 'cambAIApi'
+        this.version = 1.0
+        this.description = 'Get your API key from <a target="_blank" href="https://studio.camb.ai">CAMB AI Studio</a>'
+        this.inputs = [
+            {
+                label: 'CAMB AI API Key',
+                name: 'cambApiKey',
+                type: 'password'
+            }
+        ]
+    }
+}
+
+module.exports = { credClass: CambAIApi }

--- a/packages/components/nodes/tools/CambAI/CambAudioSeparation.ts
+++ b/packages/components/nodes/tools/CambAI/CambAudioSeparation.ts
@@ -1,0 +1,86 @@
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { cambPostMultipart, pollTask, cambFetch } from './core'
+
+class CambAudioSeparationTool extends Tool {
+    name = 'camb_audio_separation'
+    description = 'Separate vocals/speech from background audio using CAMB AI. Provide an audio URL. Returns JSON with URLs for separated vocals and background audio.'
+    apiKey: string
+
+    constructor(apiKey: string) {
+        super()
+        this.apiKey = apiKey
+    }
+
+    async _call(input: string): Promise<string> {
+        const config = { apiKey: this.apiKey }
+
+        // Download audio from URL, then upload via multipart (API requires file upload)
+        const audioRes = await fetch(input.trim())
+        if (!audioRes.ok) {
+            throw new Error(`Failed to download audio from ${input}: ${audioRes.status}`)
+        }
+        const audioBuffer = await audioRes.arrayBuffer()
+        const formData = new FormData()
+        formData.append('media_file', new Blob([audioBuffer]), 'audio.mp3')
+
+        const result = await cambPostMultipart('/audio-separation', config, formData)
+        const taskId = result.task_id
+
+        const status = await pollTask(`/audio-separation/${taskId}`, config)
+        const runId = status.run_id
+
+        // Get separation result
+        const res = await cambFetch(`/audio-separation-result/${runId}`, config)
+        if (!res.ok) {
+            throw new Error(`CAMB AI Audio Separation result error (${res.status}): ${await res.text()}`)
+        }
+
+        const sepResult = await res.json()
+        return JSON.stringify({
+            foreground_audio_url: sepResult.foreground_audio_url || null,
+            background_audio_url: sepResult.background_audio_url || null,
+            status: 'completed'
+        }, null, 2)
+    }
+}
+
+class CambAudioSeparation_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI Audio Separation'
+        this.name = 'cambAudioSeparation'
+        this.version = 1.0
+        this.type = 'CambAudioSeparation'
+        this.icon = 'camb-ai.svg'
+        this.category = 'Tools'
+        this.description = 'Separate vocals from background audio using CAMB AI'
+        this.baseClasses = [this.type, ...getBaseClasses(CambAudioSeparationTool)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['cambAIApi']
+        }
+        this.inputs = []
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('cambApiKey', credentialData, nodeData)
+        return new CambAudioSeparationTool(apiKey)
+    }
+}
+
+module.exports = { nodeClass: CambAudioSeparation_Tools }

--- a/packages/components/nodes/tools/CambAI/CambTTS.ts
+++ b/packages/components/nodes/tools/CambAI/CambTTS.ts
@@ -1,0 +1,112 @@
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { streamTTS } from './core'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+class CambTTSTool extends Tool {
+    name = 'camb_tts'
+    description = 'Convert text to speech using CAMB AI. Supports 140+ languages and multiple voice models. Returns the file path to the generated audio.'
+    apiKey: string
+    language: string
+    voiceId: number
+    speechModel: string
+
+    constructor(apiKey: string, language: string, voiceId: number, speechModel: string) {
+        super()
+        this.apiKey = apiKey
+        this.language = language
+        this.voiceId = voiceId
+        this.speechModel = speechModel
+    }
+
+    async _call(input: string): Promise<string> {
+        const body: Record<string, any> = {
+            text: input,
+            language: this.language,
+            voice_id: this.voiceId,
+            speech_model: this.speechModel,
+            output_configuration: { format: 'wav' }
+        }
+
+        const audioBuffer = await streamTTS({ apiKey: this.apiKey }, body)
+        const tmpFile = path.join(os.tmpdir(), `camb_tts_${Date.now()}.wav`)
+        fs.writeFileSync(tmpFile, audioBuffer)
+        return `Audio saved to: ${tmpFile}`
+    }
+}
+
+class CambTTS_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI Text-to-Speech'
+        this.name = 'cambTTS'
+        this.version = 1.0
+        this.type = 'CambTTS'
+        this.icon = 'camb-ai.svg'
+        this.category = 'Tools'
+        this.description = 'Convert text to speech using CAMB AI with 140+ languages'
+        this.baseClasses = [this.type, ...getBaseClasses(CambTTSTool)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['cambAIApi']
+        }
+        this.inputs = [
+            {
+                label: 'Language',
+                name: 'language',
+                type: 'string',
+                default: 'en-us',
+                description: 'BCP-47 language code (e.g. en-us, fr-fr)',
+                optional: true
+            },
+            {
+                label: 'Voice ID',
+                name: 'voiceId',
+                type: 'number',
+                default: 147320,
+                description: 'Voice ID for speech synthesis',
+                optional: true
+            },
+            {
+                label: 'Speech Model',
+                name: 'speechModel',
+                type: 'options',
+                options: [
+                    { label: 'Mars Flash', name: 'mars-flash' },
+                    { label: 'Mars Pro', name: 'mars-pro' },
+                    { label: 'Mars Instruct', name: 'mars-instruct' }
+                ],
+                default: 'mars-flash',
+                description: 'The speech model to use',
+                optional: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('cambApiKey', credentialData, nodeData)
+        const language = (nodeData.inputs?.language as string) || 'en-us'
+        const voiceId = parseInt((nodeData.inputs?.voiceId as string) || '147320', 10)
+        const speechModel = (nodeData.inputs?.speechModel as string) || 'mars-flash'
+
+        return new CambTTSTool(apiKey, language, voiceId, speechModel)
+    }
+}
+
+module.exports = { nodeClass: CambTTS_Tools }

--- a/packages/components/nodes/tools/CambAI/CambTextToSound.ts
+++ b/packages/components/nodes/tools/CambAI/CambTextToSound.ts
@@ -1,0 +1,98 @@
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { cambPost, pollTask, cambFetch } from './core'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+class CambTextToSoundTool extends Tool {
+    name = 'camb_text_to_sound'
+    description = 'Generate sounds, music, or soundscapes from text descriptions using CAMB AI. Returns the file path to the generated audio.'
+    apiKey: string
+    audioType: string
+
+    constructor(apiKey: string, audioType: string) {
+        super()
+        this.apiKey = apiKey
+        this.audioType = audioType
+    }
+
+    async _call(input: string): Promise<string> {
+        const config = { apiKey: this.apiKey }
+        const body: Record<string, any> = { prompt: input }
+        if (this.audioType) {
+            body.audio_type = this.audioType
+        }
+
+        const result = await cambPost('/text-to-sound', config, body)
+        const taskId = result.task_id
+
+        const status = await pollTask(`/text-to-sound/${taskId}`, config)
+        const runId = status.run_id
+
+        // Get audio result
+        const res = await cambFetch(`/text-to-sound-result/${runId}`, config)
+        if (!res.ok) {
+            throw new Error(`CAMB AI Text-to-Sound result error (${res.status}): ${await res.text()}`)
+        }
+
+        const audioBuffer = Buffer.from(await res.arrayBuffer())
+        const tmpFile = path.join(os.tmpdir(), `camb_sound_${Date.now()}.wav`)
+        fs.writeFileSync(tmpFile, audioBuffer)
+        return `Audio saved to: ${tmpFile}`
+    }
+}
+
+class CambTextToSound_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI Text-to-Sound'
+        this.name = 'cambTextToSound'
+        this.version = 1.0
+        this.type = 'CambTextToSound'
+        this.icon = 'camb-ai.svg'
+        this.category = 'Tools'
+        this.description = 'Generate sounds, music, or soundscapes from text descriptions using CAMB AI'
+        this.baseClasses = [this.type, ...getBaseClasses(CambTextToSoundTool)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['cambAIApi']
+        }
+        this.inputs = [
+            {
+                label: 'Audio Type',
+                name: 'audioType',
+                type: 'options',
+                options: [
+                    { label: 'Sound', name: 'sound' },
+                    { label: 'Music', name: 'music' }
+                ],
+                default: 'sound',
+                description: 'Type of audio to generate',
+                optional: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('cambApiKey', credentialData, nodeData)
+        const audioType = (nodeData.inputs?.audioType as string) || 'sound'
+        return new CambTextToSoundTool(apiKey, audioType)
+    }
+}
+
+module.exports = { nodeClass: CambTextToSound_Tools }

--- a/packages/components/nodes/tools/CambAI/CambTranscribe.ts
+++ b/packages/components/nodes/tools/CambAI/CambTranscribe.ts
@@ -1,0 +1,96 @@
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { cambFetch, cambPostMultipart, pollTask } from './core'
+
+class CambTranscribeTool extends Tool {
+    name = 'camb_transcribe'
+    description = 'Transcribe audio to text with speaker identification using CAMB AI. Provide an audio URL. Returns JSON with transcription segments.'
+    apiKey: string
+    language: number
+
+    constructor(apiKey: string, language: number) {
+        super()
+        this.apiKey = apiKey
+        this.language = language
+    }
+
+    async _call(input: string): Promise<string> {
+        const config = { apiKey: this.apiKey }
+
+        // Download audio from URL, then upload via multipart (API requires file upload)
+        const audioRes = await fetch(input.trim())
+        if (!audioRes.ok) {
+            throw new Error(`Failed to download audio from ${input}: ${audioRes.status}`)
+        }
+        const audioBuffer = await audioRes.arrayBuffer()
+        const formData = new FormData()
+        formData.append('language', String(this.language))
+        formData.append('media_file', new Blob([audioBuffer]), 'audio.mp3')
+
+        const result = await cambPostMultipart('/transcribe', config, formData)
+        const taskId = result.task_id
+
+        // Poll for completion
+        const status = await pollTask(`/transcribe/${taskId}`, config)
+        const runId = status.run_id
+
+        // Get transcription result (GET with query params)
+        const res = await cambFetch(`/transcription-result/${runId}?data_type=json&format_type=txt`, config)
+        if (!res.ok) {
+            throw new Error(`CAMB AI Transcription result error (${res.status}): ${await res.text()}`)
+        }
+        const transcription = await res.json()
+
+        return JSON.stringify(transcription, null, 2)
+    }
+}
+
+class CambTranscribe_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI Transcribe'
+        this.name = 'cambTranscribe'
+        this.version = 1.0
+        this.type = 'CambTranscribe'
+        this.icon = 'camb-ai.svg'
+        this.category = 'Tools'
+        this.description = 'Transcribe audio to text with speaker identification using CAMB AI'
+        this.baseClasses = [this.type, ...getBaseClasses(CambTranscribeTool)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['cambAIApi']
+        }
+        this.inputs = [
+            {
+                label: 'Language',
+                name: 'language',
+                type: 'number',
+                default: 1,
+                description: 'Language code (integer). 1=English, 2=Spanish, 3=French, etc.'
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('cambApiKey', credentialData, nodeData)
+        const language = parseInt((nodeData.inputs?.language as string) || '1', 10)
+
+        return new CambTranscribeTool(apiKey, language)
+    }
+}
+
+module.exports = { nodeClass: CambTranscribe_Tools }

--- a/packages/components/nodes/tools/CambAI/CambTranslate.ts
+++ b/packages/components/nodes/tools/CambAI/CambTranslate.ts
@@ -1,0 +1,94 @@
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { cambFetch } from './core'
+
+class CambTranslateTool extends Tool {
+    name = 'camb_translate'
+    description = 'Translate text between 140+ languages using CAMB AI. Language codes: 1=English, 2=Spanish, 3=French, 4=German, 5=Italian, 6=Portuguese, 7=Dutch, 8=Russian, 9=Japanese, 10=Korean, 11=Chinese.'
+    apiKey: string
+    sourceLanguage: number
+    targetLanguage: number
+
+    constructor(apiKey: string, sourceLanguage: number, targetLanguage: number) {
+        super()
+        this.apiKey = apiKey
+        this.sourceLanguage = sourceLanguage
+        this.targetLanguage = targetLanguage
+    }
+
+    async _call(input: string): Promise<string> {
+        const body = {
+            text: input,
+            source_language: this.sourceLanguage,
+            target_language: this.targetLanguage
+        }
+
+        const res = await cambFetch('/translation/stream', { apiKey: this.apiKey }, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        })
+        if (!res.ok) {
+            throw new Error(`CAMB AI Translation error (${res.status}): ${await res.text()}`)
+        }
+        return await res.text()
+    }
+}
+
+class CambTranslate_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI Translate'
+        this.name = 'cambTranslate'
+        this.version = 1.0
+        this.type = 'CambTranslate'
+        this.icon = 'camb-ai.svg'
+        this.category = 'Tools'
+        this.description = 'Translate text between 140+ languages using CAMB AI'
+        this.baseClasses = [this.type, ...getBaseClasses(CambTranslateTool)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['cambAIApi']
+        }
+        this.inputs = [
+            {
+                label: 'Source Language',
+                name: 'sourceLanguage',
+                type: 'number',
+                default: 1,
+                description: 'Source language code (integer). 1=English, 2=Spanish, 3=French, etc.'
+            },
+            {
+                label: 'Target Language',
+                name: 'targetLanguage',
+                type: 'number',
+                default: 2,
+                description: 'Target language code (integer). 1=English, 2=Spanish, 3=French, etc.'
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('cambApiKey', credentialData, nodeData)
+        const sourceLanguage = parseInt((nodeData.inputs?.sourceLanguage as string) || '1', 10)
+        const targetLanguage = parseInt((nodeData.inputs?.targetLanguage as string) || '2', 10)
+
+        return new CambTranslateTool(apiKey, sourceLanguage, targetLanguage)
+    }
+}
+
+module.exports = { nodeClass: CambTranslate_Tools }

--- a/packages/components/nodes/tools/CambAI/CambTranslatedTTS.ts
+++ b/packages/components/nodes/tools/CambAI/CambTranslatedTTS.ts
@@ -1,0 +1,111 @@
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { cambPost, pollTask, getTTSResult } from './core'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+class CambTranslatedTTSTool extends Tool {
+    name = 'camb_translated_tts'
+    description = 'Translate text and convert to speech in one step using CAMB AI. Returns the file path to the generated audio.'
+    apiKey: string
+    sourceLanguage: number
+    targetLanguage: number
+    voiceId: number
+
+    constructor(apiKey: string, sourceLanguage: number, targetLanguage: number, voiceId: number) {
+        super()
+        this.apiKey = apiKey
+        this.sourceLanguage = sourceLanguage
+        this.targetLanguage = targetLanguage
+        this.voiceId = voiceId
+    }
+
+    async _call(input: string): Promise<string> {
+        const config = { apiKey: this.apiKey }
+        const body = {
+            text: input,
+            source_language: this.sourceLanguage,
+            target_language: this.targetLanguage,
+            voice_id: this.voiceId
+        }
+
+        const result = await cambPost('/translated-tts', config, body)
+        const taskId = result.task_id
+
+        const status = await pollTask(`/translated-tts/${taskId}`, config)
+        const runId = status.run_id
+
+        const audioBuffer = await getTTSResult(runId, config)
+        const tmpFile = path.join(os.tmpdir(), `camb_translated_tts_${Date.now()}.wav`)
+        fs.writeFileSync(tmpFile, audioBuffer)
+        return `Audio saved to: ${tmpFile}`
+    }
+}
+
+class CambTranslatedTTS_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI Translated TTS'
+        this.name = 'cambTranslatedTTS'
+        this.version = 1.0
+        this.type = 'CambTranslatedTTS'
+        this.icon = 'camb-ai.svg'
+        this.category = 'Tools'
+        this.description = 'Translate text and convert to speech in one step using CAMB AI'
+        this.baseClasses = [this.type, ...getBaseClasses(CambTranslatedTTSTool)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['cambAIApi']
+        }
+        this.inputs = [
+            {
+                label: 'Source Language',
+                name: 'sourceLanguage',
+                type: 'number',
+                default: 1,
+                description: 'Source language code (integer)'
+            },
+            {
+                label: 'Target Language',
+                name: 'targetLanguage',
+                type: 'number',
+                default: 2,
+                description: 'Target language code (integer)'
+            },
+            {
+                label: 'Voice ID',
+                name: 'voiceId',
+                type: 'number',
+                default: 147320,
+                description: 'Voice ID for TTS output',
+                optional: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('cambApiKey', credentialData, nodeData)
+        const sourceLanguage = parseInt((nodeData.inputs?.sourceLanguage as string) || '1', 10)
+        const targetLanguage = parseInt((nodeData.inputs?.targetLanguage as string) || '2', 10)
+        const voiceId = parseInt((nodeData.inputs?.voiceId as string) || '147320', 10)
+
+        return new CambTranslatedTTSTool(apiKey, sourceLanguage, targetLanguage, voiceId)
+    }
+}
+
+module.exports = { nodeClass: CambTranslatedTTS_Tools }

--- a/packages/components/nodes/tools/CambAI/CambVoiceClone.ts
+++ b/packages/components/nodes/tools/CambAI/CambVoiceClone.ts
@@ -1,0 +1,95 @@
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { cambFetch } from './core'
+import * as fs from 'fs'
+import * as path from 'path'
+
+class CambVoiceCloneTool extends Tool {
+    name = 'camb_voice_clone'
+    description = 'Clone a voice from an audio sample using CAMB AI. Input should be a JSON string with voice_name and audio_file_path fields.'
+    apiKey: string
+
+    constructor(apiKey: string) {
+        super()
+        this.apiKey = apiKey
+    }
+
+    async _call(input: string): Promise<string> {
+        let params: { voice_name: string; audio_file_path: string; gender?: number; age?: number }
+        try {
+            params = JSON.parse(input)
+        } catch {
+            return JSON.stringify({ error: 'Input must be JSON with voice_name and audio_file_path' })
+        }
+
+        const filePath = params.audio_file_path
+        if (!fs.existsSync(filePath)) {
+            return JSON.stringify({ error: `Audio file not found: ${filePath}` })
+        }
+
+        const fileBuffer = fs.readFileSync(filePath)
+        const fileName = path.basename(filePath)
+
+        const formData = new FormData()
+        formData.append('voice_name', params.voice_name)
+        formData.append('gender', String(params.gender || 0))
+        formData.append('age', String(params.age || 30))
+        formData.append('file', new Blob([fileBuffer]), fileName)
+
+        const res = await cambFetch('/create-custom-voice', { apiKey: this.apiKey }, {
+            method: 'POST',
+            body: formData
+        })
+
+        if (!res.ok) {
+            throw new Error(`CAMB AI Voice Clone error (${res.status}): ${await res.text()}`)
+        }
+
+        const result = await res.json()
+        return JSON.stringify({
+            voice_id: result.voice_id || result.id,
+            voice_name: params.voice_name,
+            status: 'created'
+        }, null, 2)
+    }
+}
+
+class CambVoiceClone_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI Voice Clone'
+        this.name = 'cambVoiceClone'
+        this.version = 1.0
+        this.type = 'CambVoiceClone'
+        this.icon = 'camb-ai.svg'
+        this.category = 'Tools'
+        this.description = 'Clone a voice from an audio sample using CAMB AI'
+        this.baseClasses = [this.type, ...getBaseClasses(CambVoiceCloneTool)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['cambAIApi']
+        }
+        this.inputs = []
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('cambApiKey', credentialData, nodeData)
+        return new CambVoiceCloneTool(apiKey)
+    }
+}
+
+module.exports = { nodeClass: CambVoiceClone_Tools }

--- a/packages/components/nodes/tools/CambAI/CambVoiceList.ts
+++ b/packages/components/nodes/tools/CambAI/CambVoiceList.ts
@@ -1,0 +1,71 @@
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { cambFetch } from './core'
+
+class CambVoiceListTool extends Tool {
+    name = 'camb_list_voices'
+    description = 'List all available voices from CAMB AI. Returns JSON array with voice IDs and names.'
+    apiKey: string
+
+    constructor(apiKey: string) {
+        super()
+        this.apiKey = apiKey
+    }
+
+    async _call(_input: string): Promise<string> {
+        const res = await cambFetch('/list-voices', { apiKey: this.apiKey })
+        if (!res.ok) {
+            throw new Error(`CAMB AI Voice List error (${res.status}): ${await res.text()}`)
+        }
+
+        const voices = await res.json()
+        const formatted = Array.isArray(voices)
+            ? voices.map((v: any) => ({
+                  id: v.id,
+                  voice_name: v.voice_name || v.name || 'Unknown'
+              }))
+            : voices
+
+        return JSON.stringify(formatted, null, 2)
+    }
+}
+
+class CambVoiceList_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'CAMB AI Voice List'
+        this.name = 'cambVoiceList'
+        this.version = 1.0
+        this.type = 'CambVoiceList'
+        this.icon = 'camb-ai.svg'
+        this.category = 'Tools'
+        this.description = 'List all available voices from CAMB AI'
+        this.baseClasses = [this.type, ...getBaseClasses(CambVoiceListTool)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['cambAIApi']
+        }
+        this.inputs = []
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('cambApiKey', credentialData, nodeData)
+        return new CambVoiceListTool(apiKey)
+    }
+}
+
+module.exports = { nodeClass: CambVoiceList_Tools }

--- a/packages/components/nodes/tools/CambAI/camb-ai.svg
+++ b/packages/components/nodes/tools/CambAI/camb-ai.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="16" fill="#6366f1"/>
+  <text x="50" y="58" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="22" fill="white">CAMB</text>
+</svg>

--- a/packages/components/nodes/tools/CambAI/core.ts
+++ b/packages/components/nodes/tools/CambAI/core.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared CAMB AI HTTP helpers for Flowise nodes.
+ * Uses raw HTTP to https://client.camb.ai/apis/ endpoints.
+ */
+
+const CAMB_BASE_URL = 'https://client.camb.ai/apis'
+
+export interface CambConfig {
+    apiKey: string
+    maxPollAttempts?: number
+    pollInterval?: number
+}
+
+/**
+ * Make an authenticated request to the CAMB AI API.
+ */
+export async function cambFetch(
+    path: string,
+    config: CambConfig,
+    options: RequestInit = {}
+): Promise<Response> {
+    const url = `${CAMB_BASE_URL}${path}`
+    const headers: Record<string, string> = {
+        'x-api-key': config.apiKey,
+        ...(options.headers as Record<string, string> || {})
+    }
+
+    const res = await fetch(url, {
+        ...options,
+        headers
+    })
+
+    return res
+}
+
+/**
+ * Make a JSON POST request to the CAMB AI API.
+ */
+export async function cambPost(
+    path: string,
+    config: CambConfig,
+    body: Record<string, any>
+): Promise<any> {
+    const res = await cambFetch(path, config, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    })
+
+    if (!res.ok) {
+        const errorText = await res.text()
+        throw new Error(`CAMB AI API error (${res.status}): ${errorText}`)
+    }
+
+    return res.json()
+}
+
+/**
+ * Make a multipart POST request to the CAMB AI API (for file uploads).
+ */
+export async function cambPostMultipart(
+    path: string,
+    config: CambConfig,
+    formData: FormData
+): Promise<any> {
+    const res = await cambFetch(path, config, {
+        method: 'POST',
+        body: formData
+    })
+
+    if (!res.ok) {
+        const errorText = await res.text()
+        throw new Error(`CAMB AI API error (${res.status}): ${errorText}`)
+    }
+
+    return res.json()
+}
+
+/**
+ * Poll a CAMB AI async task until completion.
+ */
+export async function pollTask(
+    statusPath: string,
+    config: CambConfig
+): Promise<any> {
+    const maxAttempts = config.maxPollAttempts || 60
+    const interval = config.pollInterval || 2000
+
+    for (let i = 0; i < maxAttempts; i++) {
+        const res = await cambFetch(statusPath, config)
+        if (!res.ok) {
+            throw new Error(`CAMB AI poll error (${res.status}): ${await res.text()}`)
+        }
+
+        const data = await res.json()
+        const status = data.status || data.message?.status
+
+        if (status === 'SUCCESS' || status === 'completed' || status === 'complete') {
+            return data
+        }
+        if (status === 'FAILED' || status === 'ERROR' || status === 'TIMEOUT' || status === 'PAYMENT_REQUIRED' || status === 'error' || status === 'failed') {
+            throw new Error(`CAMB AI task failed: ${data.exception_reason || data.error || 'Unknown error'}`)
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, interval))
+    }
+
+    throw new Error(`CAMB AI task timed out after ${maxAttempts * interval / 1000}s`)
+}
+
+/**
+ * Stream TTS audio from the CAMB AI API and return as Buffer.
+ */
+export async function streamTTS(
+    config: CambConfig,
+    body: Record<string, any>
+): Promise<Buffer> {
+    const res = await cambFetch('/tts-stream', config, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    })
+
+    if (!res.ok) {
+        throw new Error(`CAMB AI TTS error (${res.status}): ${await res.text()}`)
+    }
+
+    const arrayBuffer = await res.arrayBuffer()
+    return Buffer.from(arrayBuffer)
+}
+
+/**
+ * Get audio result for a completed TTS task.
+ */
+export async function getTTSResult(
+    runId: string,
+    config: CambConfig
+): Promise<Buffer> {
+    const res = await cambFetch(`/tts-result/${runId}`, config)
+    if (!res.ok) {
+        throw new Error(`CAMB AI TTS result error (${res.status}): ${await res.text()}`)
+    }
+    const arrayBuffer = await res.arrayBuffer()
+    return Buffer.from(arrayBuffer)
+}


### PR DESCRIPTION
## Summary
- Add 8 CAMB AI tool nodes: Translate, TTS, Transcribe, Translated TTS, Text-to-Sound, Audio Separation, Voice Clone, Voice List
- Add CAMB AI API credential with link to API key portal
- Add shared `core.ts` with authenticated fetch, JSON POST, multipart upload, task polling, and TTS streaming helpers

## New Files
- `packages/components/credentials/CambAIApi.credential.ts` — API key credential
- `packages/components/nodes/tools/CambAI/core.ts` — shared HTTP helpers
- `packages/components/nodes/tools/CambAI/Camb*.ts` — 8 tool node definitions
- `packages/components/nodes/tools/CambAI/camb-ai.svg` — node icon