### PR TITLE
fix(evaluations): use correct total_cost property in CostCalculator

### DIFF
--- a/packages/server/src/services/evaluations/CostCalculator.ts
+++ b/packages/server/src/services/evaluations/CostCalculator.ts
@@ -25,7 +25,7 @@ export const calculateCost = (metricsArray: ICommonObject[]) => {
                 costValues = metric.cost_values
             }
 
-            if (costValues.total_cost > 0) {
+            if (costValues.total_cost > 0 && totalTokens) {
                 let cost = costValues.total_cost * (totalTokens / 1000)
                 totalTokensCost = formatCost(cost)
             } else {

--- a/packages/server/src/services/evaluations/CostCalculator.ts
+++ b/packages/server/src/services/evaluations/CostCalculator.ts
@@ -25,7 +25,7 @@ export const calculateCost = (metricsArray: ICommonObject[]) => {
                 costValues = metric.cost_values
             }
 
-            if (costValues.total_price > 0) {
+            if (costValues.total_cost > 0) {
                 let cost = costValues.total_cost * (totalTokens / 1000)
                 totalTokensCost = formatCost(cost)
             } else {


### PR DESCRIPTION
## What happened

`CostCalculator.ts` line 28 checks `costValues.total_price`, but every other part of the codebase (models.json, evaluation runners) uses `total_cost`. Since `total_price` is always `undefined`, the condition is never true and models that define a flat `total_cost` rate fall through to the `input_cost`/`output_cost` path — which are also undefined for those models, producing `NaN` costs.

## Fix

Change `total_price` → `total_cost` on line 28 to match the actual property name.