### PR TITLE
feat:Add support for binary file uploads in chatflow and agentflow execution

### DIFF
--- a/packages/components/nodes/utilities/CustomFunction/CustomFunction.ts
+++ b/packages/components/nodes/utilities/CustomFunction/CustomFunction.ts
@@ -88,6 +88,7 @@ class CustomFunction_Utilities implements INode {
             chatflowId: options.chatflowid,
             sessionId: options.sessionId,
             chatId: options.chatId,
+            file_attachment_bin: options.fileAttachmentBin || '',
             rawOutput: options.postProcessing?.rawOutput || '',
             chatHistory: options.postProcessing?.chatHistory || [],
             sourceDocuments: options.postProcessing?.sourceDocuments,

--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -397,6 +397,7 @@ export interface IExecuteFlowParams extends IPredictionQueueAppServer {
     files?: Express.Multer.File[]
     fileUploads?: IFileUpload[]
     uploadedFilesContent?: string
+    uploadedFilesBinaryContent?: string
     isUpsert?: boolean
     isRecursive?: boolean
     parentExecutionId?: string

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -35,6 +35,7 @@ import {
     RUNTIME_MESSAGES_LENGTH_VAR_PREFIX,
     CHAT_HISTORY_VAR_PREFIX,
     databaseEntities,
+    FILE_ATTACHMENT_BIN_PREFIX,
     FILE_ATTACHMENT_PREFIX,
     getAppVersion,
     getGlobalVariable,
@@ -124,6 +125,7 @@ interface IExecuteNodeParams {
     nodeOverrides?: INodeOverrides
     variableOverrides?: IVariableOverride[]
     uploadedFilesContent?: string
+    uploadedFilesBinaryContent?: string
     fileUploads?: IFileUpload[]
     humanInput?: IHumanInput
     agentFlowExecutedData?: IAgentflowExecutedData[]
@@ -220,6 +222,7 @@ export const resolveVariables = async (
     availableVariables: Variable[],
     variableOverrides: IVariableOverride[],
     uploadedFilesContent: string,
+    uploadedFilesBinaryContent: string,
     chatHistory: IMessage[],
     componentNodes: IComponentNodes,
     agentFlowExecutedData?: IAgentflowExecutedData[],
@@ -281,6 +284,10 @@ export const resolveVariables = async (
 
             if (variableFullPath === FILE_ATTACHMENT_PREFIX) {
                 resolvedValue = resolvedValue.replace(match, uploadedFilesContent)
+            }
+
+            if (variableFullPath === FILE_ATTACHMENT_BIN_PREFIX) {
+                resolvedValue = resolvedValue.replace(match, uploadedFilesBinaryContent)
             }
 
             if (variableFullPath === CHAT_HISTORY_VAR_PREFIX) {
@@ -1024,6 +1031,7 @@ const executeNode = async ({
     nodeOverrides = {},
     variableOverrides = [],
     uploadedFilesContent = '',
+    uploadedFilesBinaryContent = '',
     fileUploads,
     humanInput,
     agentFlowExecutedData = [],
@@ -1110,6 +1118,7 @@ const executeNode = async ({
             availableVariables,
             variableOverrides,
             uploadedFilesContent,
+            uploadedFilesBinaryContent,
             chatHistory,
             componentNodes,
             agentFlowExecutedData,
@@ -1255,6 +1264,7 @@ const executeNode = async ({
                             baseURL,
                             isInternal,
                             uploadedFilesContent,
+                            uploadedFilesBinaryContent,
                             fileUploads,
                             signal: abortController,
                             isRecursive: true,
@@ -1485,6 +1495,7 @@ export const executeAgentFlow = async ({
     baseURL,
     isInternal,
     uploadedFilesContent,
+    uploadedFilesBinaryContent,
     fileUploads,
     signal: abortController,
     isRecursive = false,
@@ -1956,6 +1967,7 @@ export const executeAgentFlow = async ({
                 nodeOverrides,
                 variableOverrides,
                 uploadedFilesContent,
+                uploadedFilesBinaryContent,
                 fileUploads,
                 humanInput: currentHumanInput,
                 agentFlowExecutedData,

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -148,6 +148,7 @@ const initEndingNode = async ({
     incomingInput,
     flowConfig,
     uploadedFilesContent,
+    uploadedFilesBinaryContent,
     availableVariables,
     apiOverrideStatus,
     nodeOverrides,
@@ -159,6 +160,7 @@ const initEndingNode = async ({
     incomingInput: IncomingInput
     flowConfig: IFlowConfig
     uploadedFilesContent: string
+    uploadedFilesBinaryContent: string
     availableVariables: IVariable[]
     apiOverrideStatus: boolean
     nodeOverrides: INodeOverrides
@@ -189,7 +191,8 @@ const initEndingNode = async ({
         flowConfig,
         uploadedFilesContent,
         availableVariables,
-        variableOverrides
+        variableOverrides,
+        uploadedFilesBinaryContent
     )
 
     logger.debug(`[server]: Running ${reactFlowNodeData.label} (${reactFlowNodeData.id})`)
@@ -624,6 +627,7 @@ export const executeFlow = async ({
         componentNodes,
         question,
         uploadedFilesContent,
+        uploadedFilesBinaryContent,
         chatHistory,
         chatId,
         sessionId,
@@ -800,6 +804,7 @@ export const executeFlow = async ({
             incomingInput,
             flowConfig,
             uploadedFilesContent,
+            uploadedFilesBinaryContent,
             availableVariables,
             apiOverrideStatus,
             nodeOverrides,
@@ -823,6 +828,7 @@ export const executeFlow = async ({
             usageCacheManager,
             analytic: chatflow.analytic,
             uploads,
+            fileAttachmentBin: uploadedFilesBinaryContent,
             prependMessages,
             ...(isStreamValid && { sseStreamer, shouldStreamResponse: isStreamValid }),
             evaluationRunId,
@@ -873,6 +879,7 @@ export const executeFlow = async ({
                         sessionId,
                         chatId,
                         input: question,
+                        fileAttachmentBin: uploadedFilesBinaryContent,
                         postProcessing: {
                             rawOutput: resultText,
                             chatHistory: cloneDeep(chatHistory),

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -506,6 +506,7 @@ type BuildFlowParams = {
     subscriptionId?: string
     usageCacheManager?: any
     uploadedFilesContent?: string
+    uploadedFilesBinaryContent?: string
     updateStorageUsage?: (orgId: string, workspaceId: string, totalSize: number, usageCacheManager?: any) => void
     checkStorage?: (orgId: string, subscriptionId: string, usageCacheManager: any) => Promise<any>
 }
@@ -523,6 +524,7 @@ export const buildFlow = async ({
     componentNodes,
     question,
     uploadedFilesContent,
+    uploadedFilesBinaryContent,
     chatHistory,
     apiMessageId,
     chatId,
@@ -572,6 +574,7 @@ export const buildFlow = async ({
         chatId,
         sessionId,
         chatHistory,
+        file_attachment_bin: uploadedFilesBinaryContent,
         ...overrideConfig
     }
     while (nodeQueue.length) {
@@ -603,7 +606,8 @@ export const buildFlow = async ({
                 flowData,
                 uploadedFilesContent,
                 availableVariables,
-                variableOverrides
+                variableOverrides,
+                uploadedFilesBinaryContent
             )
 
             if (isUpsert && stopNodeId && nodeId === stopNodeId) {
@@ -654,6 +658,7 @@ export const buildFlow = async ({
                     isUpsert,
                     dynamicVariables,
                     uploads,
+                    fileAttachmentBin: uploadedFilesBinaryContent,
                     baseURL,
                     componentNodes,
                     updateStorageUsage,
@@ -879,6 +884,7 @@ export const getVariableValue = async (
     isAcceptVariable = false,
     flowConfig?: ICommonObject,
     uploadedFilesContent?: string,
+    uploadedFilesBinaryContent?: string,
     availableVariables: IVariable[] = [],
     variableOverrides: ICommonObject[] = []
 ) => {
@@ -915,6 +921,10 @@ export const getVariableValue = async (
 
             if (isAcceptVariable && variableFullPath === FILE_ATTACHMENT_PREFIX) {
                 variableDict[`{{${variableFullPath}}}`] = handleEscapeCharacters(uploadedFilesContent, false)
+            }
+
+            if (isAcceptVariable && variableFullPath === FILE_ATTACHMENT_BIN_PREFIX) {
+                variableDict[`{{${variableFullPath}}}`] = handleEscapeCharacters(uploadedFilesBinaryContent, false)
             }
 
             if (isAcceptVariable && variableFullPath === CHAT_HISTORY_VAR_PREFIX) {
@@ -1032,7 +1042,8 @@ export const resolveVariables = async (
     flowConfig?: ICommonObject,
     uploadedFilesContent?: string,
     availableVariables: IVariable[] = [],
-    variableOverrides: ICommonObject[] = []
+    variableOverrides: ICommonObject[] = [],
+    uploadedFilesBinaryContent?: string
 ): Promise<INodeData> => {
     let flowNodeData = cloneDeep(reactFlowNodeData)
 
@@ -1050,6 +1061,7 @@ export const resolveVariables = async (
                         undefined,
                         flowConfig,
                         uploadedFilesContent,
+                        uploadedFilesBinaryContent,
                         availableVariables,
                         variableOverrides
                     )
@@ -1066,6 +1078,7 @@ export const resolveVariables = async (
                     isAcceptVariable,
                     flowConfig,
                     uploadedFilesContent,
+                    uploadedFilesBinaryContent,
                     availableVariables,
                     variableOverrides
                 )

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -67,6 +67,7 @@ import {
 
 export const QUESTION_VAR_PREFIX = 'question'
 export const FILE_ATTACHMENT_PREFIX = 'file_attachment'
+export const FILE_ATTACHMENT_BIN_PREFIX = 'file_attachment_bin'
 export const CHAT_HISTORY_VAR_PREFIX = 'chat_history'
 export const RUNTIME_MESSAGES_LENGTH_VAR_PREFIX = 'runtime_messages_length'
 export const LOOP_COUNT_VAR_PREFIX = 'loop_count'

--- a/packages/ui/src/ui-component/input/suggestionOption.js
+++ b/packages/ui/src/ui-component/input/suggestionOption.js
@@ -83,6 +83,12 @@ export const suggestionOptions = (
                 description: 'Files uploaded from the chat',
                 category: 'Chat Context'
             },
+            {
+                id: 'file_attachment_bin',
+                mentionLabel: 'file_attachment_bin',
+                description: 'Files uploaded from the chat as Base64 binary JSON',
+                category: 'Chat Context'
+            },
             { id: '$flow.sessionId', mentionLabel: '$flow.sessionId', description: 'Current session ID', category: 'Flow Variables' },
             { id: '$flow.chatId', mentionLabel: '$flow.chatId', description: 'Current chat ID', category: 'Flow Variables' },
             { id: '$flow.chatflowId', mentionLabel: '$flow.chatflowId', description: 'Current chatflow ID', category: 'Flow Variables' }

--- a/packages/ui/src/ui-component/json/SelectVariable.jsx
+++ b/packages/ui/src/ui-component/json/SelectVariable.jsx
@@ -159,6 +159,45 @@ const SelectVariable = ({ availableNodesForVariable, disabled = false, onSelectA
                                         />
                                     </ListItem>
                                 </ListItemButton>
+                                <ListItemButton
+                                    sx={{
+                                        p: 0,
+                                        borderRadius: `${customization.borderRadius}px`,
+                                        boxShadow: '0 2px 14px 0 rgb(32 40 45 / 8%)',
+                                        mb: 1
+                                    }}
+                                    disabled={disabled}
+                                    onClick={() => onSelectOutputResponseClick(null, 'file_attachment_bin')}
+                                >
+                                    <ListItem alignItems='center'>
+                                        <ListItemAvatar>
+                                            <div
+                                                style={{
+                                                    width: 50,
+                                                    height: 50,
+                                                    borderRadius: '50%',
+                                                    backgroundColor: 'white'
+                                                }}
+                                            >
+                                                <img
+                                                    style={{
+                                                        width: '100%',
+                                                        height: '100%',
+                                                        padding: 10,
+                                                        objectFit: 'contain'
+                                                    }}
+                                                    alt='fileAttachmentBinary'
+                                                    src={fileAttachmentPNG}
+                                                />
+                                            </div>
+                                        </ListItemAvatar>
+                                        <ListItemText
+                                            sx={{ ml: 1 }}
+                                            primary='file_attachment_bin'
+                                            secondary={`Files uploaded from the chat as Base64 binary JSON`}
+                                        />
+                                    </ListItem>
+                                </ListItemButton>
                                 {availableNodesForVariable &&
                                     availableNodesForVariable.length > 0 &&
                                     availableNodesForVariable.map((node, index) => {


### PR DESCRIPTION
## Summary

This PR adds support for using binary file uploads in **Chatflow** and **Agentflow** execution.

With the new variable:

- `{{file_attachment_bin}}`

you can now access files uploaded via full file upload in **Base64 format**.

## What is now possible?

`{{file_attachment_bin}}` can be used in:

- **Agent prompts**
- **Tool inputs**

This enables passing uploaded file content directly into prompt logic or downstream tools that require Base64 input.

## Changes

- Added binary file attachment support for flow execution
- Exposed uploaded file content as `{{file_attachment_bin}}`
- Enabled usage in both:
  - Agent prompt templates
  - Tool input mappings

## Example Usage

Use the following variable where Base64 file content is needed:

- `{{file_attachment_bin}}`

## Notes

- This variable is intended for files uploaded through the full file upload flow
- The content is provided in Base64 format for easier interoperability with tools and APIs

## Screenshots

- Added screenshots showing usage in Agent Prompt
- Added screenshots showing usage in Tool Input

<img width="1278" height="928" alt="CleanShot 2026-02-24 at 21 05 21" src="https://github.com/user-attachments/assets/0d8a47c8-577f-46c0-9bc9-e8f4404bc19e" />

<img width="1279" height="931" alt="CleanShot 2026-02-24 at 21 05 36" src="https://github.com/user-attachments/assets/a6707568-fb2a-48c5-a6d9-64f1f3a800f5" />

<img width="777" height="337" alt="Code 2026-02-24 20 29 24" src="https://github.com/user-attachments/assets/09d941d9-5c7e-4ae9-a077-91f0dd59ea76" />
