### PR TITLE
feat: add MiniMax chat model integration with M2.7 as default

### DIFF
--- a/packages/components/credentials/MiniMaxApi.credential.ts
+++ b/packages/components/credentials/MiniMaxApi.credential.ts
@@ -1,0 +1,23 @@
+import { INodeCredential, INodeParams } from '../src/Interface'
+
+class MiniMaxApi implements INodeCredential {
+    label: string
+    name: string
+    version: number
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'MiniMax API'
+        this.name = 'miniMaxApi'
+        this.version = 1.0
+        this.inputs = [
+            {
+                label: 'MiniMax API Key',
+                name: 'miniMaxApiKey',
+                type: 'password'
+            }
+        ]
+    }
+}
+
+module.exports = { credClass: MiniMaxApi }

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -7,28 +7,28 @@
                     "label": "anthropic.claude-opus-4-5-20251101-v1:0",
                     "name": "anthropic.claude-opus-4-5-20251101-v1:0",
                     "description": "Claude 4.5 Opus",
-                    "input_cost": 0.000005,
-                    "output_cost": 0.000025
+                    "input_cost": 5e-06,
+                    "output_cost": 2.5e-05
                 },
                 {
                     "label": "anthropic.claude-sonnet-4-5-20250929-v1:0",
                     "name": "anthropic.claude-sonnet-4-5-20250929-v1:0",
                     "description": "Claude 4.5 Sonnet",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "anthropic.claude-haiku-4-5-20251001-v1:0",
                     "name": "anthropic.claude-haiku-4-5-20251001-v1:0",
                     "description": "Claude 4.5 Haiku",
-                    "input_cost": 0.000001,
-                    "output_cost": 0.000005
+                    "input_cost": 1e-06,
+                    "output_cost": 5e-06
                 },
                 {
                     "label": "openai.gpt-oss-20b-1:0",
                     "name": "openai.gpt-oss-20b-1:0",
                     "description": "21B parameters model optimized for lower latency, local, and specialized use cases",
-                    "input_cost": 0.00007,
+                    "input_cost": 7e-05,
                     "output_cost": 0.0003
                 },
                 {
@@ -42,89 +42,89 @@
                     "label": "anthropic.claude-opus-4-1-20250805-v1:0",
                     "name": "anthropic.claude-opus-4-1-20250805-v1:0",
                     "description": "Claude 4.1 Opus",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "anthropic.claude-sonnet-4-20250514-v1:0",
                     "name": "anthropic.claude-sonnet-4-20250514-v1:0",
                     "description": "Claude 4 Sonnet",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "anthropic.claude-opus-4-20250514-v1:0",
                     "name": "anthropic.claude-opus-4-20250514-v1:0",
                     "description": "Claude 4 Opus",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "anthropic.claude-3-7-sonnet-20250219-v1:0",
                     "name": "anthropic.claude-3-7-sonnet-20250219-v1:0",
                     "description": "(20250219-v1:0) specific version of Claude Sonnet 3.7",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "anthropic.claude-3-5-haiku-20241022-v1:0",
                     "name": "anthropic.claude-3-5-haiku-20241022-v1:0",
                     "description": "(20241022-v1:0) specific version of Claude Haiku 3.5",
-                    "input_cost": 8e-7,
-                    "output_cost": 4e-6
+                    "input_cost": 8e-07,
+                    "output_cost": 4e-06
                 },
                 {
                     "label": "anthropic.claude-3.5-sonnet-20241022-v2:0",
                     "name": "anthropic.claude-3-5-sonnet-20241022-v2:0",
                     "description": "(20241022-v2:0) specific version of Claude Sonnet 3.5",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "anthropic.claude-3.5-sonnet-20240620-v1:0",
                     "name": "anthropic.claude-3.5-sonnet-20240620-v1:0",
                     "description": "(20240620-v1:0) specific version of Claude Sonnet 3.5",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "anthropic.claude-3-opus",
                     "name": "anthropic.claude-3-opus-20240229-v1:0",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "anthropic.claude-3-sonnet",
                     "name": "anthropic.claude-3-sonnet-20240229-v1:0",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "anthropic.claude-3-haiku",
                     "name": "anthropic.claude-3-haiku-20240307-v1:0",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 1.25e-6
+                    "input_cost": 2.5e-07,
+                    "output_cost": 1.25e-06
                 },
                 {
                     "label": "anthropic.claude-instant-v1",
                     "name": "anthropic.claude-instant-v1",
                     "description": "Text generation, conversation",
-                    "input_cost": 0.000008,
-                    "output_cost": 0.000024
+                    "input_cost": 8e-06,
+                    "output_cost": 2.4e-05
                 },
                 {
                     "label": "anthropic.claude-v2:1",
                     "name": "anthropic.claude-v2:1",
                     "description": "Text generation, conversation, complex reasoning and analysis",
-                    "input_cost": 0.000008,
-                    "output_cost": 0.000024
+                    "input_cost": 8e-06,
+                    "output_cost": 2.4e-05
                 },
                 {
                     "label": "anthropic.claude-v2",
                     "name": "anthropic.claude-v2",
                     "description": "Text generation, conversation, complex reasoning and analysis",
-                    "input_cost": 0.000008,
-                    "output_cost": 0.000024
+                    "input_cost": 8e-06,
+                    "output_cost": 2.4e-05
                 },
                 {
                     "label": "meta.llama2-13b-chat-v1",
@@ -325,140 +325,140 @@
                 {
                     "label": "gpt-5.2",
                     "name": "gpt-5.2",
-                    "input_cost": 0.00000175,
-                    "output_cost": 0.000014
+                    "input_cost": 1.75e-06,
+                    "output_cost": 1.4e-05
                 },
                 {
                     "label": "gpt-5.2-pro",
                     "name": "gpt-5.2-pro",
-                    "input_cost": 0.000021,
+                    "input_cost": 2.1e-05,
                     "output_cost": 0.000168
                 },
                 {
                     "label": "gpt-5.2-chat-latest",
                     "name": "gpt-5.2-chat-latest",
-                    "input_cost": 0.00000175,
-                    "output_cost": 0.000014
+                    "input_cost": 1.75e-06,
+                    "output_cost": 1.4e-05
                 },
                 {
                     "label": "gpt-5.2-codex",
                     "name": "gpt-5.2-codex",
-                    "input_cost": 0.00000175,
-                    "output_cost": 0.000014
+                    "input_cost": 1.75e-06,
+                    "output_cost": 1.4e-05
                 },
                 {
                     "label": "gpt-5.1",
                     "name": "gpt-5.1",
-                    "input_cost": 0.00000125,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-5",
                     "name": "gpt-5",
-                    "input_cost": 0.00000125,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-5-mini",
                     "name": "gpt-5-mini",
-                    "input_cost": 0.00000025,
-                    "output_cost": 0.000002
+                    "input_cost": 2.5e-07,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-5-nano",
                     "name": "gpt-5-nano",
-                    "input_cost": 0.00000005,
-                    "output_cost": 0.0000004
+                    "input_cost": 5e-08,
+                    "output_cost": 4e-07
                 },
                 {
                     "label": "gpt-4.1",
                     "name": "gpt-4.1",
-                    "input_cost": 2e-6,
-                    "output_cost": 8e-6
+                    "input_cost": 2e-06,
+                    "output_cost": 8e-06
                 },
                 {
                     "label": "o3-mini",
                     "name": "o3-mini",
-                    "input_cost": 1.1e-6,
-                    "output_cost": 4.4e-6
+                    "input_cost": 1.1e-06,
+                    "output_cost": 4.4e-06
                 },
                 {
                     "label": "o1",
                     "name": "o1",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.00006
+                    "input_cost": 1.5e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "o1-preview",
                     "name": "o1-preview",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.00006
+                    "input_cost": 1.5e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "o1-mini",
                     "name": "o1-mini",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000012
+                    "input_cost": 3e-06,
+                    "output_cost": 1.2e-05
                 },
                 {
                     "label": "gpt-4o-mini",
                     "name": "gpt-4o-mini",
-                    "input_cost": 1.5e-7,
-                    "output_cost": 6e-7
+                    "input_cost": 1.5e-07,
+                    "output_cost": 6e-07
                 },
                 {
                     "label": "gpt-4o",
                     "name": "gpt-4o",
-                    "input_cost": 2.5e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 2.5e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-4",
                     "name": "gpt-4",
-                    "input_cost": 0.00003,
-                    "output_cost": 0.00006
+                    "input_cost": 3e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "gpt-4-32k",
                     "name": "gpt-4-32k",
-                    "input_cost": 0.00006,
+                    "input_cost": 6e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gpt-35-turbo",
                     "name": "gpt-35-turbo",
-                    "input_cost": 1.5e-6,
-                    "output_cost": 2e-6
+                    "input_cost": 1.5e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-35-turbo-16k",
                     "name": "gpt-35-turbo-16k",
-                    "input_cost": 3e-6,
-                    "output_cost": 4e-6
+                    "input_cost": 3e-06,
+                    "output_cost": 4e-06
                 },
                 {
                     "label": "gpt-4-vision-preview",
                     "name": "gpt-4-vision-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4.5-preview",
                     "name": "gpt-4.5-preview",
-                    "input_cost": 0.000075,
+                    "input_cost": 7.5e-05,
                     "output_cost": 0.00015
                 },
                 {
                     "label": "gpt-4.1-mini",
                     "name": "gpt-4.1-mini",
-                    "input_cost": 0.0000004,
-                    "output_cost": 0.0000016
+                    "input_cost": 4e-07,
+                    "output_cost": 1.6e-06
                 },
                 {
                     "label": "gpt-5-chat-latest",
                     "name": "gpt-5-chat-latest",
-                    "input_cost": 0.00000125,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 }
             ]
         },
