### PR TITLE
fix: return 401 in getAllPermissions when user is not authenticated

### DIFF
--- a/packages/server/src/enterprise/controllers/auth/index.ts
+++ b/packages/server/src/enterprise/controllers/auth/index.ts
@@ -11,6 +11,10 @@ const getAllPermissions = async (req: Request, res: Response, next: NextFunction
         const allPermissions = appServer.identityManager.getPermissions().toJSON()
         const user = req.user as LoggedInUser
 
+        if (!user) {
+            return res.status(StatusCodes.UNAUTHORIZED).json({ message: 'Unauthorized' })
+        }
+
         let permissions: { [key: string]: { key: string; value: string }[] } = allPermissions
 
         // Mapping of feature flags to permission prefixes


### PR DESCRIPTION
Fixes #6105

## Problem

`GET /api/v1/auth/resolve` returns a 500 Internal Server Error with message:
> Cannot read properties of undefined (reading 'isOrganizationAdmin')

**Root cause:** `/api/v1/auth/resolve` is added to the whitelist (unauthenticated passthrough), intended for the `POST /api/v1/auth/resolve` handler. However, a `GET` request to the same path also bypasses authentication and matches the `GET /api/v1/auth/:type` route with `type='resolve'`. This calls `getAllPermissions()` where `req.user` is `undefined`, leading to the crash at:

```ts
if (type !== 'ROLE' && user.isOrganizationAdmin === false) {
```

This causes the login page to fail when the UI or tooling makes an unauthenticated GET to this endpoint.

## Solution

Add an early null check in `getAllPermissions` to return `401 Unauthorized` if `req.user` is not set, instead of crashing with a 500.

```ts
if (!user) {
    return res.status(StatusCodes.UNAUTHORIZED).json({ message: 'Unauthorized' })
}
```

This is a minimal defensive fix that makes the endpoint robust against unauthenticated requests regardless of how they reach the handler.

## Testing

- Fresh install of Flowise 3.x: `GET /api/v1/auth/resolve` now returns `401` instead of `500`
- Authenticated users calling `GET /api/v1/auth/:type` are unaffected
- `POST /api/v1/auth/resolve` (used by the UI) is unaffected