### PR TITLE
fix(models): correct sonar-deep-research model name in Perplexity config

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1629,7 +1629,7 @@
                 },
                 {
                     "label": "sonar-deep-research",
-                    "name": "sonar",
+                    "name": "sonar-deep-research",
                     "input_cost": 2e-6,
                     "output_cost": 8e-6
                 },


### PR DESCRIPTION
The `sonar-deep-research` entry under `chatPerplexity` in `models.json` had its `name` field incorrectly set to `"sonar"` instead of `"sonar-deep-research"`.

### Impact
This fix addresses two significant issues:
1. **Functional Bug**: Users selecting "Sonar Deep Research" in the UI were actually hitting the regular `sonar` API endpoint, resulting in lower-quality search results than expected.
2. **Data Collision**: It caused a duplicate `name` collision with the existing `sonar` entry at line 1608, which led to incorrect cost calculations and model lookups within the `modelLoader`.

### Changes
- Updated `packages/components/models.json` to change the `name` field for the `sonar-deep-research` label from `"sonar"` to `"sonar-deep-research"`.

### Bug Reproduction
The video below demonstrates the issue, when selecting `sonar-deep-research` from the model dropdown, the API request is sent with `"sonar"` as the model identifier instead of `"sonar-deep-research"`:


https://github.com/user-attachments/assets/270d7ec9-57b5-4259-8b65-e43235f51d35


