### PR TITLE
Bugfix/add compact table transformer for NotionAPILoader

### DIFF
--- a/packages/components/nodes/documentloaders/Notion/NotionDB.ts
+++ b/packages/components/nodes/documentloaders/Notion/NotionDB.ts
@@ -3,6 +3,7 @@ import { ICommonObject, IDocument, INode, INodeData, INodeParams } from '../../.
 import { TextSplitter } from '@langchain/textsplitters'
 import { NotionAPILoader, NotionAPILoaderOptions } from '@langchain/community/document_loaders/web/notionapi'
 import { getCredentialData, getCredentialParam, handleEscapeCharacters, INodeOutputsValue } from '../../../src'
+import { applyCompactTableTransformer } from './notionTableFix'
 
 class NotionDB_DocumentLoaders implements INode {
     label: string
@@ -108,6 +109,7 @@ class NotionDB_DocumentLoaders implements INode {
             type: 'database'
         }
         const loader = new NotionAPILoader(obj)
+        applyCompactTableTransformer(loader)
 
         let docs: IDocument[] = []
         if (textSplitter) {

--- a/packages/components/nodes/documentloaders/Notion/NotionPage.ts
+++ b/packages/components/nodes/documentloaders/Notion/NotionPage.ts
@@ -3,6 +3,7 @@ import { ICommonObject, IDocument, INode, INodeData, INodeParams } from '../../.
 import { TextSplitter } from '@langchain/textsplitters'
 import { NotionAPILoader, NotionAPILoaderOptions } from '@langchain/community/document_loaders/web/notionapi'
 import { getCredentialData, getCredentialParam, handleEscapeCharacters, INodeOutputsValue } from '../../../src'
+import { applyCompactTableTransformer } from './notionTableFix'
 
 class NotionPage_DocumentLoaders implements INode {
     label: string
@@ -105,6 +106,7 @@ class NotionPage_DocumentLoaders implements INode {
             type: 'page'
         }
         const loader = new NotionAPILoader(obj)
+        applyCompactTableTransformer(loader)
 
         let docs: IDocument[] = []
         if (textSplitter) {

--- a/packages/components/nodes/documentloaders/Notion/notionTableFix.test.ts
+++ b/packages/components/nodes/documentloaders/Notion/notionTableFix.test.ts
@@ -1,0 +1,251 @@
+import { applyCompactTableTransformer } from './notionTableFix'
+
+/**
+ * Creates a mock NotionAPILoader with fake n2mClient and notionClient.
+ * The n2mClient.blockToMarkdown mock converts rich_text cells to their plain_text,
+ * mimicking the real notion-to-md behavior (which appends trailing newlines).
+ */
+function createMockLoader(tableRows: MockTableRow[]) {
+    let capturedTransformer: ((block: Record<string, unknown>) => Promise<string>) | null = null
+
+    const mockNotionClient = {
+        blocks: {
+            children: {
+                list: jest.fn().mockResolvedValue({
+                    results: tableRows.map((row) => ({
+                        type: 'table_row',
+                        table_row: { cells: row.cells }
+                    })),
+                    has_more: false,
+                    next_cursor: null
+                })
+            }
+        }
+    }
+
+    const mockN2m = {
+        setCustomTransformer: jest.fn((type: string, transformer: typeof capturedTransformer) => {
+            if (type === 'table') {
+                capturedTransformer = transformer
+            }
+        }),
+        blockToMarkdown: jest.fn(async (block: { paragraph: { rich_text: MockRichText[] } }) => {
+            // Simulate notion-to-md behavior: join plain_text with trailing newlines
+            const text = block.paragraph.rich_text.map((rt: MockRichText) => rt.plain_text).join('')
+            return text + '\n\n'
+        })
+    }
+
+    const loader = {
+        n2mClient: mockN2m,
+        notionClient: mockNotionClient
+    }
+
+    return {
+        loader,
+        mockNotionClient,
+        mockN2m,
+        getTransformer: () => capturedTransformer
+    }
+}
+
+interface MockRichText {
+    type: string
+    plain_text: string
+}
+
+interface MockTableRow {
+    cells: MockRichText[][]
+}
+
+function richText(text: string): MockRichText[] {
+    return [{ type: 'text', plain_text: text }]
+}
+
+function createTableBlock(options: { has_children: boolean; has_column_header: boolean }) {
+    return {
+        id: 'block-id',
+        type: 'table',
+        has_children: options.has_children,
+        table: {
+            has_column_header: options.has_column_header,
+            has_row_header: false,
+            table_width: 3
+        }
+    }
+}
+
+describe('applyCompactTableTransformer', () => {
+    it('registers a custom transformer for the table block type', () => {
+        const { loader, mockN2m } = createMockLoader([])
+        applyCompactTableTransformer(loader as never)
+        expect(mockN2m.setCustomTransformer).toHaveBeenCalledWith('table', expect.any(Function))
+    })
+
+    it('returns empty string when block has no children', async () => {
+        const { loader, getTransformer } = createMockLoader([])
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: false, has_column_header: true }))
+        expect(result).toBe('')
+    })
+
+    it('returns empty string when API returns no rows', async () => {
+        const { loader, getTransformer } = createMockLoader([])
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+        expect(result).toBe('')
+    })
+
+    it('produces a compact markdown table with column header', async () => {
+        const rows: MockTableRow[] = [
+            { cells: [richText('Item'), richText('Price'), richText('Stock')] },
+            { cells: [richText('Apple'), richText('$1.00'), richText('50')] },
+            { cells: [richText('Banana'), richText('$0.50'), richText('100')] }
+        ]
+        const { loader, getTransformer } = createMockLoader(rows)
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+
+        expect(result).toBe(
+            '| Item | Price | Stock |\n' + '| --- | --- | --- |\n' + '| Apple | $1.00 | 50 |\n' + '| Banana | $0.50 | 100 |'
+        )
+    })
+
+    it('generates blank header row when has_column_header is false', async () => {
+        const rows: MockTableRow[] = [{ cells: [richText('Apple'), richText('$1.00')] }, { cells: [richText('Banana'), richText('$0.50')] }]
+        const { loader, getTransformer } = createMockLoader(rows)
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: false }))
+
+        expect(result).toBe('|  |  |\n' + '| --- | --- |\n' + '| Apple | $1.00 |\n' + '| Banana | $0.50 |')
+    })
+
+    it('trims trailing newlines from blockToMarkdown output', async () => {
+        const rows: MockTableRow[] = [{ cells: [richText('Header')] }, { cells: [richText('Value')] }]
+        const { loader, getTransformer, mockN2m } = createMockLoader(rows)
+
+        // Override to add extra newlines as notion-to-md does
+        mockN2m.blockToMarkdown.mockImplementation(async (block: { paragraph: { rich_text: MockRichText[] } }) => {
+            const text = block.paragraph.rich_text.map((rt: MockRichText) => rt.plain_text).join('')
+            return text + '\n\n\n'
+        })
+
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+
+        expect(result).toBe('| Header |\n| --- |\n| Value |')
+    })
+
+    it('escapes pipe characters in cell content', async () => {
+        const rows: MockTableRow[] = [{ cells: [richText('Header')] }, { cells: [richText('a|b|c')] }]
+        const { loader, getTransformer } = createMockLoader(rows)
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+
+        expect(result).toBe('| Header |\n| --- |\n| a\\|b\\|c |')
+    })
+
+    it('escapes backslash characters in cell content', async () => {
+        const rows: MockTableRow[] = [{ cells: [richText('Path')] }, { cells: [richText('C:\\Users\\file')] }]
+        const { loader, getTransformer } = createMockLoader(rows)
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+
+        expect(result).toBe('| Path |\n| --- |\n| C:\\\\Users\\\\file |')
+    })
+
+    it('replaces internal newlines with spaces', async () => {
+        const rows: MockTableRow[] = [{ cells: [richText('Header')] }, { cells: [richText('line1')] }]
+        const { loader, getTransformer, mockN2m } = createMockLoader(rows)
+
+        mockN2m.blockToMarkdown.mockImplementation(async (block: { paragraph: { rich_text: MockRichText[] } }) => {
+            const text = block.paragraph.rich_text.map((rt: MockRichText) => rt.plain_text).join('')
+            // Simulate content with internal newlines
+            return text === 'line1' ? 'line1\nline2\n\n' : text + '\n\n'
+        })
+
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+
+        expect(result).toBe('| Header |\n| --- |\n| line1 line2 |')
+    })
+
+    it('handles tables with long URLs without adding padding', async () => {
+        const rows: MockTableRow[] = [
+            { cells: [richText('Item'), richText('URL')] },
+            { cells: [richText('Chatflows'), richText('https://flowiseai.com')] },
+            { cells: [richText('Docs'), richText('https://github.com/FlowiseAI/Flowise')] }
+        ]
+        const { loader, getTransformer } = createMockLoader(rows)
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+
+        // Verify no extra spaces — each cell should be trimmed tightly
+        const lines = result.split('\n')
+        expect(lines[0]).toBe('| Item | URL |')
+        expect(lines[1]).toBe('| --- | --- |')
+        expect(lines[2]).toBe('| Chatflows | https://flowiseai.com |')
+        expect(lines[3]).toBe('| Docs | https://github.com/FlowiseAI/Flowise |')
+    })
+
+    it('falls back to default handler when an error occurs', async () => {
+        const { loader, getTransformer, mockNotionClient } = createMockLoader([])
+
+        // Simulate an API error
+        mockNotionClient.blocks.children.list.mockRejectedValueOnce(new Error('API rate limited'))
+
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+
+        // Returning false tells notion-to-md to use the default table handler
+        expect(result).toBe(false)
+    })
+
+    it('handles pagination when fetching child blocks', async () => {
+        const page1Rows: MockTableRow[] = [{ cells: [richText('Header')] }]
+        const page2Rows: MockTableRow[] = [{ cells: [richText('Row1')] }]
+
+        const { loader, getTransformer, mockNotionClient } = createMockLoader([])
+
+        // Override to simulate paginated responses
+        mockNotionClient.blocks.children.list
+            .mockResolvedValueOnce({
+                results: [{ type: 'table_row', table_row: { cells: page1Rows[0].cells } }],
+                has_more: true,
+                next_cursor: 'cursor-abc'
+            })
+            .mockResolvedValueOnce({
+                results: [{ type: 'table_row', table_row: { cells: page2Rows[0].cells } }],
+                has_more: false,
+                next_cursor: null
+            })
+
+        applyCompactTableTransformer(loader as never)
+
+        const transformer = getTransformer()!
+        const result = await transformer(createTableBlock({ has_children: true, has_column_header: true }))
+
+        expect(mockNotionClient.blocks.children.list).toHaveBeenCalledTimes(2)
+        expect(result).toBe('| Header |\n| --- |\n| Row1 |')
+    })
+})

