### PR TITLE
fix: apply pagination to non-feedback chat message queries to prevent OOM

### DIFF
--- a/packages/server/src/controllers/chat-messages/index.ts
+++ b/packages/server/src/controllers/chat-messages/index.ts
@@ -122,6 +122,7 @@ const getAllInternalChatMessages = async (req: Request, res: Response, next: Nex
         if (feedbackTypeFilters) {
             feedbackTypeFilters = getFeedbackTypeFilters(feedbackTypeFilters)
         }
+        const { page, limit } = getPageAndLimitParams(req)
         const apiResponse = await chatMessagesService.getAllInternalChatMessages(
             req.params.id,
             [ChatType.INTERNAL],
@@ -134,7 +135,9 @@ const getAllInternalChatMessages = async (req: Request, res: Response, next: Nex
             messageId,
             feedback,
             feedbackTypeFilters,
-            activeWorkspaceId
+            activeWorkspaceId,
+            page,
+            limit
         )
         return res.json(parseAPIResponse(apiResponse))
     } catch (error) {

--- a/packages/server/src/services/chat-messages/index.ts
+++ b/packages/server/src/services/chat-messages/index.ts
@@ -81,7 +81,9 @@ const getAllInternalChatMessages = async (
     messageId?: string,
     feedback?: boolean,
     feedbackTypes?: ChatMessageRatingType[],
-    activeWorkspaceId?: string
+    activeWorkspaceId?: string,
+    page?: number,
+    pageSize?: number
 ): Promise<ChatMessage[]> => {
     try {
         const dbResponse = await utilGetChatMessage({
@@ -96,7 +98,9 @@ const getAllInternalChatMessages = async (
             messageId,
             feedback,
             feedbackTypes,
-            activeWorkspaceId
+            activeWorkspaceId,
+            page,
+            pageSize
         })
         return dbResponse
     } catch (error) {

--- a/packages/server/src/utils/getChatMessage.ts
+++ b/packages/server/src/utils/getChatMessage.ts
@@ -100,6 +100,8 @@ export const utilGetChatMessage = async ({
         }
     }
 
+    const shouldPaginate = page > -1 && pageSize > -1
+
     const messages = await appServer.AppDataSource.getRepository(ChatMessage).find({
         where: {
             chatflowid,
@@ -115,7 +117,9 @@ export const utilGetChatMessage = async ({
         },
         order: {
             createdDate: sortOrder === 'DESC' ? 'DESC' : 'ASC'
-        }
+        },
+        skip: shouldPaginate ? pageSize * (page - 1) : undefined,
+        take: shouldPaginate ? pageSize : undefined
     })
 
     return messages


### PR DESCRIPTION
## Summary
OOM crash in Chat Messages panel when database has large volume of messages

## Root Cause
In `packages/server/src/utils/getChatMessage.ts`, the `utilGetChatMessage` function accepted `page` and `pageSize` parameters but only applied them in the `handleFeedbackQuery` path (when `feedback=true`).

When `feedback=false` (the default — the main ViewMessagesDialog path), the query used `.find({})` with **no pagination**, loading **all matching messages** into memory.

Additionally, `getAllInternalChatMessages` in the controller never passed `page`/`limit` to the service at all.

## Fix
1. **`getChatMessage.ts`**: Added `skip`/`take` to the non-feedback `.find()` query when `page > -1 && pageSize > -1` (sentinel values from `getPageAndLimitParams`).
2. **`controllers/chat-messages/index.ts`**: `getAllInternalChatMessages` now calls `getPageAndLimitParams(req)` and passes `page`/`limit` to the service.
3. **`services/chat-messages/index.ts`**: `getAllInternalChatMessages` now accepts and forwards `page`/`pageSize` to `utilGetChatMessage`.

The `ViewMessagesDialog` UI already passes `page` and `limit` correctly — the backend was just ignoring them in the non-feedback path.

## Files Changed
- `packages/server/src/utils/getChatMessage.ts` — core fix
- `packages/server/src/services/chat-messages/index.ts` — add page/pageSize to internal messages service
- `packages/server/src/controllers/chat-messages/index.ts` — read and pass pagination params

Fixes #6038