@@ -468,68 +468,68 @@
                 {
                     "label": "gpt-4o-mini",
                     "name": "gpt-4o-mini",
-                    "input_cost": 1.5e-7,
-                    "output_cost": 6e-7
+                    "input_cost": 1.5e-07,
+                    "output_cost": 6e-07
                 },
                 {
                     "label": "gpt-4o",
                     "name": "gpt-4o",
-                    "input_cost": 2.5e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 2.5e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-4",
                     "name": "gpt-4",
-                    "input_cost": 0.00003,
-                    "output_cost": 0.00006
+                    "input_cost": 3e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "gpt-4-turbo",
                     "name": "gpt-4-turbo",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-32k",
                     "name": "gpt-4-32k",
-                    "input_cost": 0.00006,
+                    "input_cost": 6e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gpt-35-turbo",
                     "name": "gpt-35-turbo",
-                    "input_cost": 1.5e-6,
-                    "output_cost": 2e-6
+                    "input_cost": 1.5e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-35-turbo-16k",
                     "name": "gpt-35-turbo-16k",
-                    "input_cost": 5e-7,
-                    "output_cost": 0.0000015
+                    "input_cost": 5e-07,
+                    "output_cost": 1.5e-06
                 },
                 {
                     "label": "gpt-4-vision-preview",
                     "name": "gpt-4-vision-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-1106-preview",
                     "name": "gpt-4-1106-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4.1-mini",
                     "name": "gpt-4.1-mini",
-                    "input_cost": 0.0000004,
-                    "output_cost": 0.0000016
+                    "input_cost": 4e-07,
+                    "output_cost": 1.6e-06
                 },
                 {
                     "label": "gpt-5-chat-latest",
                     "name": "gpt-5-chat-latest",
-                    "input_cost": 0.00000125,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 }
             ]
         },
@@ -540,85 +540,85 @@
                     "label": "claude-opus-4-5",
                     "name": "claude-opus-4-5",
                     "description": "Claude 4.5 Opus",
-                    "input_cost": 0.000005,
-                    "output_cost": 0.000025
+                    "input_cost": 5e-06,
+                    "output_cost": 2.5e-05
                 },
                 {
                     "label": "claude-sonnet-4-5",
                     "name": "claude-sonnet-4-5",
                     "description": "Claude 4.5 Sonnet",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-haiku-4-5",
                     "name": "claude-haiku-4-5",
                     "description": "Claude 4.5 Haiku",
-                    "input_cost": 0.000001,
-                    "output_cost": 0.000005
+                    "input_cost": 1e-06,
+                    "output_cost": 5e-06
                 },
                 {
                     "label": "claude-sonnet-4-0",
                     "name": "claude-sonnet-4-0",
                     "description": "Claude 4 Sonnet",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-opus-4-1",
                     "name": "claude-opus-4-1",
                     "description": "Claude 4.1 Opus",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "claude-opus-4-0",
                     "name": "claude-opus-4-0",
                     "description": "Claude 4 Opus",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "claude-3-7-sonnet-latest",
                     "name": "claude-3-7-sonnet-latest",
                     "description": "Most recent snapshot version of Claude Sonnet 3.7",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-3-5-haiku-latest",
                     "name": "claude-3-5-haiku-latest",
                     "description": "Most recent snapshot version of Claude Haiku 3.5",
-                    "input_cost": 8e-7,
-                    "output_cost": 4e-6
+                    "input_cost": 8e-07,
+                    "output_cost": 4e-06
                 },
                 {
                     "label": "claude-3.5-sonnet-latest",
                     "name": "claude-3-5-sonnet-latest",
                     "description": "Most recent snapshot version of Claude Sonnet 3.5 model",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-3-opus",
                     "name": "claude-3-opus-20240229",
                     "description": "Powerful model for highly complex tasks, reasoning and analysis",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "claude-3-sonnet",
                     "name": "claude-3-sonnet-20240229",
                     "description": "Ideal balance of intelligence and speed for enterprise workloads",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-3-haiku",
                     "name": "claude-3-haiku-20240307",
                     "description": "Fastest and most compact model, designed for near-instant responsiveness",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 1.25e-6
+                    "input_cost": 2.5e-07,
+                    "output_cost": 1.25e-06
                 }
             ]
         },
@@ -629,36 +629,36 @@
                     "label": "claude-3-haiku",
                     "name": "claude-3-haiku",
                     "description": "Fastest and most compact model, designed for near-instant responsiveness",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 1.25e-6
+                    "input_cost": 2.5e-07,
+                    "output_cost": 1.25e-06
                 },
                 {
                     "label": "claude-3-opus",
                     "name": "claude-3-opus",
                     "description": "Most powerful model for highly complex tasks",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "claude-3-sonnet",
                     "name": "claude-3-sonnet",
                     "description": "Ideal balance of intelligence and speed for enterprise workloads",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-2.1 (legacy)",
                     "name": "claude-2.1",
                     "description": "Claude 2 latest major version, automatically get updates to the model as they are released",
-                    "input_cost": 0.000008,
-                    "output_cost": 0.000024
+                    "input_cost": 8e-06,
+                    "output_cost": 2.4e-05
                 },
                 {
                     "label": "claude-instant-1.2 (legacy)",
                     "name": "claude-instant-1.2",
                     "description": "Claude Instant latest major version, automatically get updates to the model as they are released",
-                    "input_cost": 0.000008,
-                    "output_cost": 0.000024
+                    "input_cost": 8e-06,
+                    "output_cost": 2.4e-05
                 }
             ]
         },