--- a/packages/components/nodes/documentloaders/Notion/notionTableFix.ts
+++ b/packages/components/nodes/documentloaders/Notion/notionTableFix.ts
@@ -1,0 +1,41 @@
+import { getBlockChildren } from 'notion-to-md/build/utils/notion.js'
+
+/**
+ * Overrides the default table block handler on a NotionAPILoader instance
+ * to produce compact markdown tables without the excessive cell padding
+ * added by the markdown-table library's default options.
+ */
+export function applyCompactTableTransformer(loader: any) {
+    const n2m = loader.n2mClient
+    const notionClient = loader.notionClient
+
+    n2m.setCustomTransformer('table', async (block: any) => {
+        const { id, has_children } = block
+        const tableArr: string[][] = []
+
+        if (has_children) {
+            const tableRows = await getBlockChildren(notionClient, id, 100)
+            const rowsPromise = tableRows?.map(async (row: any) => {
+                const { type } = row
+                const cells = row[type]['cells']
+                const cellStrings = await Promise.all(
+                    cells.map(async (cell: any) =>
+                        n2m.blockToMarkdown({
+                            type: 'paragraph',
+                            paragraph: { rich_text: cell }
+                        })
+                    )
+                )
+                tableArr.push(cellStrings)
+            })
+            await Promise.all(rowsPromise || [])
+        }
+
+        if (tableArr.length === 0) return ''
+
+        const header = '| ' + tableArr[0].join(' | ') + ' |'
+        const separator = '| ' + tableArr[0].map(() => '---').join(' | ') + ' |'
+        const rows = tableArr.slice(1).map((row) => '| ' + row.join(' | ') + ' |')
+        return [header, separator, ...rows].join('\n')
+    })
+}

