### PR TITLE
refactor: Extract loadNodesFromDir() from NodesPool for reuse

### DIFF
--- a/packages/server/src/NodesPool.ts
+++ b/packages/server/src/NodesPool.ts
@@ -24,11 +24,23 @@ export class NodesPool {
      * Initialize nodes
      */
     private async initializeNodes() {
-        const disabled_nodes = process.env.DISABLED_NODES ? process.env.DISABLED_NODES.split(',') : []
         const packagePath = getNodeModulesPackagePath('flowise-components')
         const nodesPath = path.join(packagePath, 'dist', 'nodes')
-        const nodeFiles = await this.getFiles(nodesPath)
-        return Promise.all(
+        const nodes = await this.loadNodesFromDir(nodesPath)
+        Object.assign(this.componentNodes, nodes)
+    }
+
+    /**
+     * Load and filter nodes from a directory.
+     * Applies DISABLED_NODES, skipCategories, and community node checks.
+     * Used internally for flowise-components nodes and externally by
+     * extension pools (e.g. EnterpriseNodesPool) to load additional nodes.
+     */
+    async loadNodesFromDir(dir: string): Promise<IComponentNodes> {
+        const disabled_nodes = process.env.DISABLED_NODES ? process.env.DISABLED_NODES.split(',') : []
+        const nodes: IComponentNodes = {}
+        const nodeFiles = await this.getFiles(dir)
+        await Promise.all(
             nodeFiles.map(async (file) => {
                 if (file.endsWith('.js')) {
                     try {
@@ -69,7 +81,7 @@ export class NodesPool {
                             const isDisabled = disabled_nodes.includes(newNodeInstance.name)
 
                             if (conditionOne && conditionTwo && !isDisabled) {
-                                this.componentNodes[newNodeInstance.name] = newNodeInstance
+                                nodes[newNodeInstance.name] = newNodeInstance
                             }
                         }
                     } catch (err) {
@@ -78,6 +90,7 @@ export class NodesPool {
                 }
             })
         )
+        return nodes
     }
 
     /**


### PR DESCRIPTION
## Summary
- Extract node-loading logic from `NodesPool.initializeNodes()` into a public `loadNodesFromDir(dir)` method
- Enables enterprise extensions to load nodes from additional directories without duplicating filtering logic (DISABLED_NODES, skipCategories, community nodes)
- Pure refactoring — no behavior change, no new dependencies

## Test plan
- [ ] `pnpm build` passes
- [ ] All existing nodes still load correctly on startup
- [ ] No behavior change for default usage