### PR TITLE
Replace zai-glm-4.6 (deprecated) with zai-glm-4.7 cerebras

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,5 +132,6 @@
                 }
             ]
         ]
-    }
+    },
+    "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
 }

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1207,8 +1207,8 @@
                     "description": "Largest model for demanding tasks"
                 },
                 {
-                    "label": "zai-glm-4.6",
-                    "name": "zai-glm-4.6",
+                    "label": "zai-glm-4.7",
+                    "name": "zai-glm-4.7",
                     "description": "Advanced reasoning and complex problem-solving"
                 }
             ]


### PR DESCRIPTION
Replace model version from zai-glm-4.6 (deprecated) to zai-glm-4.7 in models.json for cerebras