### PR TITLE
chore: add OpenAI gpt-5.4-mini and gpt-5.4-nano models

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1246,6 +1246,18 @@
                     "output_cost": 0.00018
                 },
                 {
+                    "label": "gpt-5.4-mini",
+                    "name": "gpt-5.4-mini",
+                    "input_cost": 0.00000075,
+                    "output_cost": 0.0000045
+                },
+                {
+                    "label": "gpt-5.4-nano",
+                    "name": "gpt-5.4-nano",
+                    "input_cost": 0.0000002,
+                    "output_cost": 0.00000125
+                },
+                {
                     "label": "gpt-5.2",
                     "name": "gpt-5.2",
                     "input_cost": 0.00000175,


### PR DESCRIPTION
## Summary
- Add `gpt-5.4-mini` and `gpt-5.4-nano` to the ChatOpenAI model list in `models.json`
- Set correct pricing based on OpenAI's published rates:
  - **gpt-5.4-mini**: $0.75/MTok input, $4.50/MTok output
  - **gpt-5.4-nano**: $0.20/MTok input, $1.25/MTok output

## References
- https://developers.openai.com/api/docs/models/gpt-5.4-mini
- https://developers.openai.com/api/docs/models/gpt-5.4-nano