--- a/packages/components/nodes/documentloaders/Notion/notionTableFix.ts
+++ b/packages/components/nodes/documentloaders/Notion/notionTableFix.ts
@@ -1,49 +1,145 @@
-import { getBlockChildren } from 'notion-to-md/build/utils/notion.js'
+import type { Client } from '@notionhq/client'
+import type { NotionToMarkdown } from 'notion-to-md'
+import type { NotionAPILoader } from '@langchain/community/document_loaders/web/notionapi'
+
+// ────────────────────────────────────────────────────────────────
+// Local type definitions for the Notion API shapes we use.
+// These types are only available via @notionhq/client/build/src/api-endpoints
+// which is an internal path, so we define the minimal shapes here.
+// ────────────────────────────────────────────────────────────────
+
+interface TableBlock {
+    id: string
+    has_children: boolean
+    table: {
+        has_column_header: boolean
+    }
+}
+
+interface TableRowBlock {
+    type: 'table_row'
+    table_row: {
+        cells: RichText[][]
+    }
+}
+
+interface RichText {
+    type: string
+    plain_text: string
+    annotations: Record<string, unknown>
+    href: string | null
+}
+
+interface BlockListResponse {
+    results: Record<string, unknown>[]
+    has_more: boolean
+    next_cursor: string | null
+}
+
+/**
+ * Provides typed access to the private fields of NotionAPILoader
+ * that we need for applying the custom table transformer.
+ */
+interface NotionAPILoaderInternal {
+    n2mClient: NotionToMarkdown
+    notionClient: Client
+}
 
 /**
  * Overrides the default table block handler on a NotionAPILoader instance
  * to produce compact markdown tables without the excessive cell padding
  * added by the markdown-table library's default options.
  */