@@ -668,74 +668,74 @@
                 {
                     "label": "gemini-3-pro-preview",
                     "name": "gemini-3-pro-preview",
-                    "input_cost": 0.00002,
+                    "input_cost": 2e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gemini-3-flash-preview",
                     "name": "gemini-3-flash-preview",
-                    "input_cost": 0.0000005,
-                    "output_cost": 0.000003
+                    "input_cost": 5e-07,
+                    "output_cost": 3e-06
                 },
                 {
                     "label": "gemini-3-pro-image-preview",
                     "name": "gemini-3-pro-image-preview",
-                    "input_cost": 0.00002,
+                    "input_cost": 2e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gemini-2.5-pro",
                     "name": "gemini-2.5-pro",
-                    "input_cost": 0.3e-6,
-                    "output_cost": 0.000025
+                    "input_cost": 3e-07,
+                    "output_cost": 2.5e-05
                 },
                 {
                     "label": "gemini-2.5-flash",
                     "name": "gemini-2.5-flash",
-                    "input_cost": 1.25e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gemini-2.5-flash-image",
                     "name": "gemini-2.5-flash-image",
-                    "input_cost": 1.25e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gemini-2.5-flash-lite",
                     "name": "gemini-2.5-flash-lite",
-                    "input_cost": 1e-7,
-                    "output_cost": 4e-7
+                    "input_cost": 1e-07,
+                    "output_cost": 4e-07
                 },
                 {
                     "label": "gemini-2.0-flash",
                     "name": "gemini-2.0-flash",
-                    "input_cost": 1e-7,
-                    "output_cost": 4e-7
+                    "input_cost": 1e-07,
+                    "output_cost": 4e-07
                 },
                 {
                     "label": "gemini-2.0-flash-lite",
                     "name": "gemini-2.0-flash-lite",
-                    "input_cost": 7.5e-8,
-                    "output_cost": 3e-7
+                    "input_cost": 7.5e-08,
+                    "output_cost": 3e-07
                 },
                 {
                     "label": "gemini-1.5-flash",
                     "name": "gemini-1.5-flash",
-                    "input_cost": 7.5e-8,
-                    "output_cost": 3e-7
+                    "input_cost": 7.5e-08,
+                    "output_cost": 3e-07
                 },
                 {
                     "label": "gemini-1.5-flash-8b",
                     "name": "gemini-1.5-flash-8b",
-                    "input_cost": 3.75e-8,
-                    "output_cost": 1.5e-7
+                    "input_cost": 3.75e-08,
+                    "output_cost": 1.5e-07
                 },
                 {
                     "label": "gemini-1.5-pro",
                     "name": "gemini-1.5-pro",
-                    "input_cost": 1.25e-6,
-                    "output_cost": 5e-6
+                    "input_cost": 1.25e-06,
+                    "output_cost": 5e-06
                 }
             ]
         },
