### PR TITLE
feat: improve Azure OpenAI support for latest models

### DIFF
--- a/packages/components/credentials/AzureOpenAIApi.credential.ts
+++ b/packages/components/credentials/AzureOpenAIApi.credential.ts
@@ -36,9 +36,9 @@ class AzureOpenAIApi implements INodeCredential {
                 label: 'Azure OpenAI Api Version',
                 name: 'azureOpenAIApiVersion',
                 type: 'string',
-                placeholder: '2023-06-01-preview',
+                placeholder: '2024-10-21',
                 description:
-                    'Description of Supported API Versions. Please refer <a target="_blank" href="https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#chat-completions">examples</a>'
+                    'Description of Supported API Versions. Please refer <a target="_blank" href="https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle">API version lifecycle</a>'
             }
         ]
     }

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -383,6 +383,30 @@
                     "output_cost": 4.4e-6
                 },
                 {
+                    "label": "o3",
+                    "name": "o3",
+                    "input_cost": 2e-6,
+                    "output_cost": 8e-6
+                },
+                {
+                    "label": "o3-pro",
+                    "name": "o3-pro",
+                    "input_cost": 2e-5,
+                    "output_cost": 8e-5
+                },
+                {
+                    "label": "o4-mini",
+                    "name": "o4-mini",
+                    "input_cost": 1.1e-6,
+                    "output_cost": 4.4e-6
+                },
+                {
+                    "label": "codex-mini",
+                    "name": "codex-mini",
+                    "input_cost": 1.5e-6,
+                    "output_cost": 6e-6
+                },
+                {
                     "label": "o1",
                     "name": "o1",
                     "input_cost": 0.000015,
@@ -453,6 +477,18 @@
                     "name": "gpt-4.1-mini",
                     "input_cost": 0.0000004,
                     "output_cost": 0.0000016
+                },
+                {
+                    "label": "gpt-4.1-nano",
+                    "name": "gpt-4.1-nano",
+                    "input_cost": 1e-7,
+                    "output_cost": 4e-7
+                },
+                {
+                    "label": "gpt-5-pro",
+                    "name": "gpt-5-pro",
+                    "input_cost": 2.1e-5,
+                    "output_cost": 1.68e-4
                 },
                 {
                     "label": "gpt-5-chat-latest",

--- a/packages/components/nodes/chatmodels/AzureChatOpenAI/AzureChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/AzureChatOpenAI/AzureChatOpenAI.ts
@@ -51,7 +51,8 @@ class AzureChatOpenAI_ChatModels implements INode {
                 label: 'Model Name',
                 name: 'modelName',
                 type: 'asyncOptions',
-                loadMethod: 'listModels'
+                loadMethod: 'listModels',
+                freeSolo: true
             },
             {
                 label: 'Temperature',
@@ -166,7 +167,7 @@ class AzureChatOpenAI_ChatModels implements INode {
             },
             {
                 label: 'Reasoning Effort',
-                description: 'Constrains effort on reasoning for reasoning models. Only applicable for o1 and o3 models.',
+                description: 'Constrains effort on reasoning for reasoning models. Applicable for o-series and gpt-5 models.',
                 name: 'reasoningEffort',
                 type: 'options',
                 options: [
@@ -273,7 +274,15 @@ class AzureChatOpenAI_ChatModels implements INode {
                 console.error('Error parsing base options', exception)
             }
         }
-        if (modelName.includes('o1') || modelName.includes('o3') || modelName.includes('gpt-5')) {
+        const isReasoningModel = (name: string): boolean => {
+            if (/^o[134]/.test(name)) return true
+            if (name === 'codex-mini') return true
+            if (name.includes('gpt-5') && name.includes('-chat')) return false
+            if (name.includes('gpt-5')) return true
+            return false
+        }
+
+        if (isReasoningModel(modelName)) {
             delete obj.temperature
             delete obj.stop
             const reasoning: OpenAIClient.Reasoning = {}

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -292,7 +292,15 @@ class ChatOpenAI_ChatModels implements INode {
         }
         if (strictToolCalling) obj.supportsStrictToolCalling = strictToolCalling
 
-        if (modelName.includes('o1') || modelName.includes('o3') || modelName.includes('gpt-5')) {
+        const isReasoningModel = (name: string): boolean => {
+            if (/^o[134]/.test(name)) return true
+            if (name === 'codex-mini') return true
+            if (name.includes('gpt-5') && name.includes('-chat')) return false
+            if (name.includes('gpt-5')) return true
+            return false
+        }
+
+        if (isReasoningModel(modelName)) {
             delete obj.temperature
             delete obj.stop
             const reasoning: OpenAIClient.Reasoning = {}
@@ -303,6 +311,11 @@ class ChatOpenAI_ChatModels implements INode {
                 reasoning.summary = reasoningSummary
             }
             obj.reasoning = reasoning
+
+            if (maxTokens) {
+                delete obj.maxTokens
+                obj.maxCompletionTokens = parseInt(maxTokens, 10)
+            }
         }
 
         let parsedBaseOptions: any | undefined = undefined


### PR DESCRIPTION
## Summary

Fixes #5888 — Improves Azure OpenAI support for the latest models with 4 surgical changes across 4 files (64 lines added, 6 removed).

- **Add 6 missing GA models** to `azureChatOpenAI` in `models.json`: o3, o3-pro, o4-mini, codex-mini, gpt-4.1-nano, gpt-5-pro
- **Fix reasoning model detection** to catch o4-mini and codex-mini, and exclude gpt-5-chat variants (non-reasoning)
- **Add `maxCompletionTokens` conversion** to ChatOpenAI.ts (was only in AzureChatOpenAI.ts — fixes #5804 for reasoning models)
- **Update API version placeholder** from deprecated `2023-06-01-preview` to current GA `2024-10-21`
- **Enable `freeSolo`** on Azure model name input so users can type custom deployment names

## Changes

| File | Change |
|------|--------|
| `packages/components/models.json` | Add 6 model entries with cost tracking |
| `packages/components/nodes/chatmodels/AzureChatOpenAI/AzureChatOpenAI.ts` | Fix reasoning detection, add freeSolo, update description |
| `packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts` | Fix reasoning detection, add missing maxCompletionTokens |
| `packages/components/credentials/AzureOpenAIApi.credential.ts` | Update placeholder + doc link |

## Reasoning Model Detection

Replaced simple `includes()` checks with a proper `isReasoningModel()` function:
```typescript
const isReasoningModel = (name: string): boolean => {
    if (/^o[134]/.test(name)) return true      // o1, o3, o3-mini, o3-pro, o4-mini
    if (name === 'codex-mini') return true       // fine-tuned o4-mini
    if (name.includes('gpt-5') && name.includes('-chat')) return false  // chat variants
    if (name.includes('gpt-5')) return true       // gpt-5 reasoning models
    return false
}
```

## Test plan

- [ ] New models appear in Azure ChatOpenAI dropdown (o3, o3-pro, o4-mini, codex-mini, gpt-4.1-nano, gpt-5-pro)
- [ ] Custom model names can be typed in Azure ChatOpenAI model field (freeSolo)
- [ ] Credential placeholder shows `2024-10-21`
- [ ] o4-mini correctly detected as reasoning model (no temperature sent, maxCompletionTokens used)
- [ ] gpt-5-chat-latest NOT treated as reasoning model (temperature preserved)
- [ ] ChatOpenAI node correctly uses maxCompletionTokens for reasoning models

🤖 Generated with [Claude Code](https://claude.com/claude-code)