### PR TITLE
fix (AgentFlow) - generate ArrayInput item keys synchronously to prevent missing React keys

### DIFF
--- a/packages/agentflow/README.md
+++ b/packages/agentflow/README.md
@@ -21,6 +21,22 @@
 
 `@flowiseai/agentflow` is a React-based flow editor for creating AI agent workflows. It provides a visual canvas built on ReactFlow for connecting AI agents, LLMs, tools, and logic nodes.
 
+## Features
+
+-   **Visual Canvas** — Drag-and-drop flow editor built on ReactFlow with zoom, pan, minimap, and fit-to-view controls
+-   **15 Built-in Node Types** — Start, Agent, LLM, Condition, Condition Agent, Human Input, Loop, Direct Reply, Custom Function, Tool, Retriever, Sticky Note, HTTP, Iteration, and Execute Flow
+-   **Node Editor Dialog** — Modal for editing node parameters with dynamic input types (text, number, boolean, dropdown, arrays, async options)
+-   **Rich Text Editor** — TipTap-based editor with syntax highlighting for JavaScript, TypeScript, Python, and JSON (lazy-loaded)
+-   **Specialized Input Components** — Condition builder, messages input (role + content), and structured output schema builder
+-   **AI Flow Generator** — Generate flows from natural language descriptions with model selection
+-   **Flow Validation** — Detects empty flows, missing start nodes, disconnected nodes, cycles, hanging edges, and per-node input errors with visual feedback
+-   **Dark Mode** — Full light/dark theme support via design tokens and CSS variables
+-   **Read-Only Mode** — Disable editing for view-only embedding
+-   **Custom Rendering** — Replace the default header and node palette with your own components via render props
+-   **Imperative API** — Programmatic control via ref (`getFlow`, `validate`, `fitView`, `clear`, `addNode`, `toJSON`)
+-   **Request Interceptor** — Customize outgoing API requests (headers, credentials) via an Axios interceptor callback
+-   **Keyboard Shortcuts** — Cmd/Ctrl+S to save
+
 ## Installation
 
 ```bash
@@ -139,9 +155,47 @@ The `requestInterceptor` callback runs inside the Axios request pipeline and has
 -   Follow the **principle of least privilege** — only read or modify the specific config properties you need (e.g., `withCredentials`, custom headers).
 -   If the interceptor throws, the error is caught, logged, and the **original unmodified config** is used so the request still proceeds safely.
 
+### Node Types
+
+The following node types are available in the palette by default. Use the `components` prop to restrict which types are shown.
+
+<!-- prettier-ignore -->
+| Node Type                  | Description                          |
+| -------------------------- | ------------------------------------ |
+| `startAgentflow`           | Entry point (required, always shown) |
+| `agentAgentflow`           | AI agent execution                   |
+| `llmAgentflow`             | LLM / language model call            |
+| `conditionAgentflow`       | Conditional branching                |
+| `conditionAgentAgentflow`  | Agent-level conditional branching    |
+| `humanInputAgentflow`      | Wait for user input                  |
+| `loopAgentflow`            | Loop / iteration                     |
+| `directReplyAgentflow`     | Direct response to user              |
+| `customFunctionAgentflow`  | Custom JavaScript function           |
+| `toolAgentflow`            | Tool integration                     |
+| `retrieverAgentflow`       | Data retrieval                       |
+| `stickyNoteAgentflow`      | Canvas annotation (not connectable)  |
+| `httpAgentflow`            | HTTP request                         |
+| `iterationAgentflow`       | Iteration / map-reduce container     |
+| `executeFlowAgentflow`     | Execute a sub-flow                   |
+
 ### Design Note
 
 `<Agentflow>` is an **uncontrolled component**. The `initialFlow` prop seeds the canvas state on mount, but the component owns its own state afterward. Use the `ref` for imperative access and `onFlowChange` to observe changes.
+
+## Exports
+
+Beyond the main `<Agentflow>` component, the package exports utilities for advanced usage:
+
+```ts
+// Main component and provider
+// Types
+
+// Hooks
+// Validation
+// Node utilities
+
+// Field visibility helpers
+```
 
 ## Development
 

--- a/packages/agentflow/vite.config.ts
+++ b/packages/agentflow/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(({ mode }) => {
             dts({
                 insertTypesEntry: true,
                 include: ['src/**/*'],
-                exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/__test_utils__/**']
+                exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/__*__/**']
             })
         ],
         resolve: {


### PR DESCRIPTION
Moved key generation from useEffect to render body in ArrayInput, matching the existing pattern in MessagesInput. The effect ran after paint, so newly added items rendered with key={undefined} on their first frame.


https://github.com/user-attachments/assets/955ea563-93a3-48a5-a7e1-49e5b2823943

