### PR TITLE
Bugfix/ChatAnthropic: reject invalid top_p, top_k, temperature values

### DIFF
--- a/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
@@ -197,15 +197,21 @@ class ChatAnthropic_ChatModels implements INode {
         const allowImageUploads = nodeData.inputs?.allowImageUploads as boolean
 
         const obj: Partial<AnthropicInput> & BaseLLMParams & { anthropicApiKey?: string } = {
-            temperature: parseFloat(temperature),
             modelName,
             anthropicApiKey,
             streaming: streaming ?? true
         }
 
+        const parsedTemperature = parseFloat(temperature)
+        if (!isNaN(parsedTemperature)) obj.temperature = parsedTemperature
+
         if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
-        if (topP) obj.topP = parseFloat(topP)
-        if (topK) obj.topK = parseFloat(topK)
+
+        const parsedTopP = parseFloat(topP)
+        if (!isNaN(parsedTopP) && parsedTopP >= 0) obj.topP = parsedTopP
+
+        const parsedTopK = parseFloat(topK)
+        if (!isNaN(parsedTopK) && parsedTopK >= 0) obj.topK = parsedTopK
         if (cache) obj.cache = cache
 
         if (adaptiveThinking) {

--- a/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic_LlamaIndex.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic_LlamaIndex.ts
@@ -88,13 +88,17 @@ class ChatAnthropic_LlamaIndex_ChatModels implements INode {
         const anthropicApiKey = getCredentialParam('anthropicApiKey', credentialData, nodeData)
 
         const obj: Partial<Anthropic> = {
-            temperature: parseFloat(temperature),
             model: modelName,
             apiKey: anthropicApiKey
         }
 
+        const parsedTemperature = parseFloat(temperature)
+        if (!isNaN(parsedTemperature)) obj.temperature = parsedTemperature
+
         if (maxTokensToSample) obj.maxTokens = parseInt(maxTokensToSample, 10)
-        if (topP) obj.topP = parseFloat(topP)
+
+        const parsedTopP = parseFloat(topP)
+        if (!isNaN(parsedTopP) && parsedTopP >= 0) obj.topP = parsedTopP
 
         const model = new Anthropic(obj)
         return model


### PR DESCRIPTION
Fixes #5998

ChatAnthropic was sending `top_p: -1` to the Anthropic API because invalid numeric values were not validated before being passed to the constructor.

**Changes:**
- Validate `top_p` and `top_k` with `!isNaN()` and `>= 0` checks (previously only a truthy check)
- Guard `temperature` with `!isNaN()` (was set unconditionally, could produce `NaN`)
- Same fix applied to `ChatAnthropic_LlamaIndex.ts`