### PR TITLE
fix(docker): uncomment JWT secrets in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -101,8 +101,9 @@ PORT=3000
 
 # Auth secrets: set via env (backwards compat) or leave unset to use file/AWS storage (SECRETKEY_PATH or SECRETKEY_STORAGE_TYPE=aws)
 # Generate a secure 32-byte secret using: openssl rand -hex 32
-# JWT_AUTH_TOKEN_SECRET=
-# JWT_REFRESH_TOKEN_SECRET=
+# REQUIRED for docker compose deployments (v3.0.1+):JwtStrategy requires these secrets
+JWT_AUTH_TOKEN_SECRET=
+JWT_REFRESH_TOKEN_SECRET=
 
 JWT_ISSUER=Flowise
 JWT_AUDIENCE=Flowise


### PR DESCRIPTION
## Summary
JwtStrategy requires `JWT_AUTH_TOKEN_SECRET` and `JWT_REFRESH_TOKEN_SECRET` in v3.0.1+.
Without these, `docker compose up` fails with `TypeError: JwtStrategy requires a secret or key`.

This was a breaking change in v3.0.1 — users following the same setup as before would hit the error because `.env.example` had these lines commented out.

## Fix
Uncommented the JWT secret lines in `docker/.env.example` and added a clarifying comment noting they are required for docker compose deployments (v3.0.1+).

## Testing
- Verified the fix locally by checking that the `.env.example` now includes uncommented JWT secret placeholders.

## Closes
Closes #4563