-export function applyCompactTableTransformer(loader: any) {
-    const n2m = loader.n2mClient
-    const notionClient = loader.notionClient
+export function applyCompactTableTransformer(loader: NotionAPILoader): void {
+    const internal = loader as unknown as NotionAPILoaderInternal
+    const n2m = internal.n2mClient
+    const notionClient = internal.notionClient
 
-    n2m.setCustomTransformer('table', async (block: any) => {
-        const { id, has_children } = block
-        const { has_column_header } = block.table
+    n2m.setCustomTransformer('table', async (block) => {
+        try {
+            const tableBlock = block as unknown as TableBlock
+            const { id, has_children } = tableBlock
+            const { has_column_header } = tableBlock.table
 
-        if (!has_children) return ''
+            if (!has_children) return ''
 
-        const tableRows = await getBlockChildren(notionClient, id, null)
-        const tableArr = await Promise.all(
-            (tableRows || []).map(async (row: any) => {
-                const { type } = row
-                const cells = row[type]?.cells || []
-                return await Promise.all(
-                    cells.map(async (cell: any) =>
-                        (
-                            await n2m.blockToMarkdown({
-                                type: 'paragraph',
-                                paragraph: { rich_text: cell }
-                            })
-                        )
-                            .trim()
-                            .replace(/\n/g, ' ')
-                            .replace(/\|/g, '\\|')
-                    )
-                )
-            })
-        )
+            // Fetch all table row blocks using the public Notion API
+            const childBlocks = await fetchAllChildBlocks(notionClient, id)
 
-        if (tableArr.length === 0) return ''
+            // Convert each row's cells to markdown strings
+            const tableArr: string[][] = []
+            for (const child of childBlocks) {
+                const row = child as unknown as TableRowBlock
+                const cells: RichText[][] = row.table_row?.cells || []
+                const cellStrings: string[] = []
 
-        const headerArray = has_column_header ? tableArr[0] : new Array(tableArr[0].length).fill('')
-        const rowsArray = has_column_header ? tableArr.slice(1) : tableArr
+                for (const cell of cells) {
+                    const raw = await n2m.blockToMarkdown({
+                        type: 'paragraph',
+                        paragraph: { rich_text: cell }
+                    } as Parameters<typeof n2m.blockToMarkdown>[0])
+                    const cleaned = escapeForTable(raw)
+                    cellStrings.push(cleaned)
+                }
 
-        const header = '| ' + headerArray.join(' | ') + ' |'
-        const separator = '| ' + headerArray.map(() => '---').join(' | ') + ' |'
-        const rows = rowsArray.map((row) => '| ' + row.join(' | ') + ' |')
-        return [header, separator, ...rows].join('\n')
+                tableArr.push(cellStrings)
+            }
+
+            if (tableArr.length === 0) return ''
+
+            // Build the markdown table
+            const columnCount = tableArr[0].length
+            const headerArray = has_column_header ? tableArr[0] : new Array<string>(columnCount).fill('')
+            const dataRows = has_column_header ? tableArr.slice(1) : tableArr
+
+            const header = formatRow(headerArray)
+            const separator = formatRow(new Array<string>(columnCount).fill('---'))
+            const rows = dataRows.map(formatRow)
+
+            return [header, separator, ...rows].join('\n')
+        } catch {
+            // Fall back to the default (padded) table handler rather than failing the entire load
+            return false
+        }
     })
+}
+
+/**
+ * Fetches all child blocks for a given block ID, handling pagination.
+ */
+async function fetchAllChildBlocks(notionClient: Client, blockId: string): Promise<BlockListResponse['results']> {
+    const blocks: BlockListResponse['results'] = []
+    let cursor: string | undefined = undefined
+
+    do {
+        const response: BlockListResponse = await notionClient.blocks.children.list({
+            block_id: blockId,
+            start_cursor: cursor
+        })
+        blocks.push(...response.results)
+        cursor = response.has_more ? response.next_cursor ?? undefined : undefined
+    } while (cursor)
+
+    return blocks
+}
+
+/**
+ * Cleans a blockToMarkdown result for use inside a table cell:
+ * - Trims surrounding whitespace and trailing newlines
+ * - Replaces internal newlines with spaces
+ * - Escapes backslashes and pipes to preserve table structure
+ */
+function escapeForTable(raw: string): string {
+    const trimmed = raw.trim()
+    const singleLine = trimmed.replace(/\n/g, ' ')
+    const escapedBackslashes = singleLine.replace(/\\/g, '\\\\')
+    const escapedPipes = escapedBackslashes.replace(/\|/g, '\\|')
+    return escapedPipes
+}
+
+/**
+ * Formats an array of cell strings into a markdown table row.
+ */
+function formatRow(cells: string[]): string {
+    return '| ' + cells.join(' | ') + ' |'
 }

--- a/packages/components/nodes/documentloaders/Notion/notionTableFix.ts
+++ b/packages/components/nodes/documentloaders/Notion/notionTableFix.ts
@@ -11,14 +11,15 @@ export function applyCompactTableTransformer(loader: any) {
 
     n2m.setCustomTransformer('table', async (block: any) => {
         const { id, has_children } = block
+        const { has_column_header } = block.table
 
         if (!has_children) return ''
 
-        const tableRows = await getBlockChildren(notionClient, id, 100)
+        const tableRows = await getBlockChildren(notionClient, id, null)
         const tableArr = await Promise.all(
             (tableRows || []).map(async (row: any) => {
                 const { type } = row
-                const cells = row[type]['cells']
+                const cells = row[type]?.cells || []
                 return await Promise.all(
                     cells.map(async (cell: any) =>
                         (
@@ -29,6 +30,7 @@ export function applyCompactTableTransformer(loader: any) {
                         )
                             .trim()
                             .replace(/\n/g, ' ')
+                            .replace(/\|/g, '\\|')
                     )
                 )
             })
@@ -36,9 +38,12 @@ export function applyCompactTableTransformer(loader: any) {
 
         if (tableArr.length === 0) return ''
 
-        const header = '| ' + tableArr[0].join(' | ') + ' |'
-        const separator = '| ' + tableArr[0].map(() => '---').join(' | ') + ' |'
-        const rows = tableArr.slice(1).map((row) => '| ' + row.join(' | ') + ' |')
+        const headerArray = has_column_header ? tableArr[0] : new Array(tableArr[0].length).fill('')
+        const rowsArray = has_column_header ? tableArr.slice(1) : tableArr
+
+        const header = '| ' + headerArray.join(' | ') + ' |'
+        const separator = '| ' + headerArray.map(() => '---').join(' | ') + ' |'
+        const rows = rowsArray.map((row) => '| ' + row.join(' | ') + ' |')
         return [header, separator, ...rows].join('\n')
     })
 }

--- a/packages/components/nodes/documentloaders/Notion/notionTableFix.ts
+++ b/packages/components/nodes/documentloaders/Notion/notionTableFix.ts
@@ -11,25 +11,28 @@ export function applyCompactTableTransformer(loader: any) {
 
     n2m.setCustomTransformer('table', async (block: any) => {
         const { id, has_children } = block
-        const tableArr: string[][] = []
 
-        if (has_children) {
-            const tableRows = await getBlockChildren(notionClient, id, 100)
-            const rowsPromise = tableRows?.map(async (row: any) => {
+        if (!has_children) return ''
+
+        const tableRows = await getBlockChildren(notionClient, id, 100)
+        const tableArr = await Promise.all(
+            (tableRows || []).map(async (row: any) => {
                 const { type } = row
                 const cells = row[type]['cells']
-                const cellStrings = await Promise.all(
+                return await Promise.all(
                     cells.map(async (cell: any) =>
-                        n2m.blockToMarkdown({
-                            type: 'paragraph',
-                            paragraph: { rich_text: cell }
-                        })
+                        (
+                            await n2m.blockToMarkdown({
+                                type: 'paragraph',
+                                paragraph: { rich_text: cell }
+                            })
+                        )
+                            .trim()
+                            .replace(/\n/g, ' ')
                     )
                 )
-                tableArr.push(cellStrings)
             })
-            await Promise.all(rowsPromise || [])
-        }
+        )
 
         if (tableArr.length === 0) return ''
 


### PR DESCRIPTION
## Root Cause
`notion-to-md's md.table()` function calls `markdown-table(cells)` with no options, inheriting the library's padding defaults. The `n2mClient1 in LangChain's NotionAPILoader is private, so there's no way to configure this externally — but setCustomTransformer allows overriding specific block type handlers.

## Fix
Uses `setCustomTransformer('table', ...)` on the NotionAPILoader's internal `n2mClient` to bypass the default table handler. The custom transformer replicates the same cell-fetching logic but generates compact markdown tables without padding.

Previously:
<img width="1452" height="770" alt="image" src="https://github.com/user-attachments/assets/53429344-2543-46fa-8125-53d181742a65" />

After:
<img width="1150" height="860" alt="image" src="https://github.com/user-attachments/assets/ff314613-87b9-4a0c-b326-f12ae939445a" />