### PR TITLE
fix: extract content from AIMessage objects to preserve base64 images

### DIFF
--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -500,9 +500,16 @@ class ExtendedLunaryHandler extends LunaryHandler {
         if (this.chatId && runId === this.currentRunId) {
             const answer = outputs.output
 
+            // Extract content properly - handle both string and AIMessage objects
+            // This fixes OpenRouter base64 image data being discarded
+            let content = answer
+            if (answer && typeof answer === 'object' && 'content' in answer) {
+                content = (answer as any).content
+            }
+
             this.thread.trackMessage({
                 id: this.apiMessageId,
-                content: answer,
+                content: content,
                 role: 'assistant'
             })
 


### PR DESCRIPTION
## Summary

Fixes issue #5931 - OpenRouter base64 image data discarded by Flowise.

## Changes

When using ChatOpenRouter to access models that generate images, the base64 image data in the response is not passed through to Flowise's frontend because the handler was treating the output as a plain string instead of extracting the `content` property from AIMessage objects.

## Fix

Modified `handleChainEnd` in `packages/components/src/handler.ts` to:
1. Check if `outputs.output` is an object with a `content` property
2. Extract the content properly to preserve base64 image data

This ensures that when the LLM returns an AIMessage object with base64 image data, it's properly extracted and stored in the database for the frontend to access.

## Testing

- [x] Code compiles without errors
- [x] Handles string outputs (backward compatible)
- [x] Handles AIMessage object outputs (new behavior)

---
**Related Issue:** #5931