### PR TITLE
fix: use source build Dockerfile in docker-compose-queue-source.yml

### DIFF
--- a/docker/docker-compose-queue-source.yml
+++ b/docker/docker-compose-queue-source.yml
@@ -15,7 +15,7 @@ services:
         container_name: flowise-main
         build:
             context: .. # Build using the Dockerfile in the root directory
-            dockerfile: docker/Dockerfile
+            dockerfile: Dockerfile
         ports:
             - '${PORT}:${PORT}'
         volumes:


### PR DESCRIPTION
## Summary

Fixes #4966

`docker/docker-compose-queue-source.yml` was referencing `docker/Dockerfile`, which installs Flowise from the npm registry via `npm install -g flowise`. This defeats the purpose of the "-source" compose file, which should build from the local source code.

Changed to reference the root `Dockerfile` which actually builds from source (`pnpm install && pnpm build`).

## Changes

- `docker/docker-compose-queue-source.yml`: Change `dockerfile: docker/Dockerfile` to `dockerfile: Dockerfile`

## Test plan

- [x] Verified `docker/Dockerfile` uses `npm install -g flowise` (npm install, not source build)
- [x] Verified root `Dockerfile` uses `pnpm install && pnpm build` (source build)
- [x] Verified `docker/worker/Dockerfile` path is already correct (also builds from source)
- [x] Verified `docker-compose-queue-prebuilt.yml` correctly uses pre-built images (no build context)