### PR TITLE
feat: allow custom Cohere rerank model names

### DIFF
--- a/packages/components/nodes/retrievers/CohereRerankRetriever/CohereRerankRetriever.ts
+++ b/packages/components/nodes/retrievers/CohereRerankRetriever/CohereRerankRetriever.ts
@@ -43,21 +43,10 @@ class CohereRerankRetriever_Retrievers implements INode {
             {
                 label: 'Model Name',
                 name: 'model',
-                type: 'options',
-                options: [
-                    {
-                        label: 'rerank-v3.5',
-                        name: 'rerank-v3.5'
-                    },
-                    {
-                        label: 'rerank-english-v3.0',
-                        name: 'rerank-english-v3.0'
-                    },
-                    {
-                        label: 'rerank-multilingual-v3.0',
-                        name: 'rerank-multilingual-v3.0'
-                    }
-                ],
+                type: 'string',
+                placeholder: 'rerank-v3.5',
+                description:
+                    'Name of the Cohere rerank model. Defaults to rerank-v3.5. Supports custom fine-tuned rerank models.',
                 default: 'rerank-v3.5',
                 optional: true
             },


### PR DESCRIPTION
Fixes #4086

## Problem

The Cohere Rerank Retriever node's Model Name field is a hardcoded dropdown with only 3 options (rerank-v3.5, rerank-english-v3.0, rerank-multilingual-v3.0). Users with [custom fine-tuned Cohere rerank models](https://docs.cohere.com/docs/rerank-fine-tuning) cannot enter their model name.

## Fix

Change the Model Name field from \	ype: 'options'\ to \	ype: 'string'\ with a default of \erank-v3.5\. This allows users to:
- Use the default model by leaving the field empty
- Enter any custom fine-tuned model name directly

## Change

1 file, 1 field type change in \CohereRerankRetriever.ts\:

\\\diff
- type: 'options',
- options: [{ label: 'rerank-v3.5', ... }, ...]
+ type: 'string',
+ placeholder: 'rerank-v3.5',
+ description: 'Name of the Cohere rerank model. Defaults to rerank-v3.5. Supports custom fine-tuned rerank models.',
\\\

No backend changes needed -- the model name string is already passed through to the Cohere API unchanged.