### PR TITLE
Replace zai-glm-4.6 (deprecated) with zai-glm-4.7 cerebras

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1207,8 +1207,8 @@
                     "description": "Largest model for demanding tasks"
                 },
                 {
-                    "label": "zai-glm-4.6",
-                    "name": "zai-glm-4.6",
+                    "label": "zai-glm-4.7",
+                    "name": "zai-glm-4.7",
                     "description": "Advanced reasoning and complex problem-solving"
                 }
             ]


### PR DESCRIPTION
Replace model version from zai-glm-4.6 (deprecated) to zai-glm-4.7 in models.json for cerebras