### PR TITLE
fix(agentflow): handle empty form object in form-input mode

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -1156,7 +1156,8 @@ const executeNode = async ({
             !isRecursive &&
             (!graph[nodeId] || graph[nodeId].length === 0 || (!humanInput && reactFlowNode.data.name === 'humanInputAgentflow'))
 
-        if (incomingInput.question && incomingInput.form) {
+        const incomingFormHasData = incomingInput.form && Object.keys(incomingInput.form).length > 0
+        if (incomingInput.question && incomingFormHasData) {
             throw new Error('Question and form cannot be provided at the same time')
         }
 
@@ -1164,7 +1165,7 @@ const executeNode = async ({
         if (incomingInput.question) {
             // Prepare final question with uploaded content if any
             finalInput = uploadedFilesContent ? `${uploadedFilesContent}\n\n${incomingInput.question}` : incomingInput.question
-        } else if (incomingInput.form) {
+        } else if (incomingFormHasData) {
             finalInput = Object.entries(incomingInput.form || {})
                 .map(([key, value]) => `${key}: ${value}`)
                 .join('\n')
@@ -2241,8 +2242,8 @@ export const executeAgentFlow = async ({
     if (startInputType === 'chatInput') {
         finalUserInput = question || humanInput?.feedback || ' '
     } else if (startInputType === 'formInput') {
-        if (form) {
-            finalUserInput = Object.entries(form || {})
+        if (form && Object.keys(form).length > 0) {
+            finalUserInput = Object.entries(form)
                 .map(([key, value]) => `${key}: ${value}`)
                 .join('\n')
         } else {


### PR DESCRIPTION
Fixes #6013

## Problem

When an AgentFlow V2 uses **Form Input** on the Start node, subsequent messages from the embed chat (or share link) arrive at the server with an empty `form: {}` payload and no `question` field:

```json
{"chatId":"...","form":{},"overrideConfig":{},"streaming":true}
```

Because an empty object is truthy in JavaScript, the existing code branches treated `form: {}` as a populated form. This caused two issues:

1. `finalInput` was set to `""` (empty string from `Object.entries({}).join('\n')`) instead of falling through to the user's `question`
2. `finalUserInput` (the content saved to the `ChatMessage` table) was also set to `""`, causing blank user messages to be stored in the database
3. The validation guard `if (incomingInput.question && incomingInput.form)` would erroneously throw if a caller sent `question` alongside an empty `form: {}`

## Solution

Introduce an explicit `incomingFormHasData` check (`Object.keys(form).length > 0`) instead of relying on bare object truthiness:

- Only treat `incomingInput.form` as real form data when it actually contains keys
- Apply the same guard when computing `finalUserInput` for `formInput` flows
- Relax the mutual-exclusion validation so it only fires when both `question` **and** a non-empty `form` are present simultaneously

This allows the server to correctly fall back to the `question` field when an empty `form: {}` is sent, and stores a meaningful user message in the database.

## Testing

- Verified the logic change with the three affected code paths in `buildAgentflow.ts`
- Existing form-input behaviour (non-empty form) is preserved: the new guard evaluates identically to the old truthy check for populated form objects