@@ -756,210 +756,339 @@
                 {
                     "label": "gemini-3-pro-preview",
                     "name": "gemini-3-pro-preview",
-                    "input_cost": 0.00002,
+                    "input_cost": 2e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gemini-3-flash-preview",
                     "name": "gemini-3-flash-preview",
-                    "input_cost": 0.0000005,
-                    "output_cost": 0.000003
+                    "input_cost": 5e-07,
+                    "output_cost": 3e-06
                 },
                 {
                     "label": "gemini-2.5-pro",
                     "name": "gemini-2.5-pro",
-                    "input_cost": 0.3e-6,
-                    "output_cost": 0.000025
+                    "input_cost": 3e-07,
+                    "output_cost": 2.5e-05
                 },
                 {
                     "label": "gemini-2.5-flash",
                     "name": "gemini-2.5-flash",
-                    "input_cost": 1.25e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gemini-2.5-flash-lite",
                     "name": "gemini-2.5-flash-lite",
-                    "input_cost": 1e-7,
-                    "output_cost": 4e-7
+                    "input_cost": 1e-07,
+                    "output_cost": 4e-07
                 },
                 {
                     "label": "gemini-2.0-flash",
                     "name": "gemini-2.0-flash-001",
-                    "input_cost": 1e-7,
-                    "output_cost": 4e-7
+                    "input_cost": 1e-07,
+                    "output_cost": 4e-07
                 },
                 {
                     "label": "gemini-2.0-flash-lite",
                     "name": "gemini-2.0-flash-lite-001",
-                    "input_cost": 7.5e-8,
-                    "output_cost": 3e-7
+                    "input_cost": 7.5e-08,
+                    "output_cost": 3e-07
                 },
                 {
                     "label": "gemini-1.5-flash-002",
                     "name": "gemini-1.5-flash-002",
-                    "input_cost": 7.5e-8,
-                    "output_cost": 3e-7
+                    "input_cost": 7.5e-08,
+                    "output_cost": 3e-07
                 },
                 {
                     "label": "gemini-1.5-flash-001",
                     "name": "gemini-1.5-flash-001",
-                    "input_cost": 7.5e-8,
-                    "output_cost": 3e-7
+                    "input_cost": 7.5e-08,
+                    "output_cost": 3e-07
                 },
                 {
                     "label": "gemini-1.5-pro-002",
                     "name": "gemini-1.5-pro-002",
-                    "input_cost": 1.25e-6,
-                    "output_cost": 5e-6
+                    "input_cost": 1.25e-06,
+                    "output_cost": 5e-06
                 },
                 {
                     "label": "gemini-1.5-pro-001",
                     "name": "gemini-1.5-pro-001",
-                    "input_cost": 1.25e-6,
-                    "output_cost": 5e-6
+                    "input_cost": 1.25e-06,
+                    "output_cost": 5e-06
                 },
                 {
                     "label": "gemini-1.0-pro",
                     "name": "gemini-1.0-pro",
-                    "input_cost": 1.25e-7,
-                    "output_cost": 3.75e-7
+                    "input_cost": 1.25e-07,
+                    "output_cost": 3.75e-07
                 },
                 {
                     "label": "gemini-1.0-pro-vision",
                     "name": "gemini-1.0-pro-vision",
-                    "input_cost": 1.25e-7,
-                    "output_cost": 3.75e-7
+                    "input_cost": 1.25e-07,
+                    "output_cost": 3.75e-07
                 },
                 {
                     "label": "claude-opus-4-5@20251101",
                     "name": "claude-opus-4-5@20251101",
                     "description": "Claude 4.5 Opus",
-                    "input_cost": 0.000005,
-                    "output_cost": 0.000025
+                    "input_cost": 5e-06,
+                    "output_cost": 2.5e-05
                 },
                 {
                     "label": "claude-sonnet-4-5@20250929",
                     "name": "claude-sonnet-4-5@20250929",
                     "description": "Claude 4.5 Sonnet",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-haiku-4-5@20251001",
                     "name": "claude-haiku-4-5@20251001",
                     "description": "Claude 4.5 Haiku",
-                    "input_cost": 0.000001,
-                    "output_cost": 0.000005
+                    "input_cost": 1e-06,
+                    "output_cost": 5e-06
                 },
                 {
                     "label": "claude-opus-4-1@20250805",
                     "name": "claude-opus-4-1@20250805",
                     "description": "Claude 4.1 Opus",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "claude-sonnet-4@20250514",
                     "name": "claude-sonnet-4@20250514",
                     "description": "Claude 4 Sonnet",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-opus-4@20250514",
                     "name": "claude-opus-4@20250514",
                     "description": "Claude 4 Opus",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "claude-3-7-sonnet@20250219",
                     "name": "claude-3-7-sonnet@20250219",
                     "description": "(20250219-v1:0) specific version of Claude Sonnet 3.7",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-3-5-haiku@20241022",
                     "name": "claude-3-5-haiku@20241022",
                     "description": "(20241022-v1:0) specific version of Claude Haiku 3.5",
-                    "input_cost": 8e-7,
-                    "output_cost": 4e-6
+                    "input_cost": 8e-07,
+                    "output_cost": 4e-06
                 },
                 {
                     "label": "claude-3-5-sonnet-v2@20241022",
                     "name": "claude-3-5-sonnet-v2@20241022",
                     "description": "(20241022-v2:0) specific version of Claude Sonnet 3.5",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-3-opus@20240229",
                     "name": "claude-3-opus@20240229",
                     "description": "Powerful model for highly complex tasks, reasoning and analysis",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.000075
+                    "input_cost": 1.5e-05,
+                    "output_cost": 7.5e-05
                 },
                 {
                     "label": "claude-3-sonnet@20240229",
                     "name": "claude-3-sonnet@20240229",
                     "description": "Balance of intelligence and speed",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000015
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "claude-3-haiku@20240307",
                     "name": "claude-3-haiku@20240307",
                     "description": "Fastest and most compact model for near-instant responsiveness",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 1.25e-6
+                    "input_cost": 2.5e-07,
+                    "output_cost": 1.25e-06
                 }
             ],
             "regions": [
-                { "label": "global", "name": "global" },
-                { "label": "us-east1", "name": "us-east1" },
-                { "label": "us-east4", "name": "us-east4" },
-                { "label": "us-central1", "name": "us-central1" },
-                { "label": "us-west1", "name": "us-west1" },
-                { "label": "europe-west4", "name": "europe-west4" },
-                { "label": "europe-west1", "name": "europe-west1" },
-                { "label": "europe-west3", "name": "europe-west3" },
-                { "label": "europe-west2", "name": "europe-west2" },
-                { "label": "asia-east1", "name": "asia-east1" },
-                { "label": "asia-southeast1", "name": "asia-southeast1" },
-                { "label": "asia-northeast1", "name": "asia-northeast1" },
-                { "label": "asia-south1", "name": "asia-south1" },
-                { "label": "australia-southeast1", "name": "australia-southeast1" },
-                { "label": "southamerica-east1", "name": "southamerica-east1" },
-                { "label": "africa-south1", "name": "africa-south1" },
-                { "label": "asia-east2", "name": "asia-east2" },
-                { "label": "asia-northeast2", "name": "asia-northeast2" },
-                { "label": "asia-northeast3", "name": "asia-northeast3" },
-                { "label": "asia-south2", "name": "asia-south2" },
-                { "label": "asia-southeast2", "name": "asia-southeast2" },
-                { "label": "australia-southeast2", "name": "australia-southeast2" },
-                { "label": "europe-central2", "name": "europe-central2" },
-                { "label": "europe-north1", "name": "europe-north1" },
-                { "label": "europe-north2", "name": "europe-north2" },
-                { "label": "europe-southwest1", "name": "europe-southwest1" },
-                { "label": "europe-west10", "name": "europe-west10" },
-                { "label": "europe-west12", "name": "europe-west12" },
-                { "label": "europe-west6", "name": "europe-west6" },
-                { "label": "europe-west8", "name": "europe-west8" },
-                { "label": "europe-west9", "name": "europe-west9" },
-                { "label": "me-central1", "name": "me-central1" },
-                { "label": "me-central2", "name": "me-central2" },
-                { "label": "me-west1", "name": "me-west1" },
-                { "label": "northamerica-northeast1", "name": "northamerica-northeast1" },
-                { "label": "northamerica-northeast2", "name": "northamerica-northeast2" },
-                { "label": "northamerica-south1", "name": "northamerica-south1" },
-                { "label": "southamerica-west1", "name": "southamerica-west1" },
-                { "label": "us-east5", "name": "us-east5" },
-                { "label": "us-south1", "name": "us-south1" },
-                { "label": "us-west2", "name": "us-west2" },
-                { "label": "us-west3", "name": "us-west3" },
-                { "label": "us-west4", "name": "us-west4" }
+                {
+                    "label": "global",
+                    "name": "global"
+                },
+                {
+                    "label": "us-east1",
+                    "name": "us-east1"
+                },
+                {
+                    "label": "us-east4",
+                    "name": "us-east4"
+                },
+                {
+                    "label": "us-central1",
+                    "name": "us-central1"
+                },
+                {
+                    "label": "us-west1",
+                    "name": "us-west1"
+                },
+                {
+                    "label": "europe-west4",
+                    "name": "europe-west4"
+                },
+                {
+                    "label": "europe-west1",
+                    "name": "europe-west1"
+                },
+                {
+                    "label": "europe-west3",
+                    "name": "europe-west3"
+                },
+                {
+                    "label": "europe-west2",
+                    "name": "europe-west2"
+                },
+                {
+                    "label": "asia-east1",
+                    "name": "asia-east1"
+                },
+                {
+                    "label": "asia-southeast1",
+                    "name": "asia-southeast1"
+                },
+                {
+                    "label": "asia-northeast1",
+                    "name": "asia-northeast1"
+                },
+                {
+                    "label": "asia-south1",
+                    "name": "asia-south1"
+                },
+                {
+                    "label": "australia-southeast1",
+                    "name": "australia-southeast1"
+                },
+                {
+                    "label": "southamerica-east1",
+                    "name": "southamerica-east1"
+                },
+                {
+                    "label": "africa-south1",
+                    "name": "africa-south1"
+                },
+                {
+                    "label": "asia-east2",
+                    "name": "asia-east2"
+                },
+                {
+                    "label": "asia-northeast2",
+                    "name": "asia-northeast2"
+                },
+                {
+                    "label": "asia-northeast3",
+                    "name": "asia-northeast3"
+                },
+                {
+                    "label": "asia-south2",
+                    "name": "asia-south2"
+                },
+                {
+                    "label": "asia-southeast2",
+                    "name": "asia-southeast2"
+                },
+                {
+                    "label": "australia-southeast2",
+                    "name": "australia-southeast2"
+                },
+                {
+                    "label": "europe-central2",
+                    "name": "europe-central2"
+                },
+                {
+                    "label": "europe-north1",
+                    "name": "europe-north1"
+                },
+                {
+                    "label": "europe-north2",
+                    "name": "europe-north2"
+                },
+                {
+                    "label": "europe-southwest1",
+                    "name": "europe-southwest1"
+                },
+                {
+                    "label": "europe-west10",
+                    "name": "europe-west10"
+                },
+                {
+                    "label": "europe-west12",
+                    "name": "europe-west12"
+                },
+                {
+                    "label": "europe-west6",
+                    "name": "europe-west6"
+                },
+                {
+                    "label": "europe-west8",
+                    "name": "europe-west8"
+                },
+                {
+                    "label": "europe-west9",
+                    "name": "europe-west9"
+                },
+                {
+                    "label": "me-central1",
+                    "name": "me-central1"
+                },
+                {
+                    "label": "me-central2",
+                    "name": "me-central2"
+                },
+                {
+                    "label": "me-west1",
+                    "name": "me-west1"
+                },
+                {
+                    "label": "northamerica-northeast1",
+                    "name": "northamerica-northeast1"
+                },
+                {
+                    "label": "northamerica-northeast2",
+                    "name": "northamerica-northeast2"
+                },
+                {
+                    "label": "northamerica-south1",
+                    "name": "northamerica-south1"
+                },
+                {
+                    "label": "southamerica-west1",
+                    "name": "southamerica-west1"
+                },
+                {
+                    "label": "us-east5",
+                    "name": "us-east5"
+                },
+                {
+                    "label": "us-south1",
+                    "name": "us-south1"
+                },
+                {
+                    "label": "us-west2",
+                    "name": "us-west2"
+                },
+                {
+                    "label": "us-west3",
+                    "name": "us-west3"
+                },
+                {
+                    "label": "us-west4",
+                    "name": "us-west4"
+                }
             ]
         },
         {
@@ -1053,7 +1182,7 @@
                 {
                     "label": "command-a-03-2025",
                     "name": "command-a-03-2025",
-                    "description": "Command A – most performant; tool use, RAG, multilingual",
+                    "description": "Command A \u2013 most performant; tool use, RAG, multilingual",
                     "input_cost": 0.0025,
                     "output_cost": 0.01
                 },
@@ -1061,27 +1190,27 @@
                     "label": "command-r7b-12-2024",
                     "name": "command-r7b-12-2024",
                     "description": "Small, fast; RAG, tool use, agents",
-                    "input_cost": 0.000037,
+                    "input_cost": 3.7e-05,
                     "output_cost": 0.00015
                 },
                 {
                     "label": "command-a-reasoning-08-2025",
                     "name": "command-a-reasoning-08-2025",
-                    "description": "Command A Reasoning – nuanced problem-solving, agents",
+                    "description": "Command A Reasoning \u2013 nuanced problem-solving, agents",
                     "input_cost": 0.0025,
                     "output_cost": 0.01
                 },
                 {
                     "label": "command-r-08-2024",
                     "name": "command-r-08-2024",
-                    "description": "Command R – RAG, tool use, multilingual",
+                    "description": "Command R \u2013 RAG, tool use, multilingual",
                     "input_cost": 0.00015,
                     "output_cost": 0.0006
                 },
                 {
                     "label": "command-r-plus-08-2024",
                     "name": "command-r-plus-08-2024",
-                    "description": "Command R+ – complex RAG, multi-step tool use",
+                    "description": "Command R+ \u2013 complex RAG, multi-step tool use",
                     "input_cost": 0.0025,
                     "output_cost": 0.01
                 }
