### PR TITLE
fix: prevent raw AIMessage JSON from being displayed in chat when using Gemini with Retriever Tool

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -1336,11 +1336,14 @@ class Agent_Agentflow implements INode {
                 finalResponse = processedParts.filter((text) => text).join('\n')
             } else if (response.content && typeof response.content === 'string') {
                 finalResponse = response.content
-            } else if (response.content === '') {
+            } else if (response.content === '' || response.content == null) {
                 // Empty response content, this could happen when there is only image data
+                // or when content is null/undefined (e.g., when there are only tool_calls)
                 finalResponse = ''
             } else {
-                finalResponse = JSON.stringify(response, null, 2)
+                // Fallback: extract text content using the utility function
+                // instead of serializing the entire response object
+                finalResponse = extractResponseContent(response)
             }
 
             // Address built in tools

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -854,7 +854,8 @@ export const executeFlow = async ({
                     logger.log('[server]: Post Processing Error:', e)
                 }
             }
-        } else if (result.json) resultText = '```json\n' + JSON.stringify(result.json, null, 2)
+        } else if (result.json) resultText = '```json\n' + JSON.stringify(result.json, null, 2) + '\n```'
+        else if (result.content) resultText = result.content
         else resultText = JSON.stringify(result, null, 2)
 
         const apiMessage: Omit<IChatMessage, 'createdDate'> = {


### PR DESCRIPTION
## Issue

Fixes #5982

When using the **ChatGemini** (Google Generative AI) node in a chatflow connected to a **Knowledge Base/Retriever Tool**, the chat interface displays the raw `AIMessage` JSON object (including `tool_calls` and `thoughtSignature`) instead of hiding the intermediate thought process and showing only the final retrieved answer.

## Root Cause

The bug was in the Agent node code (`packages/components/nodes/agentflow/Agent/Agent.ts`). When the response content was `null` or `undefined` (which can happen when there are only tool_calls without text content), the code fell back to serializing the entire response object using `JSON.stringify(response, null, 2)`. This resulted in the raw LangChain AIMessage object (with `lc`, `type`, `id`, `kwargs` properties) being displayed in the chat.

## Changes

### 1. Agent.ts (lines 1339-1346)
- Added check for `null`/`undefined` content to return empty string instead of serializing the response
- Changed fallback from `JSON.stringify(response, null, 2)` to `extractResponseContent(response)`, which properly extracts text content without serializing the entire object

### 2. buildChatflow.ts (lines 857-859)
- Added check for `result.content` before falling back to serializing the entire result object
- This provides an additional safety net for nodes that return `content` instead of `text`

## Testing

The fix ensures that:
1. When content is `null`/`undefined` (e.g., tool-only responses), an empty string is returned instead of serializing the AIMessage
2. The `extractResponseContent` utility function properly handles complex content arrays and extracts only the text parts
3. Agent nodes returning `content` are properly handled in the chatflow execution

---

This fix is submitted by [ClawOSS](https://github.com/kevinlin/clawOSS), an autonomous codebase helper.
