### PR TITLE
fix: move onClick handlers from Avatar to ButtonBase for keyboard accessibility

### DIFF
--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -297,7 +297,7 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                 </Typography>
                                 {chatflow?.id && (
                                     <Available permission={savePermission}>
-                                        <ButtonBase title='Edit Name' sx={{ borderRadius: '50%' }}>
+                                        <ButtonBase title='Edit Name' sx={{ borderRadius: '50%' }} onClick={() => setEditingFlowName(true)}>
                                             <Avatar
                                                 variant='rounded'
                                                 sx={{
@@ -313,7 +313,6 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                                     }
                                                 }}
                                                 color='inherit'
-                                                onClick={() => setEditingFlowName(true)}
                                             >
                                                 <IconPencil stroke={1.5} size='1.3rem' />
                                             </Avatar>
@@ -389,7 +388,7 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                 </Stack>
                 <Box>
                     {chatflow?.id && (
-                        <ButtonBase title='API Endpoint' sx={{ borderRadius: '50%', mr: 2 }}>
+                        <ButtonBase title='API Endpoint' sx={{ borderRadius: '50%', mr: 2 }} onClick={onAPIDialogClick}>
                             <Avatar
                                 variant='rounded'
                                 sx={{
@@ -404,14 +403,13 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                     }
                                 }}
                                 color='inherit'
-                                onClick={onAPIDialogClick}
                             >
                                 <IconCode stroke={1.5} size='1.3rem' />
                             </Avatar>
                         </ButtonBase>
                     )}
                     <Available permission={savePermission}>
-                        <ButtonBase title={`Save ${title}`} sx={{ borderRadius: '50%', mr: 2 }}>
+                        <ButtonBase title={`Save ${title}`} sx={{ borderRadius: '50%', mr: 2 }} onClick={onSaveChatflowClick}>
                             <Avatar
                                 variant='rounded'
                                 sx={{
@@ -426,13 +424,12 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                     }
                                 }}
                                 color='inherit'
-                                onClick={onSaveChatflowClick}
                             >
                                 <IconDeviceFloppy stroke={1.5} size='1.3rem' />
                             </Avatar>
                         </ButtonBase>
                     </Available>
-                    <ButtonBase ref={settingsRef} title='Settings' sx={{ borderRadius: '50%' }}>
+                    <ButtonBase ref={settingsRef} title='Settings' sx={{ borderRadius: '50%' }} onClick={() => setSettingsOpen(!isSettingsOpen)}>
                         <Avatar
                             variant='rounded'
                             sx={{
@@ -446,7 +443,6 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                     color: theme.palette.canvasHeader.settingsLight
                                 }
                             }}
-                            onClick={() => setSettingsOpen(!isSettingsOpen)}
                         >
                             <IconSettings stroke={1.5} size='1.3rem' />
                         </Avatar>


### PR DESCRIPTION
## Description

Fixes #5819: Misplaced click event in chat flow window

This PR moves the onClick event handlers from the Avatar components to their parent ButtonBase components for 4 buttons in the canvas header:
- Edit Name
- API Endpoint
- Save
- Settings

## Problem

The click events were bound to the Avatar (which renders as a div), making these buttons non-functional when activated via keyboard (Enter or Space key). This is an accessibility issue that prevents keyboard-only users and screen reader users from interacting with these buttons.

## Solution

Move the onClick handler from the child Avatar element to the parent ButtonBase element, which is a proper button element that responds to keyboard interactions.

## Testing

1. Go to chat flows
2. Click add new chat flow, add a node
3. Focus the Save button using the keyboard (Tab)
4. Press Enter or Space
5. The click event should now trigger

## Accessibility

This fix is particularly important for keyboard-only users and screen reader users, as noted in the original issue report.