### PR TITLE
Chore/Remove Redundant Check for Image Processing

### DIFF
--- a/packages/components/nodes/agents/ConversationalAgent/ConversationalAgent.ts
+++ b/packages/components/nodes/agents/ConversationalAgent/ConversationalAgent.ts
@@ -10,16 +10,7 @@ import { RunnableSequence } from '@langchain/core/runnables'
 import { ChatConversationalAgent } from '@langchain/classic/agents'
 import { getBaseClasses, transformBracesWithColon } from '../../../src/utils'
 import { ConsoleCallbackHandler, CustomChainHandler, additionalCallbacks } from '../../../src/handler'
-import {
-    IVisionChatModal,
-    FlowiseMemory,
-    ICommonObject,
-    INode,
-    INodeData,
-    INodeParams,
-    IUsedTool,
-    IServerSideEventStreamer
-} from '../../../src/Interface'
+import { FlowiseMemory, ICommonObject, INode, INodeData, INodeParams, IUsedTool, IServerSideEventStreamer } from '../../../src/Interface'
 import { AgentExecutor } from '../../../src/agents'
 import { addImagesToMessages, llmSupportsVision } from '../../../src/multiModalUtils'
 import { checkInputs, Moderation, streamResponse } from '../../moderation/Moderation'
@@ -241,12 +232,9 @@ const prepareAgent = async (
     })
 
     if (llmSupportsVision(model)) {
-        const visionChatModel = model as IVisionChatModal
         const messageContent = await addImagesToMessages(nodeData, options, model.multiModalOption)
 
         if (messageContent?.length) {
-            visionChatModel.setVisionModel()
-
             // Pop the `agent_scratchpad` MessagePlaceHolder
             let messagePlaceholder = prompt.promptMessages.pop() as MessagesPlaceholder
             if (prompt.promptMessages.at(-1) instanceof HumanMessagePromptTemplate) {
@@ -264,8 +252,6 @@ const prepareAgent = async (
 
             // Add the `agent_scratchpad` MessagePlaceHolder back
             prompt.promptMessages.push(messagePlaceholder)
-        } else {
-            visionChatModel.revertToOriginalModel()
         }
     }
 

--- a/packages/components/nodes/agents/ConversationalRetrievalToolAgent/ConversationalRetrievalToolAgent.ts
+++ b/packages/components/nodes/agents/ConversationalRetrievalToolAgent/ConversationalRetrievalToolAgent.ts
@@ -13,16 +13,7 @@ import {
     createTextOnlyOutputParser
 } from '../../../src/utils'
 import { type ToolsAgentStep } from '@langchain/classic/agents/openai/output_parser'
-import {
-    FlowiseMemory,
-    ICommonObject,
-    INode,
-    INodeData,
-    INodeParams,
-    IServerSideEventStreamer,
-    IUsedTool,
-    IVisionChatModal
-} from '../../../src/Interface'
+import { FlowiseMemory, ICommonObject, INode, INodeData, INodeParams, IServerSideEventStreamer, IUsedTool } from '../../../src/Interface'
 import { ConsoleCallbackHandler, CustomChainHandler, additionalCallbacks } from '../../../src/handler'
 import { AgentExecutor, ToolCallingAgentOutputParser } from '../../../src/agents'
 import { Moderation, checkInputs, streamResponse } from '../../moderation/Moderation'
@@ -279,12 +270,9 @@ const prepareAgent = async (
     ])
 
     if (llmSupportsVision(model)) {
-        const visionChatModel = model as IVisionChatModal
         const messageContent = await addImagesToMessages(nodeData, options, model.multiModalOption)
 
         if (messageContent?.length) {
-            visionChatModel.setVisionModel()
-
             // Pop the `agent_scratchpad` MessagePlaceHolder
             let messagePlaceholder = prompt.promptMessages.pop() as MessagesPlaceholder
             if (prompt.promptMessages.at(-1) instanceof HumanMessagePromptTemplate) {
@@ -302,8 +290,6 @@ const prepareAgent = async (
 
             // Add the `agent_scratchpad` MessagePlaceHolder back
             prompt.promptMessages.push(messagePlaceholder)
-        } else {
-            visionChatModel.revertToOriginalModel()
         }
     }
 

--- a/packages/components/nodes/agents/ReActAgentChat/ReActAgentChat.ts
+++ b/packages/components/nodes/agents/ReActAgentChat/ReActAgentChat.ts
@@ -6,7 +6,7 @@ import type { PromptTemplate } from '@langchain/core/prompts'
 import { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { pull } from 'langchain/hub'
 import { additionalCallbacks } from '../../../src/handler'
-import { IVisionChatModal, FlowiseMemory, ICommonObject, IMessage, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { FlowiseMemory, ICommonObject, IMessage, INode, INodeData, INodeParams } from '../../../src/Interface'
 import { getBaseClasses } from '../../../src/utils'
 import { createReactAgent } from '../../../src/agents'
 import { addImagesToMessages, llmSupportsVision } from '../../../src/multiModalUtils'
@@ -105,14 +105,10 @@ class ReActAgentChat_Agents implements INode {
         let chatPromptTemplate = undefined
 
         if (llmSupportsVision(model)) {
-            const visionChatModel = model as IVisionChatModal
             const messageContent = await addImagesToMessages(nodeData, options, model.multiModalOption)
 
             if (messageContent?.length) {
-                // Change model to vision supported
-                visionChatModel.setVisionModel()
                 const oldTemplate = prompt.template as string
-
                 const msg = HumanMessagePromptTemplate.fromTemplate([
                     ...messageContent,
                     {
@@ -121,9 +117,6 @@ class ReActAgentChat_Agents implements INode {
                 ])
                 msg.inputVariables = prompt.inputVariables
                 chatPromptTemplate = ChatPromptTemplate.fromMessages([msg])
-            } else {
-                // revert to previous values if image upload is empty
-                visionChatModel.revertToOriginalModel()
             }
         }
 

--- a/packages/components/nodes/agents/ToolAgent/ToolAgent.ts
+++ b/packages/components/nodes/agents/ToolAgent/ToolAgent.ts
@@ -14,16 +14,7 @@ import {
     removeInvalidImageMarkdown,
     transformBracesWithColon
 } from '../../../src/utils'
-import {
-    FlowiseMemory,
-    ICommonObject,
-    INode,
-    INodeData,
-    INodeParams,
-    IServerSideEventStreamer,
-    IUsedTool,
-    IVisionChatModal
-} from '../../../src/Interface'
+import { FlowiseMemory, ICommonObject, INode, INodeData, INodeParams, IServerSideEventStreamer, IUsedTool } from '../../../src/Interface'
 import { ConsoleCallbackHandler, CustomChainHandler, CustomStreamingHandler, additionalCallbacks } from '../../../src/handler'
 import { AgentExecutor, ToolCallingAgentOutputParser } from '../../../src/agents'
 import { Moderation, checkInputs, streamResponse } from '../../moderation/Moderation'
@@ -315,12 +306,9 @@ const prepareAgent = async (
     }
 
     if (llmSupportsVision(model)) {
-        const visionChatModel = model as IVisionChatModal
         const messageContent = await addImagesToMessages(nodeData, options, model.multiModalOption)
 
         if (messageContent?.length) {
-            visionChatModel.setVisionModel()
-
             // Pop the `agent_scratchpad` MessagePlaceHolder
             let messagePlaceholder = prompt.promptMessages.pop() as MessagesPlaceholder
             if (prompt.promptMessages.at(-1) instanceof HumanMessagePromptTemplate) {
@@ -338,8 +326,6 @@ const prepareAgent = async (
 
             // Add the `agent_scratchpad` MessagePlaceHolder back
             prompt.promptMessages.push(messagePlaceholder)
-        } else {
-            visionChatModel.revertToOriginalModel()
         }
     }
 

--- a/packages/components/nodes/chains/ConversationChain/ConversationChain.ts
+++ b/packages/components/nodes/chains/ConversationChain/ConversationChain.ts
@@ -16,7 +16,6 @@ import { formatResponse } from '../../outputparsers/OutputParserHelpers'
 import { addImagesToMessages, llmSupportsVision } from '../../../src/multiModalUtils'
 import { ChatOpenAI } from '../../chatmodels/ChatOpenAI/FlowiseChatOpenAI'
 import {
-    IVisionChatModal,
     FlowiseMemory,
     ICommonObject,
     INode,
@@ -232,13 +231,6 @@ const prepareChain = async (nodeData: INodeData, options: ICommonObject, session
     let messageContent: MessageContentImageUrl[] = []
     if (llmSupportsVision(model)) {
         messageContent = await addImagesToMessages(nodeData, options, model.multiModalOption)
-        const visionChatModel = model as IVisionChatModal
-        if (messageContent?.length) {
-            visionChatModel.setVisionModel()
-        } else {
-            // revert to previous values if image upload is empty
-            visionChatModel.revertToOriginalModel()
-        }
     }
 
     const chatPrompt = prepareChatPrompt(nodeData, messageContent)

--- a/packages/components/nodes/chains/LLMChain/LLMChain.ts
+++ b/packages/components/nodes/chains/LLMChain/LLMChain.ts
@@ -201,8 +201,6 @@ const runPrediction = async (
         const visionChatModel = chain.llm as IVisionChatModal
         const messageContent = await addImagesToMessages(nodeData, options, visionChatModel.multiModalOption)
         if (messageContent?.length) {
-            // Change model to gpt-4-vision && max token to higher when using gpt-4-vision
-            visionChatModel.setVisionModel()
             // Add image to the message
             if (chain.prompt instanceof PromptTemplate) {
                 const existingPromptTemplate = chain.prompt.template as string
@@ -238,9 +236,6 @@ const runPrediction = async (
                 // @ts-ignore
                 chain.prompt.examplePrompt = newFewShotPromptTemplate
             }
-        } else {
-            // revert to previous values if image upload is empty
-            visionChatModel.revertToOriginalModel()
         }
     }
 

--- a/packages/components/nodes/chatmodels/AWSBedrock/FlowiseAWSChatBedrock.ts
+++ b/packages/components/nodes/chatmodels/AWSBedrock/FlowiseAWSChatBedrock.ts
@@ -1,9 +1,6 @@
 import { IVisionChatModal, IMultiModalOption } from '../../../src'
 import { ChatBedrockConverse as LCBedrockChat, ChatBedrockConverseInput } from '@langchain/aws'
 
-const DEFAULT_IMAGE_MODEL = 'anthropic.claude-3-haiku-20240307-v1:0'
-const DEFAULT_IMAGE_MAX_TOKEN = 1024
-
 export class BedrockChat extends LCBedrockChat implements IVisionChatModal {
     configuredModel: string
     configuredMaxToken?: number
@@ -17,19 +14,7 @@ export class BedrockChat extends LCBedrockChat implements IVisionChatModal {
         this.configuredMaxToken = fields?.maxTokens
     }
 
-    revertToOriginalModel(): void {
-        this.model = this.configuredModel
-        this.maxTokens = this.configuredMaxToken
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        if (!this.model.includes('claude-3')) {
-            this.model = DEFAULT_IMAGE_MODEL
-            this.maxTokens = this.configuredMaxToken ? this.configuredMaxToken : DEFAULT_IMAGE_MAX_TOKEN
-        }
     }
 }

--- a/packages/components/nodes/chatmodels/AzureChatOpenAI/FlowiseAzureChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/AzureChatOpenAI/FlowiseAzureChatOpenAI.ts
@@ -17,17 +17,8 @@ export class AzureChatOpenAI extends LangchainAzureChatOpenAI implements IVision
         this.configuredMaxToken = fields?.maxTokens
     }
 
-    revertToOriginalModel(): void {
-        this.model = this.configuredModel
-        this.maxTokens = this.configuredMaxToken
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        // pass
     }
 
     addBuiltInTools(builtInTool: Record<string, any>): void {

--- a/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.ts
@@ -2,9 +2,6 @@ import { AnthropicInput, ChatAnthropic as LangchainChatAnthropic } from '@langch
 import { type BaseChatModelParams } from '@langchain/core/language_models/chat_models'
 import { IVisionChatModal, IMultiModalOption } from '../../../src'
 
-const DEFAULT_IMAGE_MODEL = 'claude-3-5-haiku-latest'
-const DEFAULT_IMAGE_MAX_TOKEN = 2048
-
 export class ChatAnthropic extends LangchainChatAnthropic implements IVisionChatModal {
     configuredModel: string
     configuredMaxToken: number
@@ -19,19 +16,7 @@ export class ChatAnthropic extends LangchainChatAnthropic implements IVisionChat
         this.configuredMaxToken = fields?.maxTokens ?? 2048
     }
 
-    revertToOriginalModel(): void {
-        this.modelName = this.configuredModel
-        this.maxTokens = this.configuredMaxToken
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        if (!this.modelName.startsWith('claude-3')) {
-            this.modelName = DEFAULT_IMAGE_MODEL
-            this.maxTokens = this.configuredMaxToken ? this.configuredMaxToken : DEFAULT_IMAGE_MAX_TOKEN
-        }
     }
 }

--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
@@ -930,16 +930,7 @@ export class ChatGoogleGenerativeAI extends LangchainChatGoogleGenerativeAI impl
         }
     }
 
-    revertToOriginalModel(): void {
-        this.model = this.configuredModel
-        this.maxOutputTokens = this.configuredMaxToken
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        // pass
     }
 }

--- a/packages/components/nodes/chatmodels/ChatGoogleVertexAI/ChatGoogleVertexAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleVertexAI/ChatGoogleVertexAI.ts
@@ -14,9 +14,6 @@ import {
 import { getModels, getRegions, MODEL_TYPE } from '../../../src/modelLoader'
 import { getBaseClasses } from '../../../src/utils'
 
-const DEFAULT_IMAGE_MAX_TOKEN = 8192
-const DEFAULT_IMAGE_MODEL = 'gemini-1.5-flash-latest'
-
 class ChatVertexAI extends LcChatVertexAI implements IVisionChatModal {
     configuredModel: string
     configuredMaxToken: number
@@ -35,20 +32,8 @@ class ChatVertexAI extends LcChatVertexAI implements IVisionChatModal {
         this.configuredMaxToken = fields?.maxOutputTokens ?? 2048
     }
 
-    revertToOriginalModel(): void {
-        this.modelName = this.configuredModel
-        this.maxOutputTokens = this.configuredMaxToken
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        if (!this.modelName.startsWith('claude-3')) {
-            this.modelName = DEFAULT_IMAGE_MODEL
-            this.maxOutputTokens = this.configuredMaxToken ? this.configuredMaxToken : DEFAULT_IMAGE_MAX_TOKEN
-        }
     }
 }
 

--- a/packages/components/nodes/chatmodels/ChatOllama/FlowiseChatOllama.ts
+++ b/packages/components/nodes/chatmodels/ChatOllama/FlowiseChatOllama.ts
@@ -13,15 +13,7 @@ export class ChatOllama extends LCChatOllama implements IVisionChatModal {
         this.configuredModel = fields?.model ?? ''
     }
 
-    revertToOriginalModel(): void {
-        this.model = this.configuredModel
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        // pass
     }
 }

--- a/packages/components/nodes/chatmodels/ChatOpenAI/FlowiseChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/FlowiseChatOpenAI.ts
@@ -15,17 +15,8 @@ export class ChatOpenAI extends LangchainChatOpenAI implements IVisionChatModal 
         this.configuredMaxToken = fields?.maxTokens
     }
 
-    revertToOriginalModel(): void {
-        this.model = this.configuredModel
-        this.maxTokens = this.configuredMaxToken
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        // pass
     }
 
     addBuiltInTools(builtInTool: Record<string, any>): void {

--- a/packages/components/nodes/chatmodels/ChatOpenRouter/FlowiseChatOpenRouter.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenRouter/FlowiseChatOpenRouter.ts
@@ -14,16 +14,7 @@ export class ChatOpenRouter extends LangchainChatOpenAI implements IVisionChatMo
         this.configuredMaxToken = fields?.maxTokens
     }
 
-    revertToOriginalModel(): void {
-        this.model = this.configuredModel
-        this.maxTokens = this.configuredMaxToken
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        // pass - OpenRouter models don't need model switching
     }
 }

--- a/packages/components/nodes/chatmodels/ChatPerplexity/FlowiseChatPerplexity.ts
+++ b/packages/components/nodes/chatmodels/ChatPerplexity/FlowiseChatPerplexity.ts
@@ -15,18 +15,8 @@ export class ChatPerplexity extends LangchainChatPerplexity implements IVisionCh
         this.configuredMaxToken = fields?.maxTokens
     }
 
-    // Method to revert to the original model configuration
-    revertToOriginalModel(): void {
-        this.model = this.configuredModel
-        this.maxTokens = this.configuredMaxToken
-    }
-
     // Method to set multimodal options
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        // pass
     }
 }

--- a/packages/components/nodes/chatmodels/ChatXAI/FlowiseChatXAI.ts
+++ b/packages/components/nodes/chatmodels/ChatXAI/FlowiseChatXAI.ts
@@ -14,16 +14,7 @@ export class ChatXAI extends LCChatXAI implements IVisionChatModal {
         this.configuredMaxToken = fields?.maxTokens
     }
 
-    revertToOriginalModel(): void {
-        this.model = this.configuredModel
-        this.maxTokens = this.configuredMaxToken
-    }
-
     setMultiModalOption(multiModalOption: IMultiModalOption): void {
         this.multiModalOption = multiModalOption
-    }
-
-    setVisionModel(): void {
-        // pass
     }
 }

--- a/packages/components/nodes/multiagents/Supervisor/Supervisor.ts
+++ b/packages/components/nodes/multiagents/Supervisor/Supervisor.ts
@@ -2,16 +2,7 @@ import { flatten } from 'lodash'
 import { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { Runnable, RunnableConfig } from '@langchain/core/runnables'
 import { ChatPromptTemplate, MessagesPlaceholder, HumanMessagePromptTemplate } from '@langchain/core/prompts'
-import {
-    ICommonObject,
-    IMultiAgentNode,
-    INode,
-    INodeData,
-    INodeParams,
-    ITeamState,
-    IVisionChatModal,
-    MessageContentImageUrl
-} from '../../../src/Interface'
+import { ICommonObject, IMultiAgentNode, INode, INodeData, INodeParams, ITeamState, MessageContentImageUrl } from '../../../src/Interface'
 import { Moderation } from '../../moderation/Moderation'
 import { z } from 'zod/v3'
 import { StructuredTool } from '@langchain/core/tools'
@@ -709,17 +700,11 @@ const processImageMessage = async (
     let multiModalMessageContent: MessageContentImageUrl[] = []
 
     if (llmSupportsVision(llm)) {
-        const visionChatModel = llm as IVisionChatModal
         multiModalMessageContent = await addImagesToMessages(nodeData, options, llm.multiModalOption)
 
         if (multiModalMessageContent?.length) {
-            visionChatModel.setVisionModel()
-
             const msg = HumanMessagePromptTemplate.fromTemplate([...multiModalMessageContent])
-
             prompt.promptMessages.splice(index, 0, msg)
-        } else {
-            visionChatModel.revertToOriginalModel()
         }
     }
 

--- a/packages/components/nodes/sequentialagents/commonUtils.ts
+++ b/packages/components/nodes/sequentialagents/commonUtils.ts
@@ -8,14 +8,7 @@ import { Runnable, RunnableConfig, mergeConfigs } from '@langchain/core/runnable
 import { AIMessage, BaseMessage, HumanMessage, MessageContentImageUrl, ToolMessage } from '@langchain/core/messages'
 import { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { addImagesToMessages, llmSupportsVision } from '../../src/multiModalUtils'
-import {
-    ICommonObject,
-    IDatabaseEntity,
-    INodeData,
-    ISeqAgentsState,
-    IVisionChatModal,
-    ConversationHistorySelection
-} from '../../src/Interface'
+import { ICommonObject, IDatabaseEntity, INodeData, ISeqAgentsState, ConversationHistorySelection } from '../../src/Interface'
 import { getVars, executeJavaScriptCode, createCodeExecutionSandbox } from '../../src/utils'
 import { ChatPromptTemplate, BaseMessagePromptTemplateLike } from '@langchain/core/prompts'
 
@@ -136,14 +129,7 @@ export const processImageMessage = async (llm: BaseChatModel, nodeData: INodeDat
     let multiModalMessageContent: MessageContentImageUrl[] = []
 
     if (llmSupportsVision(llm)) {
-        const visionChatModel = llm as IVisionChatModal
         multiModalMessageContent = await addImagesToMessages(nodeData, options, llm.multiModalOption)
-
-        if (multiModalMessageContent?.length) {
-            visionChatModel.setVisionModel()
-        } else {
-            visionChatModel.revertToOriginalModel()
-        }
     }
 
     return multiModalMessageContent

--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -413,8 +413,6 @@ export interface IVisionChatModal {
     configuredModel: string
     multiModalOption: IMultiModalOption
     configuredMaxToken?: number
-    setVisionModel(): void
-    revertToOriginalModel(): void
     setMultiModalOption(multiModalOption: IMultiModalOption): void
 }
 

--- a/packages/components/src/multiModalUtils.ts
+++ b/packages/components/src/multiModalUtils.ts
@@ -48,4 +48,5 @@ export const getImageUploads = (uploads: IFileUpload[]) => {
     return uploads.filter((upload: IFileUpload) => upload.mime.startsWith('image/'))
 }
 
-export const llmSupportsVision = (value: any): value is IVisionChatModal => !!value?.multiModalOption
+export const llmSupportsVision = (value: any): value is IVisionChatModal =>
+    !!value?.multiModalOption && value.multiModalOption.image?.allowImageUploads === true


### PR DESCRIPTION
Previously, only certain models supported image input. To ensure a smooth UI/UX, we silently switched to a default vision model when images were detected. Now that most models support image input and legacy models have been deprecated, this redundant check is no longer necessary and has been removed.