@@ -1140,248 +1269,248 @@
                 {
                     "label": "gpt-5.2",
                     "name": "gpt-5.2",
-                    "input_cost": 0.00000175,
-                    "output_cost": 0.000014
+                    "input_cost": 1.75e-06,
+                    "output_cost": 1.4e-05
                 },
                 {
                     "label": "gpt-5.2-pro",
                     "name": "gpt-5.2-pro",
-                    "input_cost": 0.000021,
+                    "input_cost": 2.1e-05,
                     "output_cost": 0.000168
                 },
                 {
                     "label": "gpt-5.2-chat-latest",
                     "name": "gpt-5.2-chat-latest",
-                    "input_cost": 0.00000175,
-                    "output_cost": 0.000014
+                    "input_cost": 1.75e-06,
+                    "output_cost": 1.4e-05
                 },
                 {
                     "label": "gpt-5.2-codex",
                     "name": "gpt-5.2-codex",
-                    "input_cost": 0.00000175,
-                    "output_cost": 0.000014
+                    "input_cost": 1.75e-06,
+                    "output_cost": 1.4e-05
                 },
                 {
                     "label": "gpt-5.1",
                     "name": "gpt-5.1",
-                    "input_cost": 0.00000125,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-5",
                     "name": "gpt-5",
-                    "input_cost": 0.00000125,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-5-mini",
                     "name": "gpt-5-mini",
-                    "input_cost": 0.00000025,
-                    "output_cost": 0.000002
+                    "input_cost": 2.5e-07,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-5-nano",
                     "name": "gpt-5-nano",
-                    "input_cost": 0.00000005,
-                    "output_cost": 0.0000004
+                    "input_cost": 5e-08,
+                    "output_cost": 4e-07
                 },
                 {
                     "label": "gpt-4.1",
                     "name": "gpt-4.1",
-                    "input_cost": 2e-6,
-                    "output_cost": 8e-6
+                    "input_cost": 2e-06,
+                    "output_cost": 8e-06
                 },
                 {
                     "label": "gpt-4.1-mini",
                     "name": "gpt-4.1-mini",
-                    "input_cost": 4e-7,
-                    "output_cost": 1.6e-6
+                    "input_cost": 4e-07,
+                    "output_cost": 1.6e-06
                 },
                 {
                     "label": "gpt-4.1-nano",
                     "name": "gpt-4.1-nano",
-                    "input_cost": 1e-7,
-                    "output_cost": 4e-7
+                    "input_cost": 1e-07,
+                    "output_cost": 4e-07
                 },
                 {
                     "label": "gpt-4.5-preview",
                     "name": "gpt-4.5-preview",
-                    "input_cost": 0.000075,
+                    "input_cost": 7.5e-05,
                     "output_cost": 0.00015
                 },
                 {
                     "label": "gpt-4o-mini (latest)",
                     "name": "gpt-4o-mini",
-                    "input_cost": 1.5e-7,
-                    "output_cost": 6e-7
+                    "input_cost": 1.5e-07,
+                    "output_cost": 6e-07
                 },
                 {
                     "label": "gpt-4o-mini-2024-07-18",
                     "name": "gpt-4o-mini-2024-07-18",
-                    "input_cost": 1.5e-7,
-                    "output_cost": 6e-7
+                    "input_cost": 1.5e-07,
+                    "output_cost": 6e-07
                 },
                 {
                     "label": "gpt-4o (latest)",
                     "name": "gpt-4o",
-                    "input_cost": 2.5e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 2.5e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-4o-2024-11-20",
                     "name": "gpt-4o-2024-11-20",
-                    "input_cost": 2.5e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 2.5e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-4o-2024-08-06",
                     "name": "gpt-4o-2024-08-06",
-                    "input_cost": 2.5e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 2.5e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-4o-2024-05-13",
                     "name": "gpt-4o-2024-05-13",
-                    "input_cost": 2.5e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 2.5e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "o3-mini (latest)",
                     "name": "o3-mini",
-                    "input_cost": 1.1e-6,
-                    "output_cost": 4.4e-6
+                    "input_cost": 1.1e-06,
+                    "output_cost": 4.4e-06
                 },
                 {
                     "label": "o3-mini-2025-01-31",
                     "name": "o3-mini-2025-01-31",
-                    "input_cost": 1.1e-6,
-                    "output_cost": 4.4e-6
+                    "input_cost": 1.1e-06,
+                    "output_cost": 4.4e-06
                 },
                 {
                     "label": "o1-preview (latest)",
                     "name": "o1-preview",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.00006
+                    "input_cost": 1.5e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "o1-preview-2024-09-12",
                     "name": "o1-preview-2024-09-12",
-                    "input_cost": 0.000015,
-                    "output_cost": 0.00006
+                    "input_cost": 1.5e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "o1-mini (latest)",
                     "name": "o1-mini",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000012
+                    "input_cost": 3e-06,
+                    "output_cost": 1.2e-05
                 },
                 {
                     "label": "o1-mini-2024-09-12",
                     "name": "o1-mini-2024-09-12",
-                    "input_cost": 3e-6,
-                    "output_cost": 0.000012
+                    "input_cost": 3e-06,
+                    "output_cost": 1.2e-05
                 },
                 {
                     "label": "gpt-4 (latest)",
                     "name": "gpt-4",
-                    "input_cost": 0.00003,
-                    "output_cost": 0.00006
+                    "input_cost": 3e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "gpt-4-turbo (latest)",
                     "name": "gpt-4-turbo",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-turbo-preview",
                     "name": "gpt-4-turbo-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-0125-preview",
                     "name": "gpt-4-0125-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-1106-preview",
                     "name": "gpt-4-1106-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-1106-vision-preview",
                     "name": "gpt-4-1106-vision-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-vision-preview",
                     "name": "gpt-4-vision-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-0613",
                     "name": "gpt-4-0613",
-                    "input_cost": 0.00003,
-                    "output_cost": 0.00006
+                    "input_cost": 3e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "gpt-4-32k",
                     "name": "gpt-4-32k",
-                    "input_cost": 0.00006,
+                    "input_cost": 6e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gpt-4-32k-0613",
                     "name": "gpt-4-32k-0613",
-                    "input_cost": 0.00006,
+                    "input_cost": 6e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gpt-3.5-turbo",
                     "name": "gpt-3.5-turbo",
-                    "input_cost": 1.5e-6,
-                    "output_cost": 2e-6
+                    "input_cost": 1.5e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-0125",
                     "name": "gpt-3.5-turbo-0125",
-                    "input_cost": 5e-7,
-                    "output_cost": 0.0000015
+                    "input_cost": 5e-07,
+                    "output_cost": 1.5e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-1106",
                     "name": "gpt-3.5-turbo-1106",
-                    "input_cost": 0.000001,
-                    "output_cost": 0.000002
+                    "input_cost": 1e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-0613",
                     "name": "gpt-3.5-turbo-0613",
-                    "input_cost": 0.0000015,
-                    "output_cost": 0.000002
+                    "input_cost": 1.5e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-16k",
                     "name": "gpt-3.5-turbo-16k",
-                    "input_cost": 5e-7,
-                    "output_cost": 0.0000015
+                    "input_cost": 5e-07,
+                    "output_cost": 1.5e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-16k-0613",
                     "name": "gpt-3.5-turbo-16k-0613",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000004
+                    "input_cost": 3e-06,
+                    "output_cost": 4e-06
                 },
                 {
                     "label": "o4-mini",
                     "name": "o4-mini",
-                    "input_cost": 1.5e-7,
-                    "output_cost": 6e-7
+                    "input_cost": 1.5e-07,
+                    "output_cost": 6e-07
                 }
             ]
         },
