### PR TITLE
fix(components): add missing opik key to returnIds in AnalyticHandler.onLLMStart

### DIFF
--- a/packages/components/src/handler.ts
+++ b/packages/components/src/handler.ts
@@ -1309,7 +1309,8 @@ export class AnalyticHandler {
             lunary: {},
             langWatch: {},
             arize: {},
-            phoenix: {}
+            phoenix: {},
+            opik: {}
         }
 
         if (Object.prototype.hasOwnProperty.call(this.handlers, 'langSmith')) {


### PR DESCRIPTION
## Summary
AnalyticHandler.onLLMStart() in packages/components/src/handler.ts initializes a returnIds object that is missing the opik: {} entry. When the Opik analytics provider is enabled, the code later attempts to set returnIds['opik'].llmSpan, which throws TypeError: Cannot set properties of undefined (setting 'llmSpan').

All sibling methods (onChainStart, onToolStart) correctly include opik in their returnIds initialization. This was a copy-paste omission.

## Changes
Added opik: {} to the returnIds object in onLLMStart() (line 1312)
## How to reproduce the bug
1. Configure Opik as an analytics provider in a chatflow
2. Trigger a prediction that invokes LLM
3. onLLMStart throws TypeError, breaking analytics tracking