### PR TITLE
fix: server-side search for Chatflows page to search across all pages

### DIFF
--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -74,12 +74,14 @@ const deleteChatflow = async (req: Request, res: Response, next: NextFunction) =
 const getAllChatflows = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const { page, limit } = getPageAndLimitParams(req)
+        const search = typeof req.query?.search === 'string' ? req.query.search : undefined
 
         const apiResponse = await chatflowsService.getAllChatflows(
             req.query?.type as ChatflowType,
             req.user?.activeWorkspaceId,
             page,
-            limit
+            limit,
+            search
         )
         return res.json(apiResponse)
     } catch (error) {

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -142,7 +142,7 @@ const deleteChatflow = async (chatflowId: string, orgId: string, workspaceId: st
     }
 }
 
-const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: number = -1, limit: number = -1) => {
+const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: number = -1, limit: number = -1, search?: string) => {
     try {
         const appServer = getRunningExpressApp()
 
@@ -150,10 +150,6 @@ const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: 
             .createQueryBuilder('chat_flow')
             .orderBy('chat_flow.updatedDate', 'DESC')
 
-        if (page > 0 && limit > 0) {
-            queryBuilder.skip((page - 1) * limit)
-            queryBuilder.take(limit)
-        }
         if (type === 'MULTIAGENT') {
             queryBuilder.andWhere('chat_flow.type = :type', { type: 'MULTIAGENT' })
         } else if (type === 'AGENTFLOW') {
@@ -165,6 +161,20 @@ const getAllChatflows = async (type?: ChatflowType, workspaceId?: string, page: 
             queryBuilder.andWhere('chat_flow.type = :type', { type: 'CHATFLOW' })
         }
         if (workspaceId) queryBuilder.andWhere('chat_flow.workspaceId = :workspaceId', { workspaceId })
+        if (search?.trim()) {
+            const searchTerm = `%${search.trim().toLowerCase()}%`
+            queryBuilder.andWhere(
+                new Brackets((qb) => {
+                    qb.where('LOWER(chat_flow.name) LIKE :search', { search: searchTerm })
+                        .orWhere("LOWER(COALESCE(chat_flow.category, '')) LIKE :search", { search: searchTerm })
+                        .orWhere('CAST(chat_flow.id AS TEXT) LIKE :search', { search: searchTerm })
+                })
+            )
+        }
+        if (page > 0 && limit > 0) {
+            queryBuilder.skip((page - 1) * limit)
+            queryBuilder.take(limit)
+        }
         const [data, total] = await queryBuilder.getManyAndCount()
 
         if (page > 0 && limit > 0) {

--- a/packages/ui/src/views/chatflows/index.jsx
+++ b/packages/ui/src/views/chatflows/index.jsx
@@ -39,6 +39,7 @@ const Chatflows = () => {
     const [isLoading, setLoading] = useState(true)
     const [images, setImages] = useState({})
     const [search, setSearch] = useState('')
+    const [searchQuery, setSearchQuery] = useState('')
     const { error, setError } = useError()
 
     const getAllChatflowsApi = useApi(chatflowsApi.getAllChatflows)
@@ -56,11 +57,12 @@ const Chatflows = () => {
         applyFilters(page, pageLimit)
     }
 
-    const applyFilters = (page, limit) => {
+    const applyFilters = (page, limit, nextSearch = searchQuery) => {
         const params = {
             page: page || currentPage,
             limit: limit || pageLimit
         }
+        if (nextSearch) params.search = nextSearch
         getAllChatflowsApi.request(params)
     }
 
@@ -74,13 +76,20 @@ const Chatflows = () => {
         setSearch(event.target.value)
     }
 
-    function filterFlows(data) {
-        return (
-            data?.name.toLowerCase().indexOf(search.toLowerCase()) > -1 ||
-            (data.category && data.category.toLowerCase().indexOf(search.toLowerCase()) > -1) ||
-            data?.id.toLowerCase().indexOf(search.toLowerCase()) > -1
-        )
-    }
+    useEffect(() => {
+        const normalizedSearch = search.trim()
+        if (normalizedSearch === searchQuery) return
+
+        const timeoutId = setTimeout(() => {
+            setSearchQuery(normalizedSearch)
+            setCurrentPage(1)
+            applyFilters(1, pageLimit, normalizedSearch)
+        }, 300)
+
+        return () => clearTimeout(timeoutId)
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [search])
 
     const addNew = () => {
         navigate('/canvas')
@@ -138,7 +147,7 @@ const Chatflows = () => {
                     <ViewHeader
                         onSearchChange={onSearchChange}
                         search={true}
-                        searchPlaceholder='Search Name or Category'
+                        searchPlaceholder='Search Name, Category, or ID'
                         title='Chatflows'
                         description='Build single-agent systems, chatbots and simple LLM flows'
                     >
@@ -197,7 +206,7 @@ const Chatflows = () => {
                         <>
                             {!view || view === 'card' ? (
                                 <Box display='grid' gridTemplateColumns='repeat(3, 1fr)' gap={gridSpacing}>
-                                    {getAllChatflowsApi.data?.data?.filter(filterFlows).map((data, index) => (
+                                    {getAllChatflowsApi.data?.data?.map((data, index) => (
                                         <ItemCard key={index} onClick={() => goToCanvas(data)} data={data} images={images[data.id]} />
                                     ))}
                                 </Box>
@@ -206,7 +215,7 @@ const Chatflows = () => {
                                     data={getAllChatflowsApi.data?.data}
                                     images={images}
                                     isLoading={isLoading}
-                                    filterFunction={filterFlows}
+                                    filterFunction={() => true}
                                     updateFlowsApi={getAllChatflowsApi}
                                     setError={setError}
                                     currentPage={currentPage}


### PR DESCRIPTION
Fixes the same client-side search limitation reported for Agentflows in #5868, but for the **Chatflows** page.

## Problem

The Chatflows page uses a local `filterFlows` function that filters only the data loaded for the current page. When users have many chatflows spread across multiple pages and type in the search box, results from other pages are never shown.

## Solution

- **Backend**: Add `search` query parameter to the `getAllChatflows` controller and service. The search filter matches against `name`, `category`, and `id` using case-insensitive `LIKE` queries, and is applied before pagination so that `total` accurately reflects the filtered count.
- **Frontend**: Replace client-side `filterFlows` with a debounced (300ms) effect that passes the search term to the API and resets to page 1 on new searches. Updated search placeholder to "Search Name, Category, or ID".

## Testing

1. Create more chatflows than fit on one page (e.g., >10 with default page size)
2. Type a name that matches a chatflow on page 2 or later
3. Verify that the matching chatflow appears immediately without manually navigating pages

Note: This fix mirrors the approach used in PR #6133 for the Agentflows page.