### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/docker-image-dockerhub.yml
+++ b/.github/workflows/docker-image-dockerhub.yml
@@ -27,7 +27,7 @@ jobs:
                   echo "tag_version=${{ github.event.inputs.tag_version || 'latest' }}" >> $GITHUB_OUTPUT
 
             - name: Checkout
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@v6.0.2
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v3.0.0

--- a/.github/workflows/docker-image-ecr.yml
+++ b/.github/workflows/docker-image-ecr.yml
@@ -40,7 +40,7 @@ jobs:
                   echo "tag_version=${{ github.event.inputs.tag_version || 'latest' }}" >> $GITHUB_OUTPUT
 
             - name: Checkout
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@v6.0.2
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v3.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,12 @@ jobs:
         env:
             PUPPETEER_SKIP_DOWNLOAD: true
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: pnpm/action-setup@v4
               with:
                   version: 10.26.0
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'pnpm'

--- a/.github/workflows/proprietary-path-guard.yml
+++ b/.github/workflows/proprietary-path-guard.yml
@@ -35,7 +35,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -15,5 +15,5 @@ jobs:
         env:
             PUPPETEER_SKIP_DOWNLOAD: true
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - run: docker build --no-cache -t flowise .


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4), [`v4.1.1`](https://github.com/actions/checkout/releases/tag/v4.1.1) | [`v6.0.2`](https://github.com/actions/checkout/releases/tag/v6.0.2) | [Release](https://github.com/actions/checkout/releases/tag/v6) | docker-image-dockerhub.yml, docker-image-ecr.yml, main.yml, proprietary-path-guard.yml, test_docker_build.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | main.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: June 2nd, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/checkout** (v4.1.1 → v6.0.2): Major version upgrade — review the [release notes](https://github.com/actions/checkout/releases) for breaking changes
- **actions/setup-node** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/setup-node/releases) for breaking changes
  - ⚠️ Input `always-auth` was **removed** — if your workflow uses it, the step may fail

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
