### PR TITLE
mini-feat: Store page sizes of views in local storage

### DIFF
--- a/packages/ui/src/views/agentexecutions/index.jsx
+++ b/packages/ui/src/views/agentexecutions/index.jsx
@@ -91,7 +91,7 @@ const AgentExecutions = () => {
 
     /* Table Pagination */
     const [currentPage, setCurrentPage] = useState(1)
-    const [pageLimit, setPageLimit] = useState(parseInt(localStorage.getItem('executionsPageSize') || DEFAULT_ITEMS_PER_PAGE))
+    const [pageLimit, setPageLimit] = useState(() => Number(localStorage.getItem('executionsPageSize') || DEFAULT_ITEMS_PER_PAGE))
     const [total, setTotal] = useState(0)
     const onChange = (page, pageLimit) => {
         setCurrentPage(page)

--- a/packages/ui/src/views/agentflows/index.jsx
+++ b/packages/ui/src/views/agentflows/index.jsx
@@ -45,19 +45,19 @@ const Agentflows = () => {
     const { error, setError } = useError()
 
     const getAllAgentflows = useApi(chatflowsApi.getAllAgentflows)
-    const [view, setView] = useState(localStorage.getItem('flowDisplayStyle') || 'card')
+    const [view, setView] = useState(localStorage.getItem('agentFlowDisplayStyle') || 'card')
     const [agentflowVersion, setAgentflowVersion] = useState(localStorage.getItem('agentFlowVersion') || 'v2')
     const [showDeprecationNotice, setShowDeprecationNotice] = useState(true)
 
     /* Table Pagination */
     const [currentPage, setCurrentPage] = useState(1)
-    const [pageLimit, setPageLimit] = useState(parseInt(localStorage.getItem('flowPageSize') || DEFAULT_ITEMS_PER_PAGE))
+    const [pageLimit, setPageLimit] = useState(() => Number(localStorage.getItem('agentFlowPageSize') || DEFAULT_ITEMS_PER_PAGE))
     const [total, setTotal] = useState(0)
 
     const onChange = (page, pageLimit) => {
         setCurrentPage(page)
         setPageLimit(pageLimit)
-        localStorage.setItem('flowPageSize', pageLimit)
+        localStorage.setItem('agentFlowPageSize', pageLimit)
         refresh(page, pageLimit, agentflowVersion)
     }
 
@@ -71,7 +71,7 @@ const Agentflows = () => {
 
     const handleChange = (event, nextView) => {
         if (nextView === null) return
-        localStorage.setItem('flowDisplayStyle', nextView)
+        localStorage.setItem('agentFlowDisplayStyle', nextView)
         setView(nextView)
     }
 

--- a/packages/ui/src/views/chatflows/index.jsx
+++ b/packages/ui/src/views/chatflows/index.jsx
@@ -42,11 +42,11 @@ const Chatflows = () => {
     const { error, setError } = useError()
 
     const getAllChatflowsApi = useApi(chatflowsApi.getAllChatflows)
-    const [view, setView] = useState(localStorage.getItem('flowDisplayStyle') || 'card')
+    const [view, setView] = useState(localStorage.getItem('chatFlowDisplayStyle') || 'card')
 
     /* Table Pagination */
     const [currentPage, setCurrentPage] = useState(1)
-    const [pageLimit, setPageLimit] = useState(parseInt(localStorage.getItem('chatFlowPageSize') || DEFAULT_ITEMS_PER_PAGE))
+    const [pageLimit, setPageLimit] = useState(() => Number(localStorage.getItem('chatFlowPageSize') || DEFAULT_ITEMS_PER_PAGE))
     const [total, setTotal] = useState(0)
 
     const onChange = (page, pageLimit) => {
@@ -66,7 +66,7 @@ const Chatflows = () => {
 
     const handleChange = (event, nextView) => {
         if (nextView === null) return
-        localStorage.setItem('flowDisplayStyle', nextView)
+        localStorage.setItem('chatFlowDisplayStyle', nextView)
         setView(nextView)
     }
 

--- a/packages/ui/src/views/docstore/index.jsx
+++ b/packages/ui/src/views/docstore/index.jsx
@@ -88,7 +88,7 @@ const Documents = () => {
 
     /* Table Pagination */
     const [currentPage, setCurrentPage] = useState(1)
-    const [pageLimit, setPageLimit] = useState(parseInt(localStorage.getItem('docStorePageSize') || DEFAULT_ITEMS_PER_PAGE))
+    const [pageLimit, setPageLimit] = useState(() => Number(localStorage.getItem('docStorePageSize') || DEFAULT_ITEMS_PER_PAGE))
     const [total, setTotal] = useState(0)
     const onChange = (page, pageLimit) => {
         setCurrentPage(page)


### PR DESCRIPTION
## Summary

Stores page sizes of chatflow, agentflow, agent executions and doc store views in local storage so one doesn't have to do that manually every time.