### PR TITLE
fix: support Claude 4+ models in vision model check

### DIFF
--- a/packages/components/nodes/chatmodels/AWSBedrock/FlowiseAWSChatBedrock.ts
+++ b/packages/components/nodes/chatmodels/AWSBedrock/FlowiseAWSChatBedrock.ts
@@ -27,7 +27,9 @@ export class BedrockChat extends LCBedrockChat implements IVisionChatModal {
     }
 
     setVisionModel(): void {
-        if (!this.model.includes('claude-3')) {
+        // Claude 3+ and Claude 4+ models all support vision
+        const supportsVision = /claude-(3|opus|sonnet|haiku)/.test(this.model)
+        if (!supportsVision) {
             this.model = DEFAULT_IMAGE_MODEL
             this.maxTokens = this.configuredMaxToken ? this.configuredMaxToken : DEFAULT_IMAGE_MAX_TOKEN
         }

--- a/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.test.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.test.ts
@@ -1,0 +1,80 @@
+jest.mock('@langchain/anthropic', () => ({
+    ChatAnthropic: class MockChatAnthropic {
+        modelName: string
+        maxTokens: number
+        constructor(fields: any) {
+            this.modelName = fields?.modelName || ''
+            this.maxTokens = fields?.maxTokens ?? 2048
+        }
+    }
+}))
+
+import { ChatAnthropic } from './FlowiseChatAnthropic'
+
+describe('ChatAnthropic - setVisionModel', () => {
+    it('keeps claude-3-opus model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-3-opus-20240229' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-3-opus-20240229')
+    })
+
+    it('keeps claude-3-5-sonnet model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-3-5-sonnet-20241022' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-3-5-sonnet-20241022')
+    })
+
+    it('keeps claude-3-7-sonnet model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-3-7-sonnet-20250219' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-3-7-sonnet-20250219')
+    })
+
+    it('keeps claude-opus-4-5 model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-opus-4-5' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-opus-4-5')
+    })
+
+    it('keeps claude-sonnet-4-5 model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-sonnet-4-5' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-sonnet-4-5')
+    })
+
+    it('keeps claude-haiku-4-5 model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-haiku-4-5' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-haiku-4-5')
+    })
+
+    it('keeps claude-opus-4-0 model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-opus-4-0' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-opus-4-0')
+    })
+
+    it('keeps claude-sonnet-4-0 model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-sonnet-4-0' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-sonnet-4-0')
+    })
+
+    it('keeps claude-opus-4-1 model unchanged', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-opus-4-1' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-opus-4-1')
+    })
+
+    it('falls back to default for non-vision models', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-2.1' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-3-5-haiku-latest')
+    })
+
+    it('falls back to default for claude-instant', () => {
+        const model = new ChatAnthropic('test', { modelName: 'claude-instant-1.2' } as any)
+        model.setVisionModel()
+        expect(model.modelName).toBe('claude-3-5-haiku-latest')
+    })
+})

--- a/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.ts
@@ -29,7 +29,9 @@ export class ChatAnthropic extends LangchainChatAnthropic implements IVisionChat
     }
 
     setVisionModel(): void {
-        if (!this.modelName.startsWith('claude-3')) {
+        // Claude 3+ and Claude 4+ models all support vision
+        const supportsVision = /^claude-(3|opus|sonnet|haiku)/.test(this.modelName)
+        if (!supportsVision) {
             this.modelName = DEFAULT_IMAGE_MODEL
             this.maxTokens = this.configuredMaxToken ? this.configuredMaxToken : DEFAULT_IMAGE_MAX_TOKEN
         }


### PR DESCRIPTION
## Summary

The `setVisionModel()` method in both `FlowiseChatAnthropic.ts` and `FlowiseAWSChatBedrock.ts` only recognized `claude-3` models as vision-capable. Claude 4.x models (`claude-opus-4-0`, `claude-sonnet-4-0`, `claude-opus-4-1`, `claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5`) were silently downgraded to `claude-3-5-haiku-latest` when image uploads were enabled.

Fixes #5586

## Changes

- Updated vision model check in `FlowiseChatAnthropic.ts` to recognize Claude 4+ model naming convention (`claude-opus-*`, `claude-sonnet-*`, `claude-haiku-*`)
- Applied same fix to `FlowiseAWSChatBedrock.ts` for AWS Bedrock Claude models
- Added 11 unit tests covering all Claude model families (3, 3.5, 3.7, 4, 4.1, 4.5) and fallback behavior for non-vision models

## Test plan

- [x] All 11 new vision model tests pass
- [x] All 459 existing tests pass
- [x] No lint errors in changed files