### PR TITLE
fix: fallback to weak defaults when JWT secrets not initialized

### DIFF
--- a/packages/server/src/enterprise/utils/authSecrets.ts
+++ b/packages/server/src/enterprise/utils/authSecrets.ts
@@ -80,12 +80,17 @@ export function getExpressSessionSecret(): string {
 }
 
 export function getJWTAuthTokenSecret(): string {
-    if (jwtAuthTokenSecret === undefined) throw new Error(NOT_INITIALIZED)
+    if (jwtAuthTokenSecret === undefined) {
+        // Fallback to weak default if initialization failed (e.g., docker with default .env)
+        return WEAK_DEFAULTS.JWT_AUTH_TOKEN_SECRET
+    }
     return jwtAuthTokenSecret
 }
 
 export function getJWTRefreshTokenSecret(): string {
-    if (jwtRefreshTokenSecret === undefined) throw new Error(NOT_INITIALIZED)
+    if (jwtRefreshTokenSecret === undefined) {
+        return WEAK_DEFAULTS.JWT_REFRESH_TOKEN_SECRET
+    }
     return jwtRefreshTokenSecret
 }
 


### PR DESCRIPTION
## Description

When running docker-compose without setting JWT env vars, `initAuthSecrets()` may fail to initialize secrets, causing `JwtStrategy requires a secret or key` error on startup.

## Fix

This PR adds fallback to weak default values (same as WEAK_DEFAULTS) instead of throwing an error, making docker-compose work out of the box.

## Changes

- `getJWTAuthTokenSecret()`: Returns `WEAK_DEFAULTS.JWT_AUTH_TOKEN_SECRET` instead of throwing when undefined
- `getJWTRefreshTokenSecret()`: Returns `WEAK_DEFAULTS.JWT_REFRESH_TOKEN_SECRET` instead of throwing when undefined

## Fixes

Fixes #4563

## Testing

This fix was tested by attempting to run `docker compose up -d` without JWT env vars set, confirming the server starts successfully.