### PR TITLE
fix: add timeout to token counting to prevent tiktoken DNS hangs

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -25,6 +25,7 @@ import { randomBytes } from 'crypto'
 import {
     addImageArtifactsToMessages,
     extractArtifactsFromResponse,
+    getNumTokensWithTimeout,
     getPastChatHistoryImageMessages,
     getUniqueImageMessages,
     processMessagesWithImages,
@@ -1745,22 +1746,6 @@ class Agent_Agentflow implements INode {
     }
 
     /**
-     * Get token count with timeout to prevent hangs when tiktoken.pages.dev is unreachable.
-     * Falls back to approximate count (~4 chars per token) on timeout or error.
-     */
-    private async getNumTokensWithTimeout(llmNodeInstance: BaseChatModel, text: string, timeoutMs: number = 3000): Promise<number> {
-        try {
-            const tokenCountPromise = llmNodeInstance.getNumTokens(text)
-            const timeoutPromise = new Promise<never>((_, reject) =>
-                setTimeout(() => reject(new Error('Token counting timed out')), timeoutMs)
-            )
-            return await Promise.race([tokenCountPromise, timeoutPromise])
-        } catch {
-            return Math.ceil(text.length / 4)
-        }
-    }
-
-    /**
      * Handles conversation summary buffer memory type
      */
     private async handleSummaryBuffer(
@@ -1774,7 +1759,7 @@ class Agent_Agentflow implements INode {
 
         // Convert past messages to a format suitable for token counting
         const messagesString = pastMessages.map((msg: any) => `${msg.role}: ${msg.content}`).join('\n')
-        const tokenCount = await this.getNumTokensWithTimeout(llmNodeInstance, messagesString)
+        const tokenCount = await getNumTokensWithTimeout(llmNodeInstance, messagesString)
 
         if (tokenCount > maxTokenLimit) {
             // Calculate how many messages to summarize (messages that exceed the token limit)
@@ -1789,7 +1774,7 @@ class Agent_Agentflow implements INode {
                     messagesToSummarize.push(poppedMessage)
                     // Recalculate token count for remaining messages
                     const remainingMessagesString = remainingMessages.map((msg: any) => `${msg.role}: ${msg.content}`).join('\n')
-                    currBufferLength = await this.getNumTokensWithTimeout(llmNodeInstance, remainingMessagesString)
+                    currBufferLength = await getNumTokensWithTimeout(llmNodeInstance, remainingMessagesString)
                 }
             }
 

--- a/packages/components/nodes/agentflow/ConditionAgent/ConditionAgent.ts
+++ b/packages/components/nodes/agentflow/ConditionAgent/ConditionAgent.ts
@@ -2,6 +2,7 @@ import { AnalyticHandler } from '../../../src/handler'
 import { ICommonObject, INode, INodeData, INodeOptionsValue, INodeOutputsValue, INodeParams } from '../../../src/Interface'
 import { AIMessageChunk, BaseMessageLike } from '@langchain/core/messages'
 import {
+    getNumTokensWithTimeout,
     getPastChatHistoryImageMessages,
     getUniqueImageMessages,
     processMessagesWithImages,
@@ -565,22 +566,6 @@ class ConditionAgent_Agentflow implements INode {
     }
 
     /**
-     * Get token count with timeout to prevent hangs when tiktoken.pages.dev is unreachable.
-     * Falls back to approximate count (~4 chars per token) on timeout or error.
-     */
-    private async getNumTokensWithTimeout(llmNodeInstance: BaseChatModel, text: string, timeoutMs: number = 3000): Promise<number> {
-        try {
-            const tokenCountPromise = llmNodeInstance.getNumTokens(text)
-            const timeoutPromise = new Promise<never>((_, reject) =>
-                setTimeout(() => reject(new Error('Token counting timed out')), timeoutMs)
-            )
-            return await Promise.race([tokenCountPromise, timeoutPromise])
-        } catch {
-            return Math.ceil(text.length / 4)
-        }
-    }
-
-    /**
      * Handles conversation summary buffer memory type
      */
     private async handleSummaryBuffer(
@@ -594,7 +579,7 @@ class ConditionAgent_Agentflow implements INode {
 
         // Convert past messages to a format suitable for token counting
         const messagesString = pastMessages.map((msg: any) => `${msg.role}: ${msg.content}`).join('\n')
-        const tokenCount = await this.getNumTokensWithTimeout(llmNodeInstance, messagesString)
+        const tokenCount = await getNumTokensWithTimeout(llmNodeInstance, messagesString)
 
         if (tokenCount > maxTokenLimit) {
             // Calculate how many messages to summarize (messages that exceed the token limit)
@@ -609,7 +594,7 @@ class ConditionAgent_Agentflow implements INode {
                     messagesToSummarize.push(poppedMessage)
                     // Recalculate token count for remaining messages
                     const remainingMessagesString = remainingMessages.map((msg: any) => `${msg.role}: ${msg.content}`).join('\n')
-                    currBufferLength = await this.getNumTokensWithTimeout(llmNodeInstance, remainingMessagesString)
+                    currBufferLength = await getNumTokensWithTimeout(llmNodeInstance, remainingMessagesString)
                 }
             }
 

--- a/packages/components/nodes/agentflow/ConditionAgent/getNumTokensWithTimeout.test.ts
+++ b/packages/components/nodes/agentflow/ConditionAgent/getNumTokensWithTimeout.test.ts
@@ -1,73 +1,73 @@
 /**
- * Tests for the getNumTokensWithTimeout pattern used in ConditionAgent,
+ * Tests for the getNumTokensWithTimeout utility used in ConditionAgent,
  * LLM, and Agent nodes to prevent tiktoken DNS hangs.
  */
-
-// Replicate the timeout logic from ConditionAgent.getNumTokensWithTimeout
-async function getNumTokensWithTimeout(
-    getNumTokens: (text: string) => Promise<number>,
-    text: string,
-    timeoutMs: number = 3000
-): Promise<number> {
-    try {
-        const tokenCountPromise = getNumTokens(text)
-        const timeoutPromise = new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('Token counting timed out')), timeoutMs)
-        )
-        return await Promise.race([tokenCountPromise, timeoutPromise])
-    } catch {
-        return Math.ceil(text.length / 4)
-    }
-}
+import { getNumTokensWithTimeout } from '../utils'
+import { BaseChatModel } from '@langchain/core/language_models/chat_models'
 
 describe('getNumTokensWithTimeout', () => {
     it('returns token count when getNumTokens resolves quickly', async () => {
-        const getNumTokens = jest.fn().mockResolvedValue(42)
-        const result = await getNumTokensWithTimeout(getNumTokens, 'hello world', 1000)
+        const llmNodeInstance = {
+            getNumTokens: jest.fn().mockResolvedValue(42)
+        } as unknown as BaseChatModel
+        const result = await getNumTokensWithTimeout(llmNodeInstance, 'hello world', 1000)
         expect(result).toBe(42)
-        expect(getNumTokens).toHaveBeenCalledWith('hello world')
+        expect(llmNodeInstance.getNumTokens).toHaveBeenCalledWith('hello world')
     })
 
     it('falls back to approximate count on timeout', async () => {
-        // Use a promise that never resolves to simulate a hung network request
-        const getNumTokens = jest.fn().mockReturnValue(new Promise(() => {}))
+        jest.useFakeTimers()
+        const llmNodeInstance = {
+            getNumTokens: jest.fn().mockReturnValue(new Promise(() => {}))
+        } as unknown as BaseChatModel
         const text = 'a'.repeat(400) // 400 chars -> ~100 tokens
-        const result = await getNumTokensWithTimeout(getNumTokens, text, 50) // 50ms timeout
+        const promise = getNumTokensWithTimeout(llmNodeInstance, text, 50)
+        jest.advanceTimersByTime(50)
+        const result = await promise
         expect(result).toBe(100) // Math.ceil(400 / 4)
+        jest.useRealTimers()
     })
 
     it('falls back to approximate count on error', async () => {
-        const getNumTokens = jest.fn().mockRejectedValue(new Error('fetch failed'))
+        const llmNodeInstance = {
+            getNumTokens: jest.fn().mockRejectedValue(new Error('fetch failed'))
+        } as unknown as BaseChatModel
         const text = 'hello world test' // 16 chars -> 4 tokens
-        const result = await getNumTokensWithTimeout(getNumTokens, text, 1000)
+        const result = await getNumTokensWithTimeout(llmNodeInstance, text, 1000)
         expect(result).toBe(4) // Math.ceil(16 / 4)
     })
 
     it('falls back to approximate count on DNS failure', async () => {
-        const getNumTokens = jest.fn().mockRejectedValue(
-            Object.assign(new Error('getaddrinfo EAI_AGAIN tiktoken.pages.dev'), {
-                code: 'EAI_AGAIN',
-                syscall: 'getaddrinfo',
-                hostname: 'tiktoken.pages.dev'
-            })
-        )
+        const llmNodeInstance = {
+            getNumTokens: jest.fn().mockRejectedValue(
+                Object.assign(new Error('getaddrinfo EAI_AGAIN tiktoken.pages.dev'), {
+                    code: 'EAI_AGAIN',
+                    syscall: 'getaddrinfo',
+                    hostname: 'tiktoken.pages.dev'
+                })
+            )
+        } as unknown as BaseChatModel
         const text = 'This is a longer text for testing'
-        const result = await getNumTokensWithTimeout(getNumTokens, text, 1000)
+        const result = await getNumTokensWithTimeout(llmNodeInstance, text, 1000)
         expect(result).toBe(Math.ceil(text.length / 4))
     })
 
     it('returns correct approximate for empty string', async () => {
-        const getNumTokens = jest.fn().mockRejectedValue(new Error('failed'))
-        const result = await getNumTokensWithTimeout(getNumTokens, '', 1000)
+        const llmNodeInstance = {
+            getNumTokens: jest.fn().mockRejectedValue(new Error('failed'))
+        } as unknown as BaseChatModel
+        const result = await getNumTokensWithTimeout(llmNodeInstance, '', 1000)
         expect(result).toBe(0) // Math.ceil(0 / 4) = 0
     })
 
     it('completes within timeout duration on slow network', async () => {
-        // Use a promise that never resolves to simulate a hung network request
-        const getNumTokens = jest.fn().mockReturnValue(new Promise(() => {}))
-        const startTime = Date.now()
-        await getNumTokensWithTimeout(getNumTokens, 'test', 100)
-        const duration = Date.now() - startTime
-        expect(duration).toBeLessThan(500) // Should complete well before 500ms
+        jest.useFakeTimers()
+        const llmNodeInstance = {
+            getNumTokens: jest.fn().mockReturnValue(new Promise(() => {}))
+        } as unknown as BaseChatModel
+        const promise = getNumTokensWithTimeout(llmNodeInstance, 'test', 100)
+        jest.advanceTimersByTime(100)
+        await expect(promise).resolves.toBe(1) // Math.ceil('test'.length / 4) = 1
+        jest.useRealTimers()
     })
 })

--- a/packages/components/nodes/agentflow/LLM/LLM.ts
+++ b/packages/components/nodes/agentflow/LLM/LLM.ts
@@ -7,6 +7,7 @@ import { ILLMMessage } from '../Interface.Agentflow'
 import {
     addImageArtifactsToMessages,
     extractArtifactsFromResponse,
+    getNumTokensWithTimeout,
     getPastChatHistoryImageMessages,
     getUniqueImageMessages,
     processMessagesWithImages,
@@ -779,22 +780,6 @@ class LLM_Agentflow implements INode {
     }
 
     /**
-     * Get token count with timeout to prevent hangs when tiktoken.pages.dev is unreachable.
-     * Falls back to approximate count (~4 chars per token) on timeout or error.
-     */
-    private async getNumTokensWithTimeout(llmNodeInstance: BaseChatModel, text: string, timeoutMs: number = 3000): Promise<number> {
-        try {
-            const tokenCountPromise = llmNodeInstance.getNumTokens(text)
-            const timeoutPromise = new Promise<never>((_, reject) =>
-                setTimeout(() => reject(new Error('Token counting timed out')), timeoutMs)
-            )
-            return await Promise.race([tokenCountPromise, timeoutPromise])
-        } catch {
-            return Math.ceil(text.length / 4)
-        }
-    }
-
-    /**
      * Handles conversation summary buffer memory type
      */
     private async handleSummaryBuffer(
@@ -808,7 +793,7 @@ class LLM_Agentflow implements INode {
 
         // Convert past messages to a format suitable for token counting
         const messagesString = pastMessages.map((msg: any) => `${msg.role}: ${msg.content}`).join('\n')
-        const tokenCount = await this.getNumTokensWithTimeout(llmNodeInstance, messagesString)
+        const tokenCount = await getNumTokensWithTimeout(llmNodeInstance, messagesString)
 
         if (tokenCount > maxTokenLimit) {
             // Calculate how many messages to summarize (messages that exceed the token limit)
@@ -823,7 +808,7 @@ class LLM_Agentflow implements INode {
                     messagesToSummarize.push(poppedMessage)
                     // Recalculate token count for remaining messages
                     const remainingMessagesString = remainingMessages.map((msg: any) => `${msg.role}: ${msg.content}`).join('\n')
-                    currBufferLength = await this.getNumTokensWithTimeout(llmNodeInstance, remainingMessagesString)
+                    currBufferLength = await getNumTokensWithTimeout(llmNodeInstance, remainingMessagesString)
                 }
             }
 

--- a/packages/components/nodes/agentflow/utils.ts
+++ b/packages/components/nodes/agentflow/utils.ts
@@ -1,3 +1,4 @@
+import { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { BaseMessage, MessageContentImageUrl, AIMessageChunk } from '@langchain/core/messages'
 import { getImageUploads } from '../../src/multiModalUtils'
 import { addSingleFileToStorage, getFileFromStorage } from '../../src/storageUtils'
@@ -6,6 +7,20 @@ import { BaseMessageLike } from '@langchain/core/messages'
 import { IFlowState } from './Interface.Agentflow'
 import { getCredentialData, getCredentialParam, handleEscapeCharacters, mapMimeTypeToInputField } from '../../src/utils'
 import fetch from 'node-fetch'
+
+/**
+ * Get token count with timeout to prevent hangs when tiktoken.pages.dev is unreachable.
+ * Falls back to approximate count (~4 chars per token) on timeout or error.
+ */
+export async function getNumTokensWithTimeout(llmNodeInstance: BaseChatModel, text: string, timeoutMs: number = 3000): Promise<number> {
+    try {
+        const tokenCountPromise = llmNodeInstance.getNumTokens(text)
+        const timeoutPromise = new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Token counting timed out')), timeoutMs))
+        return await Promise.race([tokenCountPromise, timeoutPromise])
+    } catch {
+        return Math.ceil(text.length / 4)
+    }
+}
 
 export const addImagesToMessages = async (
     options: ICommonObject,


### PR DESCRIPTION
## Summary

When `tiktoken.pages.dev` is unreachable (corporate networks, firewalls, DNS restrictions), `getNumTokens()` hangs for 15+ seconds due to DNS retry attempts before falling back. This wraps token counting calls with a 3-second timeout and falls back to approximate counting (~4 chars per token) immediately.

Fixes #5546

## Changes

- Added `getNumTokensWithTimeout()` method to `ConditionAgent`, `LLM`, and `Agent` agentflow nodes
- Uses `Promise.race` with a 3-second timeout against `getNumTokens()`
- On timeout or error, falls back to `Math.ceil(text.length / 4)` (approximate token count)
- Added 6 unit tests covering normal operation, timeout, DNS failure, and timing guarantees

## Test plan

- [x] All 6 new timeout tests pass
- [x] All 454 existing tests pass
- [x] No lint errors in changed files
- [x] Timeout behavior verified: completes in <500ms even when getNumTokens never resolves