### PR TITLE
fix(server): use fileInputFieldFromMimeType in MIME type fallback branch

### DIFF
--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1863,7 +1863,7 @@ const upsertDocStore = async (
             if (fileInputFieldFromExt !== 'txtFile') {
                 fileInputField = fileInputFieldFromExt
             } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                fileInputField = fileInputFieldFromExt
+                fileInputField = fileInputFieldFromMimeType
             }
 
             if (loaderId === 'unstructuredFileLoader') {

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -448,7 +448,7 @@ export const executeFlow = async ({
             if (fileInputFieldFromExt !== 'txtFile') {
                 fileInputField = fileInputFieldFromExt
             } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                fileInputField = fileInputFieldFromExt
+                fileInputField = fileInputFieldFromMimeType
             }
 
             if (overrideConfig[fileInputField]) {

--- a/packages/server/src/utils/createAttachment.ts
+++ b/packages/server/src/utils/createAttachment.ts
@@ -177,7 +177,7 @@ export const createFileAttachment = async (req: Request) => {
             if (fileInputFieldFromExt !== 'txtFile') {
                 fileInputField = fileInputFieldFromExt
             } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                fileInputField = fileInputFieldFromExt
+                fileInputField = fileInputFieldFromMimeType
             }
 
             await removeSpecificFileFromUpload(file.path ?? file.key)

--- a/packages/server/src/utils/upsertVector.ts
+++ b/packages/server/src/utils/upsertVector.ts
@@ -96,7 +96,7 @@ export const executeUpsert = async ({
             if (fileInputFieldFromExt !== 'txtFile') {
                 fileInputField = fileInputFieldFromExt
             } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                fileInputField = fileInputFieldFromExt
+                fileInputField = fileInputFieldFromMimeType
             }
 
             if (overrideConfig[fileInputField]) {


### PR DESCRIPTION
## Summary
When processing file uploads, the code determines the correct input field using a two-step fallback: first by file extension, then by MIME type. However, in the MIME type fallback branch (else if), the code incorrectly assigns fileInputFieldFromExt (which is 'txtFile' at that point) instead of fileInputFieldFromMimeType.

This means when a file has an unrecognized extension but a recognized MIME type, the MIME type detection result is silently ignored and the file is always treated as a text file.

The same copy-paste bug exists in 4 files:

- packages/server/src/utils/buildChatflow.ts
- packages/server/src/utils/createAttachment.ts
- packages/server/src/services/documentstore/index.ts
- packages/server/src/utils/upsertVector.ts
## Changes
Changed fileInputField = fileInputFieldFromExt to fileInputField = fileInputFieldFromMimeType in the else if (fileInputFieldFromMimeType !== 'txtFile') branch across all 4 files.

## How to reproduce the bug
- Upload a file with an unusual extension but a standard MIME type (e.g., a .dat file with image/png MIME type)
- The file is incorrectly classified as txtFile instead of the correct image input field