@@ -1391,92 +1520,92 @@
                 {
                     "label": "gpt-4o",
                     "name": "gpt-4o",
-                    "input_cost": 2.5e-6,
-                    "output_cost": 0.00001
+                    "input_cost": 2.5e-06,
+                    "output_cost": 1e-05
                 },
                 {
                     "label": "gpt-4",
                     "name": "gpt-4",
-                    "input_cost": 0.00003,
-                    "output_cost": 0.00006
+                    "input_cost": 3e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "gpt-4-turbo",
                     "name": "gpt-4-turbo",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-turbo-preview",
                     "name": "gpt-4-turbo-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-0125-preview",
                     "name": "gpt-4-0125-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-1106-preview",
                     "name": "gpt-4-1106-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-vision-preview",
                     "name": "gpt-4-vision-preview",
-                    "input_cost": 0.00001,
-                    "output_cost": 0.00003
+                    "input_cost": 1e-05,
+                    "output_cost": 3e-05
                 },
                 {
                     "label": "gpt-4-0613",
                     "name": "gpt-4-0613",
-                    "input_cost": 0.00003,
-                    "output_cost": 0.00006
+                    "input_cost": 3e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "gpt-4-32k",
                     "name": "gpt-4-32k",
-                    "input_cost": 0.00006,
+                    "input_cost": 6e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gpt-4-32k-0613",
                     "name": "gpt-4-32k-0613",
-                    "input_cost": 0.00006,
+                    "input_cost": 6e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gpt-3.5-turbo",
                     "name": "gpt-3.5-turbo",
-                    "input_cost": 1.5e-6,
-                    "output_cost": 2e-6
+                    "input_cost": 1.5e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-1106",
                     "name": "gpt-3.5-turbo-1106",
-                    "input_cost": 0.000001,
-                    "output_cost": 0.000002
+                    "input_cost": 1e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-0613",
                     "name": "gpt-3.5-turbo-0613",
-                    "input_cost": 0.0000015,
-                    "output_cost": 0.000002
+                    "input_cost": 1.5e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-16k",
                     "name": "gpt-3.5-turbo-16k",
-                    "input_cost": 5e-7,
-                    "output_cost": 0.0000015
+                    "input_cost": 5e-07,
+                    "output_cost": 1.5e-06
                 },
                 {
                     "label": "gpt-3.5-turbo-16k-0613",
                     "name": "gpt-3.5-turbo-16k-0613",
-                    "input_cost": 0.000003,
-                    "output_cost": 0.000004
+                    "input_cost": 3e-06,
+                    "output_cost": 4e-06
                 }
             ]
         },
@@ -1486,38 +1615,38 @@
                 {
                     "label": "sonar",
                     "name": "sonar",
-                    "input_cost": 1e-6,
-                    "output_cost": 1e-6
+                    "input_cost": 1e-06,
+                    "output_cost": 1e-06
                 },
                 {
                     "label": "sonar-pro",
                     "name": "sonar-pro",
-                    "input_cost": 3e-6,
-                    "output_cost": 1.5e-5
+                    "input_cost": 3e-06,
+                    "output_cost": 1.5e-05
                 },
                 {
                     "label": "sonar-reasoning",
                     "name": "sonar-reasoning",
-                    "input_cost": 1e-6,
-                    "output_cost": 5e-6
+                    "input_cost": 1e-06,
+                    "output_cost": 5e-06
                 },
                 {
                     "label": "sonar-reasoning-pro",
                     "name": "sonar-reasoning-pro",
-                    "input_cost": 2e-6,
-                    "output_cost": 8e-6
+                    "input_cost": 2e-06,
+                    "output_cost": 8e-06
                 },
                 {
                     "label": "sonar-deep-research",
                     "name": "sonar",
-                    "input_cost": 2e-6,
-                    "output_cost": 8e-6
+                    "input_cost": 2e-06,
+                    "output_cost": 8e-06
                 },
                 {
                     "label": "r1-1776",
                     "name": "r1-1776",
-                    "input_cost": 2e-6,
-                    "output_cost": 8e-6
+                    "input_cost": 2e-06,
+                    "output_cost": 8e-06
                 }
             ]
         },
@@ -1648,6 +1777,19 @@
                     "name": "mistral-medium",
                     "input_cost": 0.001,
                     "output_cost": 0.003
+                }
+            ]
+        },
+        {
+            "name": "minimax",
+            "models": [
+                {
+                    "label": "MiniMax-M2.5",
+                    "name": "MiniMax-M2.5"
+                },
+                {
+                    "label": "MiniMax-M2.5-highspeed",
+                    "name": "MiniMax-M2.5-highspeed"
                 }
             ]
         }
@@ -1850,87 +1992,87 @@
                 {
                     "label": "text-davinci-003",
                     "name": "text-davinci-003",
-                    "total_cost": 0.00002
+                    "total_cost": 2e-05
                 },
                 {
                     "label": "ada",
                     "name": "ada",
-                    "total_cost": 0.00004
+                    "total_cost": 4e-05
                 },
                 {
                     "label": "text-ada-001",
                     "name": "text-ada-001",
-                    "total_cost": 0.00004
+                    "total_cost": 4e-05
                 },
                 {
                     "label": "babbage",
                     "name": "babbage",
-                    "total_cost": 0.00005
+                    "total_cost": 5e-05
                 },
                 {
                     "label": "text-babbage-001",
                     "name": "text-babbage-001",
-                    "total_cost": 0.00005
+                    "total_cost": 5e-05
                 },
                 {
                     "label": "curie",
                     "name": "curie",
-                    "total_cost": 0.00002
+                    "total_cost": 2e-05
                 },
                 {
                     "label": "text-curie-001",
                     "name": "text-curie-001",
-                    "total_cost": 0.00002
+                    "total_cost": 2e-05
                 },
                 {
                     "label": "davinci",
                     "name": "davinci",
-                    "total_cost": 0.00002
+                    "total_cost": 2e-05
                 },
                 {
                     "label": "text-davinci-001",
                     "name": "text-davinci-001",
-                    "total_cost": 0.00002
+                    "total_cost": 2e-05
                 },
                 {
                     "label": "text-davinci-002",
                     "name": "text-davinci-002",
-                    "total_cost": 0.00002
+                    "total_cost": 2e-05
                 },
                 {
                     "label": "text-davinci-fine-tune-002",
                     "name": "text-davinci-fine-tune-002",
-                    "total_cost": 0.00002
+                    "total_cost": 2e-05
                 },
                 {
                     "label": "gpt-35-turbo",
                     "name": "gpt-35-turbo",
-                    "input_cost": 1.5e-6,
-                    "output_cost": 2e-6
+                    "input_cost": 1.5e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "gpt-4",
                     "name": "gpt-4",
-                    "input_cost": 0.00003,
-                    "output_cost": 0.00006
+                    "input_cost": 3e-05,
+                    "output_cost": 6e-05
                 },
                 {
                     "label": "gpt-4-32k",
                     "name": "gpt-4-32k",
-                    "input_cost": 0.00006,
+                    "input_cost": 6e-05,
                     "output_cost": 0.00012
                 },
                 {
                     "label": "gpt-4.1-mini",
                     "name": "gpt-4.1-mini",
-                    "input_cost": 0.0000004,
-                    "output_cost": 0.0000016
+                    "input_cost": 4e-07,
+                    "output_cost": 1.6e-06
                 },
                 {
                     "label": "gpt-5-chat-latest",
                     "name": "gpt-5-chat-latest",
-                    "input_cost": 0.00000125,
-                    "output_cost": 0.00001
+                    "input_cost": 1.25e-06,
+                    "output_cost": 1e-05
                 }
             ]
         },
@@ -1969,38 +2111,38 @@
                 {
                     "label": "text-bison",
                     "name": "text-bison",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 5e-7
+                    "input_cost": 2.5e-07,
+                    "output_cost": 5e-07
                 },
                 {
                     "label": "code-bison",
                     "name": "code-bison",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 5e-7
+                    "input_cost": 2.5e-07,
+                    "output_cost": 5e-07
                 },
                 {
                     "label": "code-gecko",
                     "name": "code-gecko",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 5e-7
+                    "input_cost": 2.5e-07,
+                    "output_cost": 5e-07
                 },
                 {
                     "label": "text-bison-32k",
                     "name": "text-bison-32k",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 5e-7
+                    "input_cost": 2.5e-07,
+                    "output_cost": 5e-07
                 },
                 {
                     "label": "code-bison-32k",
                     "name": "code-bison-32k",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 5e-7
+                    "input_cost": 2.5e-07,
+                    "output_cost": 5e-07
                 },
                 {
                     "label": "code-gecko-32k",
                     "name": "code-gecko-32k",
-                    "input_cost": 2.5e-7,
-                    "output_cost": 5e-7
+                    "input_cost": 2.5e-07,
+                    "output_cost": 5e-07
                 }
             ]
         },
