### PR TITLE
fix: handle empty/whitespace LOG_PATH in docker compose

### DIFF
--- a/packages/server/src/utils/config.ts
+++ b/packages/server/src/utils/config.ts
@@ -7,7 +7,7 @@ dotenv.config({ path: path.join(__dirname, '..', '..', '.env'), override: true }
 
 // default config
 const loggingConfig = {
-    dir: process.env.LOG_PATH ?? path.join(__dirname, '..', '..', 'logs'),
+    dir: process.env.LOG_PATH?.trim() || path.join(__dirname, '..', '..', 'logs'),
     server: {
         level: process.env.LOG_LEVEL ?? 'info',
         filename: 'server.log',


### PR DESCRIPTION
## Summary

When `LOG_PATH` is set to an empty string in docker-compose (e.g. `LOG_PATH=${LOG_PATH}` with an unset `LOG_PATH` env var), the Flowise container fails to start with:

```
Error: ENOENT: no such file or directory, mkdir ''
    at Object.mkdirSync (node:fs:1386:26)
```

## Root Cause

In `packages/server/src/utils/config.ts`, the nullish coalescing operator `??` only handles `undefined` and `null`, but NOT empty strings:

```typescript
dir: process.env.LOG_PATH ?? path.join(__dirname, '..', '..', 'logs'),
```

When `LOG_PATH=` (empty string), `??` returns `""` -> `mkdirSync("")` fails.

## Fix

Use optional chaining + trim + logical OR to properly handle empty strings and whitespace-only values:

```typescript
dir: process.env.LOG_PATH?.trim() || path.join(__dirname, '..', '..', 'logs'),
```

This ensures that:
- `undefined` -> uses default
- `null` -> uses default
- `""` (empty) -> uses default
- `"   "` (whitespace) -> uses default
- `"/valid/path"` -> uses provided path

## Testing

1. `LOG_PATH=` (empty) -> uses default `./logs`
2. `LOG_PATH="   "` (whitespace) -> uses default
3. `LOG_PATH=/my/path` -> uses provided path

Fixes #6030
