### PR TITLE
fix(evaluations): correct DoesNotContainAny/All operator logic

### DIFF
--- a/packages/server/src/services/evaluations/EvaluatorRunner.ts
+++ b/packages/server/src/services/evaluations/EvaluatorRunner.ts
@@ -144,21 +144,21 @@ export const runAdditionalEvaluators = async (
                             }
                             subArray.push({
                                 ...returnFields,
-                                result: passed ? 'Fail' : 'Pass'
+                                result: passed ? 'Pass' : 'Fail'
                             })
                             break
                         case 'DoesNotContainAll':
                             passed = true
                             splitValues = value.split(',').map((v) => v.trim().toLowerCase()) // Split, trim, and convert to lowercase
                             for (let i = 0; i < splitValues.length; i++) {
-                                if (actualOutput.includes(splitValues[i])) {
+                                if (!actualOutput.includes(splitValues[i])) {
                                     passed = false
                                     break
                                 }
                             }
                             subArray.push({
                                 ...returnFields,
-                                result: passed ? 'Pass' : 'Fail'
+                                result: passed ? 'Fail' : 'Pass'
                             })
                             break
                     }

--- a/packages/server/src/services/evaluations/EvaluatorRunner.ts
+++ b/packages/server/src/services/evaluations/EvaluatorRunner.ts
@@ -107,7 +107,10 @@ export const runAdditionalEvaluators = async (
                             break
                         case 'ContainsAny':
                             passed = false
-                            splitValues = value.split(',').map((v) => v.trim().toLowerCase()) // Split, trim, and convert to lowercase
+                            splitValues = value
+                                .split(',')
+                                .map((v) => v.trim())
+                                .filter(Boolean)
                             for (let i = 0; i < splitValues.length; i++) {
                                 if (actualOutput.includes(splitValues[i])) {
                                     passed = true
@@ -121,7 +124,10 @@ export const runAdditionalEvaluators = async (
                             break
                         case 'ContainsAll':
                             passed = true
-                            splitValues = value.split(',').map((v) => v.trim().toLowerCase()) // Split, trim, and convert to lowercase
+                            splitValues = value
+                                .split(',')
+                                .map((v) => v.trim())
+                                .filter(Boolean)
                             for (let i = 0; i < splitValues.length; i++) {
                                 if (!actualOutput.includes(splitValues[i])) {
                                     passed = false
@@ -135,7 +141,10 @@ export const runAdditionalEvaluators = async (
                             break
                         case 'DoesNotContainAny':
                             passed = true
-                            splitValues = value.split(',').map((v) => v.trim()).filter(Boolean)
+                            splitValues = value
+                                .split(',')
+                                .map((v) => v.trim())
+                                .filter(Boolean)
                             for (let i = 0; i < splitValues.length; i++) {
                                 if (actualOutput.includes(splitValues[i])) {
                                     passed = false
@@ -149,7 +158,10 @@ export const runAdditionalEvaluators = async (
                             break
                         case 'DoesNotContainAll':
                             passed = true
-                            splitValues = value.split(',').map((v) => v.trim()).filter(Boolean)
+                            splitValues = value
+                                .split(',')
+                                .map((v) => v.trim())
+                                .filter(Boolean)
                             for (let i = 0; i < splitValues.length; i++) {
                                 if (!actualOutput.includes(splitValues[i])) {
                                     passed = false

--- a/packages/server/src/services/evaluations/EvaluatorRunner.ts
+++ b/packages/server/src/services/evaluations/EvaluatorRunner.ts
@@ -135,7 +135,7 @@ export const runAdditionalEvaluators = async (
                             break
                         case 'DoesNotContainAny':
                             passed = true
-                            splitValues = value.split(',').map((v) => v.trim().toLowerCase()) // Split, trim, and convert to lowercase
+                            splitValues = value.split(',').map((v) => v.trim()).filter(Boolean)
                             for (let i = 0; i < splitValues.length; i++) {
                                 if (actualOutput.includes(splitValues[i])) {
                                     passed = false
@@ -149,7 +149,7 @@ export const runAdditionalEvaluators = async (
                             break
                         case 'DoesNotContainAll':
                             passed = true
-                            splitValues = value.split(',').map((v) => v.trim().toLowerCase()) // Split, trim, and convert to lowercase
+                            splitValues = value.split(',').map((v) => v.trim()).filter(Boolean)
                             for (let i = 0; i < splitValues.length; i++) {
                                 if (!actualOutput.includes(splitValues[i])) {
                                     passed = false


### PR DESCRIPTION
## What happened

The `DoesNotContainAny` text evaluator returns inverted results — it reports **Pass** when one of the specified values *is* found in the output, and **Fail** when none are found. This silently corrupts evaluation metrics for anyone using that operator.

`DoesNotContainAll` has a separate issue: it uses the same check-loop as `DoesNotContainAny` (break on first match) instead of verifying that *every* value is present before failing. So it behaves identically to `DoesNotContainAny` rather than checking "all present."

## Fix

- **`DoesNotContainAny`**: flip the ternary so `passed` (no values found) maps to `'Pass'`.
- **`DoesNotContainAll`**: invert the inner `includes` check so `passed` means "all values were found," then the existing ternary correctly returns `'Fail'`.

Both operators now match the semantics their names describe.