### PR TITLE
feat(sticky-note): enhance sticky note functionality with color picker and resizers

### DIFF
--- a/packages/ui/src/views/agentflowsv2/StickyNote.jsx
+++ b/packages/ui/src/views/agentflowsv2/StickyNote.jsx
@@ -1,19 +1,23 @@
 import PropTypes from 'prop-types'
-import { useRef, useContext, useState } from 'react'
+import { useRef, useContext, useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import { NodeToolbar } from 'reactflow'
+import { NodeToolbar, NodeResizer } from 'reactflow'
+import { IconCopy, IconTrash, IconPalette } from '@tabler/icons-react'
+import { SketchPicker } from 'react-color'
 
 // material-ui
 import { styled, useTheme, alpha, darken, lighten } from '@mui/material/styles'
+import { ButtonGroup, IconButton, Box, Popover } from '@mui/material'
 
 // project imports
-import { ButtonGroup, IconButton, Box } from '@mui/material'
-import { IconCopy, IconTrash } from '@tabler/icons-react'
 import { Input } from '@/ui-component/input/Input'
 import MainCard from '@/ui-component/cards/MainCard'
 
 // const
 import { flowContext } from '@/store/context/ReactFlowContext'
+
+const MIN_WIDTH = 240
+const MIN_HEIGHT = 65
 
 const CardWrapper = styled(MainCard)(({ theme }) => ({
     background: theme.palette.card.main,
@@ -41,9 +45,21 @@ const StickyNote = ({ data }) => {
     const { reactFlowInstance, deleteNode, duplicateNode } = useContext(flowContext)
     const [inputParam] = data.inputParams
     const [isHovered, setIsHovered] = useState(false)
+    const [openToolbar, setOpenToolbar] = useState(false)
+    const [colorPickerAnchor, setColorPickerAnchor] = useState(null)
+    const [width, setWidth] = useState(data.inputs.size?.width || MIN_WIDTH)
+    const [height, setHeight] = useState(data.inputs.size?.height || MIN_HEIGHT)
 
     const defaultColor = '#666666' // fallback color if data.color is not present
     const nodeColor = data.color || defaultColor
+
+    useEffect(() => {
+        if (data.selected) {
+            setOpenToolbar(true)
+        } else {
+            setOpenToolbar(false)
+        }
+    }, [data.selected])
 
     // Get different shades of the color based on state
     const getStateColor = () => {
@@ -59,73 +75,149 @@ const StickyNote = ({ data }) => {
         return isHovered ? lighten(nodeColor, 0.8) : lighten(nodeColor, 0.9)
     }
 
+    const handleSizeChange = (newWidth, newHeight) => {
+        setWidth(newWidth)
+        setHeight(newHeight)
+        data.inputs.size = { width: newWidth, height: newHeight }
+    }
+
+    const handleColorPickerOpen = (event) => {
+        setColorPickerAnchor(event.currentTarget)
+    }
+
+    const handleColorPickerClose = () => {
+        setColorPickerAnchor(null)
+    }
+
+    const handleColorChange = (color) => {
+        data.color = color.hex
+    }
+
+    const openColorPicker = Boolean(colorPickerAnchor)
+
     return (
-        <div ref={ref} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
-            <StyledNodeToolbar>
-                <ButtonGroup sx={{ gap: 1 }} variant='outlined' aria-label='Basic button group'>
-                    <IconButton
-                        size={'small'}
-                        title='Duplicate'
-                        onClick={() => {
-                            duplicateNode(data.id)
-                        }}
+        <>
+            <NodeResizer
+                color='transparent'
+                isVisible={true}
+                minWidth={MIN_WIDTH}
+                minHeight={MIN_HEIGHT}
+                onResize={(_event, direction) => {
+                    setWidth(direction.width)
+                    setHeight(direction.height)
+                }}
+                onResizeEnd={(_event, direction) => {
+                    handleSizeChange(direction.width, direction.height)
+                }}
+            />
+            <div ref={ref} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+                <StyledNodeToolbar isVisible={openToolbar || openColorPicker}>
+                    <ButtonGroup sx={{ gap: 1 }} variant='outlined' aria-label='Basic button group'>
+                        <IconButton
+                            size={'small'}
+                            title='Change Color'
+                            onClick={handleColorPickerOpen}
+                            sx={{
+                                color: customization.isDarkMode ? 'white' : 'inherit',
+                                '&:hover': {
+                                    color: theme.palette.primary.main
+                                }
+                            }}
+                        >
+                            <IconPalette size={20} />
+                        </IconButton>
+                        <IconButton
+                            size={'small'}
+                            title='Duplicate'
+                            onClick={() => {
+                                duplicateNode(data.id)
+                            }}
+                            sx={{
+                                color: customization.isDarkMode ? 'white' : 'inherit',
+                                '&:hover': {
+                                    color: theme.palette.primary.main
+                                }
+                            }}
+                        >
+                            <IconCopy size={20} />
+                        </IconButton>
+                        <IconButton
+                            size={'small'}
+                            title='Delete'
+                            onClick={() => {
+                                deleteNode(data.id)
+                            }}
+                            sx={{
+                                color: customization.isDarkMode ? 'white' : 'inherit',
+                                '&:hover': {
+                                    color: theme.palette.error.main
+                                }
+                            }}
+                        >
+                            <IconTrash size={20} />
+                        </IconButton>
+                    </ButtonGroup>
+                </StyledNodeToolbar>
+                <CardWrapper
+                    content={false}
+                    sx={{
+                        borderColor: getStateColor(),
+                        borderWidth: '1px',
+                        boxShadow: data.selected ? `0 0 0 1px ${getStateColor()} !important` : 'none',
+                        width: width,
+                        height: height,
+                        backgroundColor: getBackgroundColor(),
+                        overflow: 'hidden',
+                        '&:hover': {
+                            boxShadow: data.selected ? `0 0 0 1px ${getStateColor()} !important` : 'none'
+                        }
+                    }}
+                    border={false}
+                >
+                    <Box
                         sx={{
-                            color: customization.isDarkMode ? 'white' : 'inherit',
-                            '&:hover': {
-                                color: theme.palette.primary.main
-                            }
+                            width: '100%',
+                            height: '100%',
+                            overflowX: 'hidden',
+                            overflowY: 'auto'
                         }}
                     >
-                        <IconCopy size={20} />
-                    </IconButton>
-                    <IconButton
-                        size={'small'}
-                        title='Delete'
-                        onClick={() => {
-                            deleteNode(data.id)
-                        }}
-                        sx={{
-                            color: customization.isDarkMode ? 'white' : 'inherit',
-                            '&:hover': {
-                                color: theme.palette.error.main
-                            }
-                        }}
-                    >
-                        <IconTrash size={20} />
-                    </IconButton>
-                </ButtonGroup>
-            </StyledNodeToolbar>
-            <CardWrapper
-                content={false}
-                sx={{
-                    borderColor: getStateColor(),
-                    borderWidth: '1px',
-                    boxShadow: data.selected ? `0 0 0 1px ${getStateColor()} !important` : 'none',
-                    minHeight: 60,
-                    height: 'auto',
-                    backgroundColor: getBackgroundColor(),
-                    display: 'flex',
-                    alignItems: 'center',
-                    '&:hover': {
-                        boxShadow: data.selected ? `0 0 0 1px ${getStateColor()} !important` : 'none'
+                        <Input
+                            key={data.id}
+                            placeholder={inputParam.placeholder}
+                            inputParam={inputParam}
+                            onChange={(newValue) => (data.inputs[inputParam.name] = newValue)}
+                            value={data.inputs[inputParam.name] ?? inputParam.default ?? ''}
+                            nodes={reactFlowInstance ? reactFlowInstance.getNodes() : []}
+                            edges={reactFlowInstance ? reactFlowInstance.getEdges() : []}
+                            nodeId={data.id}
+                        />
+                    </Box>
+                </CardWrapper>
+            </div>
+            <Popover
+                open={openColorPicker}
+                anchorEl={colorPickerAnchor}
+                onClose={handleColorPickerClose}
+                anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right'
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left'
+                }}
+                slotProps={{
+                    paper: {
+                        sx: {
+                            marginLeft: '16px'
+                        }
                     }
                 }}
-                border={false}
             >
-                <Box>
-                    <Input
-                        key={data.id}
-                        placeholder={inputParam.placeholder}
-                        inputParam={inputParam}
-                        onChange={(newValue) => (data.inputs[inputParam.name] = newValue)}
-                        value={data.inputs[inputParam.name] ?? inputParam.default ?? ''}
-                        nodes={reactFlowInstance ? reactFlowInstance.getNodes() : []}
-                        edges={reactFlowInstance ? reactFlowInstance.getEdges() : []}
-                        nodeId={data.id}
-                    />
-                </Box>
-            </CardWrapper>
-        </div>
+                <SketchPicker color={nodeColor} onChange={handleColorChange} />
+            </Popover>
+        </>
     )
 }
 

--- a/packages/ui/src/views/canvas/StickyNote.jsx
+++ b/packages/ui/src/views/canvas/StickyNote.jsx
@@ -1,19 +1,24 @@
 import PropTypes from 'prop-types'
-import { useContext, useState, memo } from 'react'
+import { useContext, useState, memo, useRef } from 'react'
 import { useSelector } from 'react-redux'
+import { NodeResizer } from 'reactflow'
+import { IconCopy, IconTrash, IconPalette } from '@tabler/icons-react'
+import { SketchPicker } from 'react-color'
 
 // material-ui
-import { useTheme, darken, lighten } from '@mui/material/styles'
+import { useTheme, alpha, darken, lighten } from '@mui/material/styles'
+import { IconButton, Box, Popover } from '@mui/material'
 
 // project imports
 import NodeCardWrapper from '@/ui-component/cards/NodeCardWrapper'
 import NodeTooltip from '@/ui-component/tooltip/NodeTooltip'
-import { IconButton, Box } from '@mui/material'
-import { IconCopy, IconTrash } from '@tabler/icons-react'
 import { Input } from '@/ui-component/input/Input'
 
 // const
 import { flowContext } from '@/store/context/ReactFlowContext'
+
+const MIN_WIDTH = 240
+const MIN_HEIGHT = 50
 
 const StickyNote = ({ data }) => {
     const theme = useTheme()
@@ -23,6 +28,11 @@ const StickyNote = ({ data }) => {
     const [inputParam] = data.inputParams
 
     const [open, setOpen] = useState(false)
+    const [colorPickerAnchor, setColorPickerAnchor] = useState(null)
+    const contentRef = useRef(null)
+
+    const [width, setWidth] = useState(data.inputs.size?.width || MIN_WIDTH)
+    const [height, setHeight] = useState(data.inputs.size?.height || MIN_HEIGHT)
 
     const handleClose = () => {
         setOpen(false)
@@ -32,36 +42,71 @@ const StickyNote = ({ data }) => {
         setOpen(true)
     }
 
+    const handleColorPickerOpen = (event) => {
+        setColorPickerAnchor(event.currentTarget)
+    }
+
+    const handleColorPickerClose = () => {
+        setColorPickerAnchor(null)
+    }
+
+    const handleColorChange = (color) => {
+        data.color = color.hex
+    }
+
+    const openColorPicker = Boolean(colorPickerAnchor)
+
     const defaultColor = '#FFE770' // fallback color if data.color is not present
     const nodeColor = data.color || defaultColor
 
     const getBorderColor = () => {
-        if (data.selected) return theme.palette.primary.main
-        else if (customization?.isDarkMode) return theme.palette.grey[700]
-        else return theme.palette.grey[900] + 50
+        if (data.selected) return nodeColor
+        if (open) return alpha(nodeColor, 0.8)
+        return alpha(nodeColor, 0.5)
     }
 
     const getBackgroundColor = () => {
         if (customization?.isDarkMode) {
             return data.selected ? darken(nodeColor, 0.7) : darken(nodeColor, 0.8)
         } else {
-            return data.selected ? lighten(nodeColor, 0.1) : lighten(nodeColor, 0.2)
+            return data.selected ? lighten(nodeColor, 0.8) : lighten(nodeColor, 0.9)
         }
+    }
+
+    const handleSizeChange = (newWidth, newHeight) => {
+        setWidth(newWidth)
+        setHeight(newHeight)
+        data.inputs.size = { width: newWidth, height: newHeight }
     }
 
     return (
         <>
+            <NodeResizer
+                color='transparent'
+                isVisible={true}
+                minWidth={MIN_WIDTH}
+                minHeight={MIN_HEIGHT}
+                onResize={(_event, direction) => {
+                    setWidth(direction.width)
+                    setHeight(direction.height)
+                }}
+                onResizeEnd={(_event, direction) => {
+                    handleSizeChange(direction.width, direction.height)
+                }}
+            />
             <NodeCardWrapper
                 content={false}
                 sx={{
                     padding: 0,
                     borderColor: getBorderColor(),
-                    backgroundColor: getBackgroundColor()
+                    backgroundColor: getBackgroundColor(),
+                    height: height,
+                    width: width
                 }}
                 border={false}
             >
                 <NodeTooltip
-                    open={!canvas.canvasDialogShow && open}
+                    open={!canvas.canvasDialogShow && (open || openColorPicker)}
                     onClose={handleClose}
                     onOpen={handleOpen}
                     disableFocusListener={true}
@@ -73,6 +118,18 @@ const StickyNote = ({ data }) => {
                                 flexDirection: 'column'
                             }}
                         >
+                            <IconButton
+                                title='Change Color'
+                                onClick={handleColorPickerOpen}
+                                sx={{
+                                    height: '35px',
+                                    width: '35px',
+                                    color: customization?.isDarkMode ? 'white' : 'inherit',
+                                    '&:hover': { color: theme?.palette.primary.main }
+                                }}
+                            >
+                                <IconPalette />
+                            </IconButton>
                             <IconButton
                                 title='Duplicate'
                                 onClick={() => {
@@ -105,7 +162,15 @@ const StickyNote = ({ data }) => {
                     }
                     placement='right-start'
                 >
-                    <Box>
+                    <Box
+                        ref={contentRef}
+                        sx={{
+                            width: '100%',
+                            height: '100%',
+                            overflowX: 'hidden',
+                            overflowY: 'auto'
+                        }}
+                    >
                         <Input
                             key={data.id}
                             inputParam={inputParam}
@@ -118,6 +183,28 @@ const StickyNote = ({ data }) => {
                     </Box>
                 </NodeTooltip>
             </NodeCardWrapper>
+            <Popover
+                open={openColorPicker}
+                anchorEl={colorPickerAnchor}
+                onClose={handleColorPickerClose}
+                anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right'
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left'
+                }}
+                slotProps={{
+                    paper: {
+                        sx: {
+                            marginLeft: '16px'
+                        }
+                    }
+                }}
+            >
+                <SketchPicker color={nodeColor} onChange={handleColorChange} />
+            </Popover>
         </>
     )
 }


### PR DESCRIPTION
## Ticket:  
https://github.com/orgs/FlowiseAI/projects/2?pane=issue&itemId=121642647

## Summary
Improves the sticky note component in both Chatflow and Agentflow canvases with two major new features: free resizing via drag handles and a color picker for visual customization.

![sticky-note-short](https://github.com/user-attachments/assets/c122babb-173f-4bf5-9599-b6f1b13f8839)

## Demo Recording
Youtube: [Sticky Note Demo](https://youtu.be/hC6nJ_laC0E)