### PR TITLE
fix: implement server-side search for chatflows and agentflows

### DIFF
--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -73,12 +73,14 @@ const deleteChatflow = async (req: Request, res: Response, next: NextFunction) =
 const getAllChatflows = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const { page, limit } = getPageAndLimitParams(req)
+        const search = req.query?.search as string | undefined
 
         const apiResponse = await chatflowsService.getAllChatflows(
             req.query?.type as ChatflowType,
             req.user?.activeWorkspaceId,
             page,
-            limit
+            limit,
+            search
         )
         return res.json(apiResponse)
     } catch (error) {

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -142,7 +142,7 @@ const deleteChatflow = async (chatflowId: string, orgId: string, workspaceId: st
     }
 }
 
-const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: number = -1, limit: number = -1) => {
+const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: number = -1, limit: number = -1, search?: string) => {
     try {
         const appServer = getRunningExpressApp()
 
@@ -150,10 +150,6 @@ const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: 
             .createQueryBuilder('chat_flow')
             .orderBy('chat_flow.updatedDate', 'DESC')
 
-        if (page > 0 && limit > 0) {
-            queryBuilder.skip((page - 1) * limit)
-            queryBuilder.take(limit)
-        }
         if (type === 'MULTIAGENT') {
             queryBuilder.andWhere('chat_flow.type = :type', { type: 'MULTIAGENT' })
         } else if (type === 'AGENTFLOW') {
@@ -165,6 +161,16 @@ const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: 
             queryBuilder.andWhere('chat_flow.type = :type', { type: 'CHATFLOW' })
         }
         if (workspaceId) queryBuilder.andWhere('chat_flow.workspaceId = :workspaceId', { workspaceId })
+        if (search) {
+            queryBuilder.andWhere(
+                '(chat_flow.name LIKE :search OR chat_flow.id LIKE :search)',
+                { search: `%${search}%` }
+            )
+        }
+        if (page > 0 && limit > 0) {
+            queryBuilder.skip((page - 1) * limit)
+            queryBuilder.take(limit)
+        }
         const [data, total] = await queryBuilder.getManyAndCount()
 
         if (page > 0 && limit > 0) {

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -163,7 +163,7 @@ const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: 
         if (workspaceId) queryBuilder.andWhere('chat_flow.workspaceId = :workspaceId', { workspaceId })
         if (search) {
             queryBuilder.andWhere(
-                '(chat_flow.name LIKE :search OR chat_flow.id LIKE :search)',
+                '(LOWER(chat_flow.name) LIKE LOWER(:search) OR chat_flow.id LIKE :search)',
                 { search: `%${search}%` }
             )
         }

--- a/packages/ui/src/ui-component/table/FlowListTable.jsx
+++ b/packages/ui/src/ui-component/table/FlowListTable.jsx
@@ -55,7 +55,7 @@ export const FlowListTable = ({
     images = {},
     icons = {},
     isLoading,
-    filterFunction,
+    filterFunction = () => true,
     updateFlowsApi,
     setError,
     isAgentCanvas,

--- a/packages/ui/src/views/agentflows/index.jsx
+++ b/packages/ui/src/views/agentflows/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 
@@ -28,6 +28,9 @@ import useApi from '@/hooks/useApi'
 import { baseURL, AGENTFLOW_ICONS } from '@/store/constant'
 import { useError } from '@/store/context/ErrorContext'
 
+// utils
+import { debounce } from 'lodash'
+
 // icons
 import { IconPlus, IconLayoutGrid, IconList, IconX, IconAlertTriangle } from '@tabler/icons-react'
 
@@ -54,16 +57,21 @@ const Agentflows = () => {
     const [pageLimit, setPageLimit] = useState(DEFAULT_ITEMS_PER_PAGE)
     const [total, setTotal] = useState(0)
 
+    const searchRef = useRef('')
+
     const onChange = (page, pageLimit) => {
         setCurrentPage(page)
         setPageLimit(pageLimit)
-        refresh(page, pageLimit, agentflowVersion)
+        refresh(page, pageLimit, agentflowVersion, searchRef.current)
     }
 
-    const refresh = (page, limit, nextView) => {
+    const refresh = (page, limit, nextView, searchVal) => {
         const params = {
             page: page || currentPage,
             limit: limit || pageLimit
+        }
+        if (searchVal) {
+            params.search = searchVal
         }
         getAllAgentflows.request(nextView === 'v2' ? 'AGENTFLOW' : 'MULTIAGENT', params)
     }
@@ -78,19 +86,22 @@ const Agentflows = () => {
         if (nextView === null) return
         localStorage.setItem('agentFlowVersion', nextView)
         setAgentflowVersion(nextView)
-        refresh(1, pageLimit, nextView)
+        refresh(1, pageLimit, nextView, searchRef.current)
     }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const debouncedSearch = useCallback(
+        debounce((value, version) => {
+            setCurrentPage(1)
+            refresh(1, pageLimit, version, value)
+        }, 300),
+        [pageLimit]
+    )
 
     const onSearchChange = (event) => {
         setSearch(event.target.value)
-    }
-
-    function filterFlows(data) {
-        return (
-            data.name.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
-            (data.category && data.category.toLowerCase().indexOf(search.toLowerCase()) > -1) ||
-            data.id.toLowerCase().indexOf(search.toLowerCase()) > -1
-        )
+        searchRef.current = event.target.value
+        debouncedSearch(event.target.value, agentflowVersion)
     }
 
     const addNew = () => {
@@ -304,7 +315,7 @@ const Agentflows = () => {
                         <>
                             {!view || view === 'card' ? (
                                 <Box display='grid' gridTemplateColumns='repeat(3, 1fr)' gap={gridSpacing}>
-                                    {getAllAgentflows.data?.data.filter(filterFlows).map((data, index) => (
+                                    {getAllAgentflows.data?.data?.map((data, index) => (
                                         <ItemCard
                                             key={index}
                                             onClick={() => goToCanvas(data)}
@@ -322,7 +333,6 @@ const Agentflows = () => {
                                     images={images}
                                     icons={icons}
                                     isLoading={isLoading}
-                                    filterFunction={filterFlows}
                                     updateFlowsApi={getAllAgentflows}
                                     setError={setError}
                                     currentPage={currentPage}

--- a/packages/ui/src/views/chatflows/index.jsx
+++ b/packages/ui/src/views/chatflows/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 // material-ui
@@ -27,6 +27,9 @@ import useApi from '@/hooks/useApi'
 import { baseURL } from '@/store/constant'
 import { useError } from '@/store/context/ErrorContext'
 
+// utils
+import { debounce } from 'lodash'
+
 // icons
 import { IconPlus, IconLayoutGrid, IconList } from '@tabler/icons-react'
 
@@ -48,17 +51,21 @@ const Chatflows = () => {
     const [currentPage, setCurrentPage] = useState(1)
     const [pageLimit, setPageLimit] = useState(DEFAULT_ITEMS_PER_PAGE)
     const [total, setTotal] = useState(0)
+    const searchRef = useRef('')
 
     const onChange = (page, pageLimit) => {
         setCurrentPage(page)
         setPageLimit(pageLimit)
-        applyFilters(page, pageLimit)
+        applyFilters(page, pageLimit, searchRef.current)
     }
 
-    const applyFilters = (page, limit) => {
+    const applyFilters = (page, limit, searchVal) => {
         const params = {
             page: page || currentPage,
             limit: limit || pageLimit
+        }
+        if (searchVal) {
+            params.search = searchVal
         }
         getAllChatflowsApi.request(params)
     }
@@ -69,16 +76,19 @@ const Chatflows = () => {
         setView(nextView)
     }
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const debouncedSearch = useCallback(
+        debounce((value) => {
+            setCurrentPage(1)
+            applyFilters(1, pageLimit, value)
+        }, 300),
+        [pageLimit]
+    )
+
     const onSearchChange = (event) => {
         setSearch(event.target.value)
-    }
-
-    function filterFlows(data) {
-        return (
-            data?.name.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
-            (data.category && data.category.toLowerCase().indexOf(search.toLowerCase()) > -1) ||
-            data?.id.toLowerCase().indexOf(search.toLowerCase()) > -1
-        )
+        searchRef.current = event.target.value
+        debouncedSearch(event.target.value)
     }
 
     const addNew = () => {
@@ -196,7 +206,7 @@ const Chatflows = () => {
                         <>
                             {!view || view === 'card' ? (
                                 <Box display='grid' gridTemplateColumns='repeat(3, 1fr)' gap={gridSpacing}>
-                                    {getAllChatflowsApi.data?.data?.filter(filterFlows).map((data, index) => (
+                                    {getAllChatflowsApi.data?.data?.map((data, index) => (
                                         <ItemCard key={index} onClick={() => goToCanvas(data)} data={data} images={images[data.id]} />
                                     ))}
                                 </Box>
@@ -205,7 +215,6 @@ const Chatflows = () => {
                                     data={getAllChatflowsApi.data?.data}
                                     images={images}
                                     isLoading={isLoading}
-                                    filterFunction={filterFlows}
                                     updateFlowsApi={getAllChatflowsApi}
                                     setError={setError}
                                     currentPage={currentPage}


### PR DESCRIPTION
## Summary

Search on the Chatflows and Agentflows pages currently only filters the current page of results because filtering is done client-side after pagination. This PR moves search to the server side so it works across all pages.

Fixes #5868

## Changes

**Backend (`packages/server`)**
- `services/chatflows/index.ts`: Added optional `search` parameter to `getAllChatflows`. Applies `LIKE` filter on `name` and `id` columns **before** pagination (`SKIP`/`TAKE`), so `getManyAndCount()` returns the correct filtered total.
- `controllers/chatflows/index.ts`: Extracts `search` from `req.query` and passes it to the service.

**Frontend (`packages/ui`)**
- `views/agentflows/index.jsx`: Replaced client-side `filterFlows()` with a debounced (300ms) search that sends the `search` query parameter to the API. Resets to page 1 on new search. Removed `filterFunction` prop from `FlowListTable`.
- `views/chatflows/index.jsx`: Same changes as agentflows — debounced server-side search, removed client-side `filterFlows`.

## Test plan

- [ ] Search for a chatflow/agentflow by name — results should include matches from all pages
- [ ] Search by partial ID — should return matching flows
- [ ] Clear search — should restore full paginated list
- [ ] Pagination controls should reflect filtered total count
- [ ] Switching between V1/V2 agentflow versions preserves search term
- [ ] Switching between card/list view preserves search results