### PR TITLE
feat(workflow): add GitHub Actions workflow for publishing agentflow sdk

### DIFF
--- a/.github/workflows/publish-agentflow.yml
+++ b/.github/workflows/publish-agentflow.yml
@@ -37,6 +37,8 @@ jobs:
             - uses: actions/checkout@v4
 
             - uses: pnpm/action-setup@v2
+              with:
+                  version: 10.26.0
 
             - uses: actions/setup-node@v4
               with:
@@ -46,11 +48,13 @@ jobs:
             - name: Validate custom version
               if: inputs.bump == 'custom'
               run: |
-                  if [ -z "${{ inputs.custom_version }}" ]; then
+                  if [ -z "$CUSTOM_VERSION" ]; then
                     echo "::error::custom_version is required when bump is 'custom'"
                     exit 1
                   fi
-                  npx semver "${{ inputs.custom_version }}" || (echo "::error::Invalid semver: ${{ inputs.custom_version }}" && exit 1)
+                  npx semver "$CUSTOM_VERSION" || (echo "::error::Invalid semver: $CUSTOM_VERSION" && exit 1)
+              env:
+                  CUSTOM_VERSION: ${{ inputs.custom_version }}
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
@@ -59,11 +63,14 @@ jobs:
 
             - name: Set version
               run: |
-                  if [ "${{ inputs.bump }}" = "custom" ]; then
-                    pnpm --filter @flowiseai/agentflow exec npm version "${{ inputs.custom_version }}" --no-git-tag-version
+                  if [ "$BUMP" = "custom" ]; then
+                    pnpm --filter @flowiseai/agentflow exec npm version "$CUSTOM_VERSION" --no-git-tag-version
                   else
-                    pnpm --filter @flowiseai/agentflow exec npm version "${{ inputs.bump }}" --preid dev --no-git-tag-version
+                    pnpm --filter @flowiseai/agentflow exec npm version "$BUMP" --preid dev --no-git-tag-version
                   fi
+              env:
+                  BUMP: ${{ inputs.bump }}
+                  CUSTOM_VERSION: ${{ inputs.custom_version }}
 
             - name: Resolve version
               id: resolve-version
@@ -92,6 +99,8 @@ jobs:
             - uses: actions/checkout@v4
 
             - uses: pnpm/action-setup@v2
+              with:
+                  version: 10.26.0
 
             - uses: actions/setup-node@v4
               with:
@@ -105,11 +114,14 @@ jobs:
 
             - name: Set version
               run: |
-                  if [ "${{ inputs.bump }}" = "custom" ]; then
-                    pnpm --filter @flowiseai/agentflow exec npm version "${{ inputs.custom_version }}" --no-git-tag-version
+                  if [ "$BUMP" = "custom" ]; then
+                    pnpm --filter @flowiseai/agentflow exec npm version "$CUSTOM_VERSION" --no-git-tag-version
                   else
-                    pnpm --filter @flowiseai/agentflow exec npm version "${{ inputs.bump }}" --preid dev --no-git-tag-version
+                    pnpm --filter @flowiseai/agentflow exec npm version "$BUMP" --preid dev --no-git-tag-version
                   fi
+              env:
+                  BUMP: ${{ inputs.bump }}
+                  CUSTOM_VERSION: ${{ inputs.custom_version }}
 
             - name: Log version
               run: |


### PR DESCRIPTION
- Introduced a new workflow to handle version bumps and publishing of the @flowiseai/agentflow package.
- Supports various version bump types (prerelease, patch, minor, major, custom) and allows for custom version input.
- Includes a dry-run step to validate the version and simulate the publish process before actual deployment.
- Configured to use pnpm for dependency management and publishing tasks.

Workflow Flow
```
Trigger (manual dispatch)
        │
        ▼
┌───────────────┐
│   dry-run     │  1. Validates semver (custom bump only)
│               │  2. Installs deps, sets version via bump type
│               │  3. Resolves & logs version to job summary
│               │  4. Lists package contents (npm pack --dry-run)
│               │  5. Runs publish --dry-run
└───────┬───────┘
        │ (passes)
        ▼
┌───────────────┐
│   approval    │  Pauses here — requires manual approval via
│   gate        │  the "npm-publish" GitHub environment
└───────┬───────┘
        │ (approved)
        ▼
┌───────────────┐
│   publish     │  1. Installs deps, sets version
│               │  2. Publishes to npm with selected dist-tag
│               │  3. Creates a PR to bump package.json version
└───────┬───────┘
        │ (PR created)
        ▼
┌───────────────┐
│   version     │  Team member reviews and merges the
│   bump PR     │  auto-generated version bump PR
└───────────────┘
```

Inputs

| Input            | Required | Default      | Description                                              |
|------------------|----------|--------------|----------------------------------------------------------|
| `bump`           | Yes      | `prerelease` | Version bump type: `prerelease`, `patch`, `minor`, `major`, `custom` |
| `custom_version` | No       | —            | Exact semver version (only used when bump is `custom`)   |
| `tag`            | No       | `dev`        | npm dist-tag: `dev` or `latest`                          |