### PR TITLE
fix: improve unsaved changes confirmation message

### DIFF
--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -635,7 +635,7 @@ const AgentflowCanvas = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [templateFlowData])
 
-    usePrompt('You have unsaved changes! Do you want to navigate away?', canvasDataStore.isDirty)
+    usePrompt('You have unsaved changes. Are you sure you want to leave this page?', canvasDataStore.isDirty)
 
     const [chatPopupOpen, setChatPopupOpen] = useState(false)
 

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -556,7 +556,7 @@ const Canvas = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [templateFlowData])
 
-    usePrompt('You have unsaved changes! Do you want to navigate away?', canvasDataStore.isDirty)
+    usePrompt('You have unsaved changes. Are you sure you want to leave this page?', canvasDataStore.isDirty)
 
     return (
         <>


### PR DESCRIPTION
## Description

Improve the confirmation message for unsaved changes.

## Changes

- Add a clearer default message when no custom message is provided

## Why

The previous message may be unclear or inconsistent.
This improves user understanding when navigating away with unsaved changes.