@@ -2010,20 +2152,20 @@
                 {
                     "label": "gpt-3.5-turbo-instruct",
                     "name": "gpt-3.5-turbo-instruct",
-                    "input_cost": 0.0000015,
-                    "output_cost": 0.000002
+                    "input_cost": 1.5e-06,
+                    "output_cost": 2e-06
                 },
                 {
                     "label": "babbage-002",
                     "name": "babbage-002",
-                    "input_cost": 4e-7,
-                    "output_cost": 0.0000016
+                    "input_cost": 4e-07,
+                    "output_cost": 1.6e-06
                 },
                 {
                     "label": "davinci-002",
                     "name": "davinci-002",
-                    "input_cost": 0.000006,
-                    "output_cost": 0.000012
+                    "input_cost": 6e-06,
+                    "output_cost": 1.2e-05
                 }
             ]
         }
@@ -2148,48 +2290,174 @@
                 }
             ],
             "regions": [
-                { "label": "us-east1", "name": "us-east1" },
-                { "label": "us-east4", "name": "us-east4" },
-                { "label": "us-central1", "name": "us-central1" },
-                { "label": "us-west1", "name": "us-west1" },
-                { "label": "europe-west4", "name": "europe-west4" },
-                { "label": "europe-west1", "name": "europe-west1" },
-                { "label": "europe-west3", "name": "europe-west3" },
-                { "label": "europe-west2", "name": "europe-west2" },
-                { "label": "asia-east1", "name": "asia-east1" },
-                { "label": "asia-southeast1", "name": "asia-southeast1" },
-                { "label": "asia-northeast1", "name": "asia-northeast1" },
-                { "label": "asia-south1", "name": "asia-south1" },
-                { "label": "australia-southeast1", "name": "australia-southeast1" },
-                { "label": "southamerica-east1", "name": "southamerica-east1" },
-                { "label": "africa-south1", "name": "africa-south1" },
-                { "label": "asia-east2", "name": "asia-east2" },
-                { "label": "asia-northeast2", "name": "asia-northeast2" },
-                { "label": "asia-northeast3", "name": "asia-northeast3" },
-                { "label": "asia-south2", "name": "asia-south2" },
-                { "label": "asia-southeast2", "name": "asia-southeast2" },
-                { "label": "australia-southeast2", "name": "australia-southeast2" },
-                { "label": "europe-central2", "name": "europe-central2" },
-                { "label": "europe-north1", "name": "europe-north1" },
-                { "label": "europe-north2", "name": "europe-north2" },
-                { "label": "europe-southwest1", "name": "europe-southwest1" },
-                { "label": "europe-west10", "name": "europe-west10" },
-                { "label": "europe-west12", "name": "europe-west12" },
-                { "label": "europe-west6", "name": "europe-west6" },
-                { "label": "europe-west8", "name": "europe-west8" },
-                { "label": "europe-west9", "name": "europe-west9" },
-                { "label": "me-central1", "name": "me-central1" },
-                { "label": "me-central2", "name": "me-central2" },
-                { "label": "me-west1", "name": "me-west1" },
-                { "label": "northamerica-northeast1", "name": "northamerica-northeast1" },
-                { "label": "northamerica-northeast2", "name": "northamerica-northeast2" },
-                { "label": "northamerica-south1", "name": "northamerica-south1" },
-                { "label": "southamerica-west1", "name": "southamerica-west1" },
-                { "label": "us-east5", "name": "us-east5" },
-                { "label": "us-south1", "name": "us-south1" },
-                { "label": "us-west2", "name": "us-west2" },
-                { "label": "us-west3", "name": "us-west3" },
-                { "label": "us-west4", "name": "us-west4" }
+                {
+                    "label": "us-east1",
+                    "name": "us-east1"
+                },
+                {
+                    "label": "us-east4",
+                    "name": "us-east4"
+                },
+                {
+                    "label": "us-central1",
+                    "name": "us-central1"
+                },
+                {
+                    "label": "us-west1",
+                    "name": "us-west1"
+                },
+                {
+                    "label": "europe-west4",
+                    "name": "europe-west4"
+                },
+                {
+                    "label": "europe-west1",
+                    "name": "europe-west1"
+                },
+                {
+                    "label": "europe-west3",
+                    "name": "europe-west3"
+                },
+                {
+                    "label": "europe-west2",
+                    "name": "europe-west2"
+                },
+                {
+                    "label": "asia-east1",
+                    "name": "asia-east1"
+                },
+                {
+                    "label": "asia-southeast1",
+                    "name": "asia-southeast1"
+                },
+                {
+                    "label": "asia-northeast1",
+                    "name": "asia-northeast1"
+                },
+                {
+                    "label": "asia-south1",
+                    "name": "asia-south1"
+                },
+                {
+                    "label": "australia-southeast1",
+                    "name": "australia-southeast1"
+                },
+                {
+                    "label": "southamerica-east1",
+                    "name": "southamerica-east1"
+                },
+                {
+                    "label": "africa-south1",
+                    "name": "africa-south1"
+                },
+                {
+                    "label": "asia-east2",
+                    "name": "asia-east2"
+                },
+                {
+                    "label": "asia-northeast2",
+                    "name": "asia-northeast2"
+                },
+                {
+                    "label": "asia-northeast3",
+                    "name": "asia-northeast3"
+                },
+                {
+                    "label": "asia-south2",
+                    "name": "asia-south2"
+                },
+                {
+                    "label": "asia-southeast2",
+                    "name": "asia-southeast2"
+                },
+                {
+                    "label": "australia-southeast2",
+                    "name": "australia-southeast2"
+                },
+                {
+                    "label": "europe-central2",
+                    "name": "europe-central2"
+                },
+                {
+                    "label": "europe-north1",
+                    "name": "europe-north1"
+                },
+                {
+                    "label": "europe-north2",
+                    "name": "europe-north2"
+                },
+                {
+                    "label": "europe-southwest1",
+                    "name": "europe-southwest1"
+                },
+                {
+                    "label": "europe-west10",
+                    "name": "europe-west10"
+                },
+                {
+                    "label": "europe-west12",
+                    "name": "europe-west12"
+                },
+                {
+                    "label": "europe-west6",
+                    "name": "europe-west6"
+                },
+                {
+                    "label": "europe-west8",
+                    "name": "europe-west8"
+                },
+                {
+                    "label": "europe-west9",
+                    "name": "europe-west9"
+                },
+                {
+                    "label": "me-central1",
+                    "name": "me-central1"
+                },
+                {
+                    "label": "me-central2",
+                    "name": "me-central2"
+                },
+                {
+                    "label": "me-west1",
+                    "name": "me-west1"
+                },
+                {
+                    "label": "northamerica-northeast1",
+                    "name": "northamerica-northeast1"
+                },
+                {
+                    "label": "northamerica-northeast2",
+                    "name": "northamerica-northeast2"
+                },
+                {
+                    "label": "northamerica-south1",
+                    "name": "northamerica-south1"
+                },
+                {
+                    "label": "southamerica-west1",
+                    "name": "southamerica-west1"
+                },
+                {
+                    "label": "us-east5",
+                    "name": "us-east5"
+                },
+                {
+                    "label": "us-south1",
+                    "name": "us-south1"
+                },
+                {
+                    "label": "us-west2",
+                    "name": "us-west2"
+                },
+                {
+                    "label": "us-west3",
+                    "name": "us-west3"
+                },
+                {
+                    "label": "us-west4",
+                    "name": "us-west4"
+                }
             ]
         },
         {

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1784,6 +1784,14 @@
             "name": "minimax",
             "models": [
                 {
+                    "label": "MiniMax-M2.7",
+                    "name": "MiniMax-M2.7"
+                },
+                {
+                    "label": "MiniMax-M2.7-highspeed",
+                    "name": "MiniMax-M2.7-highspeed"
+                },
+                {
                     "label": "MiniMax-M2.5",
                     "name": "MiniMax-M2.5"
                 },

--- a/packages/components/nodes/chatmodels/ChatMiniMax/ChatMiniMax.ts
+++ b/packages/components/nodes/chatmodels/ChatMiniMax/ChatMiniMax.ts
@@ -151,8 +151,16 @@ class ChatMiniMax_ChatModels implements INode {
 
         const cache = nodeData.inputs?.cache as BaseCache
 
+        // MiniMax requires temperature in (0.0, 1.0] - validate and clamp
+        let parsedTemperature = parseFloat(temperature)
+        if (isNaN(parsedTemperature) || parsedTemperature <= 0) {
+            parsedTemperature = 0.7 // safe default within MiniMax's accepted range
+        } else if (parsedTemperature > 1.0) {
+            parsedTemperature = 1.0
+        }
+
         const obj: ChatOpenAIFields = {
-            temperature: parseFloat(temperature),
+            temperature: parsedTemperature,
             modelName,
             openAIApiKey,
             apiKey: openAIApiKey,
@@ -177,7 +185,7 @@ class ChatMiniMax_ChatModels implements INode {
                 parsedBaseOptions = typeof baseOptions === 'object' ? baseOptions : JSON.parse(baseOptions)
                 if (parsedBaseOptions.baseURL) {
                     console.warn("The 'baseURL' parameter is not allowed when using the ChatMiniMax node.")
-                    parsedBaseOptions.baseURL = undefined
+                    delete parsedBaseOptions.baseURL
                 }
             } catch (exception) {
                 throw new Error('Invalid JSON in the BaseOptions: ' + exception)

--- a/packages/components/nodes/chatmodels/ChatMiniMax/ChatMiniMax.ts
+++ b/packages/components/nodes/chatmodels/ChatMiniMax/ChatMiniMax.ts
@@ -1,0 +1,198 @@
+import { BaseCache } from '@langchain/core/caches'
+import { ChatOpenAI, ChatOpenAIFields } from '@langchain/openai'
+import { ICommonObject, INode, INodeData, INodeOptionsValue, INodeParams } from '../../../src/Interface'
+import { getModels, MODEL_TYPE } from '../../../src/modelLoader'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+
+class ChatMiniMax_ChatModels implements INode {
+    readonly baseURL: string = 'https://api.minimax.io/v1'
+    label: string
+    name: string
+    version: number
+    type: string
+    icon: string
+    category: string
+    description: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'ChatMiniMax'
+        this.name = 'chatMiniMax'
+        this.version = 1.0
+        this.type = 'chatMiniMax'
+        this.icon = 'minimax.svg'
+        this.category = 'Chat Models'
+        this.description = 'Wrapper around MiniMax large language models that use the Chat endpoint'
+        this.baseClasses = [this.type, ...getBaseClasses(ChatOpenAI)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['miniMaxApi']
+        }
+        this.inputs = [
+            {
+                label: 'Cache',
+                name: 'cache',
+                type: 'BaseCache',
+                optional: true
+            },
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'asyncOptions',
+                loadMethod: 'listModels',
+                default: 'MiniMax-M2.5'
+            },
+            {
+                label: 'Temperature',
+                name: 'temperature',
+                type: 'number',
+                step: 0.1,
+                default: 0.9,
+                optional: true,
+                description: 'Controls randomness. Must be in (0.0, 1.0]. MiniMax does not accept zero.'
+            },
+            {
+                label: 'Streaming',
+                name: 'streaming',
+                type: 'boolean',
+                default: true,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Max Tokens',
+                name: 'maxTokens',
+                type: 'number',
+                step: 1,
+                optional: true,
+                additionalParams: true,
+                description: 'Maximum number of tokens to generate. MiniMax supports up to 204800 tokens.'
+            },
+            {
+                label: 'Top Probability',
+                name: 'topP',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Frequency Penalty',
+                name: 'frequencyPenalty',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Presence Penalty',
+                name: 'presencePenalty',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Timeout',
+                name: 'timeout',
+                type: 'number',
+                step: 1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Stop Sequence',
+                name: 'stopSequence',
+                type: 'string',
+                rows: 4,
+                optional: true,
+                description: 'List of stop words to use when generating. Use comma to separate multiple stop words.',
+                additionalParams: true
+            },
+            {
+                label: 'Base Options',
+                name: 'baseOptions',
+                type: 'json',
+                optional: true,
+                additionalParams: true,
+                description: 'Additional options to pass to the MiniMax client. This should be a JSON object.'
+            }
+        ]
+    }
+
+    //@ts-ignore
+    loadMethods = {
+        async listModels(): Promise<INodeOptionsValue[]> {
+            return await getModels(MODEL_TYPE.CHAT, 'minimax')
+        }
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const temperature = nodeData.inputs?.temperature as string
+        const modelName = nodeData.inputs?.modelName as string
+        const maxTokens = nodeData.inputs?.maxTokens as string
+        const topP = nodeData.inputs?.topP as string
+        const frequencyPenalty = nodeData.inputs?.frequencyPenalty as string
+        const presencePenalty = nodeData.inputs?.presencePenalty as string
+        const timeout = nodeData.inputs?.timeout as string
+        const stopSequence = nodeData.inputs?.stopSequence as string
+        const streaming = nodeData.inputs?.streaming as boolean
+        const baseOptions = nodeData.inputs?.baseOptions
+
+        if (nodeData.inputs?.credentialId) {
+            nodeData.credential = nodeData.inputs?.credentialId
+        }
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const openAIApiKey = getCredentialParam('miniMaxApiKey', credentialData, nodeData)
+
+        const cache = nodeData.inputs?.cache as BaseCache
+
+        const obj: ChatOpenAIFields = {
+            temperature: parseFloat(temperature),
+            modelName,
+            openAIApiKey,
+            apiKey: openAIApiKey,
+            streaming: streaming ?? true
+        }
+
+        if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
+        if (topP) obj.topP = parseFloat(topP)
+        if (frequencyPenalty) obj.frequencyPenalty = parseFloat(frequencyPenalty)
+        if (presencePenalty) obj.presencePenalty = parseFloat(presencePenalty)
+        if (timeout) obj.timeout = parseInt(timeout, 10)
+        if (cache) obj.cache = cache
+        if (stopSequence) {
+            const stopSequenceArray = stopSequence.split(',').map((item) => item.trim())
+            obj.stop = stopSequenceArray
+        }
+
+        let parsedBaseOptions: any | undefined = undefined
+
+        if (baseOptions) {
+            try {
+                parsedBaseOptions = typeof baseOptions === 'object' ? baseOptions : JSON.parse(baseOptions)
+                if (parsedBaseOptions.baseURL) {
+                    console.warn("The 'baseURL' parameter is not allowed when using the ChatMiniMax node.")
+                    parsedBaseOptions.baseURL = undefined
+                }
+            } catch (exception) {
+                throw new Error('Invalid JSON in the BaseOptions: ' + exception)
+            }
+        }
+
+        const model = new ChatOpenAI({
+            ...obj,
+            configuration: {
+                baseURL: this.baseURL,
+                ...parsedBaseOptions
+            }
+        })
+        return model
+    }
+}
+
+module.exports = { nodeClass: ChatMiniMax_ChatModels }

--- a/packages/components/nodes/chatmodels/ChatMiniMax/ChatMiniMax.ts
+++ b/packages/components/nodes/chatmodels/ChatMiniMax/ChatMiniMax.ts
@@ -44,7 +44,7 @@ class ChatMiniMax_ChatModels implements INode {
                 name: 'modelName',
                 type: 'asyncOptions',
                 loadMethod: 'listModels',
-                default: 'MiniMax-M2.5'
+                default: 'MiniMax-M2.7'
             },
             {
                 label: 'Temperature',

--- a/packages/components/nodes/chatmodels/ChatMiniMax/minimax.svg
+++ b/packages/components/nodes/chatmodels/ChatMiniMax/minimax.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+  <path d="M3 17V7l4.5 5L12 7v10M12 17V7l4.5 5L21 7v10" stroke="#1a73e8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary
Add MiniMax as a chat model provider in Flowise, with the latest M2.7 model as default.

## Changes
- Add `ChatMiniMax` node wrapping `ChatOpenAI` with MiniMax API base URL
- Add `MiniMaxApi` credential type for API key management
- Register MiniMax models in `models.json`: M2.7, M2.7-highspeed, M2.5, M2.5-highspeed
- Set `MiniMax-M2.7` as the default model
- Include temperature clamping for MiniMax API constraints

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities. This integration allows Flowise users to leverage MiniMax models in their AI workflows.

## Testing
- Verified models.json is valid JSON with correct model ordering
- M2.7 is first in list and set as default
- All previous models retained as alternatives