### PR TITLE
fix: preserve sourceDocuments and metadata in ExecuteFlow node

### DIFF
--- a/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
+++ b/packages/components/nodes/agentflow/ExecuteFlow/ExecuteFlow.ts
@@ -275,9 +275,9 @@ class ExecuteFlow_Agentflow implements INode {
                         role: returnRole,
                         content: resultText,
                         name: nodeData?.label ? nodeData?.label.toLowerCase().replace(/\s/g, '_').trim() : nodeData?.id,
-                        ...(((flattenedArtifacts.length > 0) ||
+                        ...((flattenedArtifacts.length > 0 ||
                             (fileAnnotations && fileAnnotations.length > 0) ||
-                            (flattenedUsedTools.length > 0)) && {
+                            flattenedUsedTools.length > 0) && {
                             additional_kwargs: {
                                 ...(flattenedArtifacts.length > 0 && { artifacts: flattenedArtifacts }),
                                 ...(fileAnnotations && fileAnnotations.length > 0 && { fileAnnotations }),


### PR DESCRIPTION
## Summary

The Execute Flow node in AgentFlow V2 only extracts text content from chatflow responses, discarding all metadata (sourceDocuments, usedTools, artifacts, fileAnnotations). This causes RAG source documents to be lost when chatflows are called from AgentFlows.

Fixes #5949

## Changes

- Extract `sourceDocuments`, `usedTools`, `artifacts`, and `fileAnnotations` from the chatflow API response
- Include metadata fields in the `returnOutput.output` object when present
- Stream metadata via SSE events (`streamSourceDocumentsEvent`, `streamUsedToolsEvent`, etc.) when the ExecuteFlow node is the last node in the flow
- Added 8 unit tests covering metadata preservation, omission when absent, and SSE streaming behavior

## Test plan

- [x] All 8 new unit tests pass
- [x] All 456 existing tests pass (10 suites)
- [x] No lint errors in changed files