### PR TITLE
bugfix: message panel crashes via large chat volume

### DIFF
--- a/packages/server/src/controllers/stats/index.ts
+++ b/packages/server/src/controllers/stats/index.ts
@@ -9,6 +9,10 @@ const getChatflowStats = async (req: Request, res: Response, next: NextFunction)
         if (typeof req.params === 'undefined' || !req.params.id) {
             throw new InternalFlowiseError(StatusCodes.PRECONDITION_FAILED, `Error: statsController.getChatflowStats - id not provided!`)
         }
+        const activeWorkspaceId = req.user?.activeWorkspaceId
+        if (!activeWorkspaceId) {
+            throw new InternalFlowiseError(StatusCodes.UNAUTHORIZED, `Error: statsController.getChatflowStats - unauthorized!`)
+        }
         const chatflowid = req.params.id
         const _chatTypes = req.query?.chatType as string | undefined
         let chatTypes: ChatType[] | undefined
@@ -47,13 +51,11 @@ const getChatflowStats = async (req: Request, res: Response, next: NextFunction)
         }
         const apiResponse = await statsService.getChatflowStats(
             chatflowid,
+            activeWorkspaceId,
             chatTypes,
             startDate,
             endDate,
-            '',
-            true,
-            feedbackTypeFilters,
-            req.user?.activeWorkspaceId
+            feedbackTypeFilters
         )
         return res.json(apiResponse)
     } catch (error) {

--- a/packages/server/src/services/stats/index.test.ts
+++ b/packages/server/src/services/stats/index.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+import { StatusCodes } from 'http-status-codes'
+import { ChatMessageRatingType, ChatType } from '../../Interface'
+import { InternalFlowiseError } from '../../errors/internalFlowiseError'
+
+jest.mock('../../utils/getRunningExpressApp', () => ({
+    getRunningExpressApp: jest.fn()
+}))
+
+import statsService from '.'
+import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
+import { ChatFlow } from '../../database/entities/ChatFlow'
+
+const mockQb: any = {
+    select: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getRawOne: jest.fn(),
+    getRawMany: jest.fn()
+}
+
+const mockMessageRepo: any = {
+    createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+    count: jest.fn()
+}
+
+const mockChatFlowRepo: any = {
+    findOneBy: jest.fn()
+}
+
+const CHATFLOW_ID = 'cf-abc-123'
+const WORKSPACE_ID = 'ws-xyz-456'
+
+describe('statsService.getChatflowStats', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(getRunningExpressApp as jest.Mock).mockReturnValue({
+            AppDataSource: {
+                getRepository: jest.fn((entity: unknown) => {
+                    if (entity === ChatFlow) return mockChatFlowRepo
+                    return mockMessageRepo
+                })
+            }
+        })
+
+        mockChatFlowRepo.findOneBy.mockResolvedValue({ id: CHATFLOW_ID } as any)
+        mockMessageRepo.count.mockResolvedValue(0)
+        mockQb.getRawOne.mockResolvedValue({ count: '0' })
+        mockQb.getRawMany.mockResolvedValue([])
+        mockQb.select.mockReturnThis()
+        mockQb.innerJoin.mockReturnThis()
+        mockQb.where.mockReturnThis()
+        mockQb.andWhere.mockReturnThis()
+        mockMessageRepo.createQueryBuilder.mockReturnValue(mockQb)
+    })
+
+    describe('workspace authorization', () => {
+        it('throws when activeWorkspaceId is not provided', async () => {
+            await expect(
+                statsService.getChatflowStats(CHATFLOW_ID, undefined as any, undefined, undefined, undefined, undefined)
+            ).rejects.toBeInstanceOf(InternalFlowiseError)
+
+            expect(mockChatFlowRepo.findOneBy).not.toHaveBeenCalled()
+        })
+
+        it('throws when chatflow is not found in the workspace', async () => {
+            mockChatFlowRepo.findOneBy.mockResolvedValue(null)
+
+            await expect(
+                statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
+            ).rejects.toBeInstanceOf(InternalFlowiseError)
+
+            expect(mockMessageRepo.count).not.toHaveBeenCalled()
+        })
+
+        it('looks up chatflow with the correct workspaceId', async () => {
+            await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
+
+            expect(mockChatFlowRepo.findOneBy).toHaveBeenCalledWith({
+                id: CHATFLOW_ID,
+                workspaceId: WORKSPACE_ID
+            })
+        })
+    })
+
+    describe('no filters', () => {
+        it('returns the correct shape with parsed integers', async () => {
+            mockMessageRepo.count.mockResolvedValue(157)
+            mockQb.getRawOne
+                .mockResolvedValueOnce({ count: '42' })
+                .mockResolvedValueOnce({ count: '10' })
+                .mockResolvedValueOnce({ count: '7' })
+
+            const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
+
+            expect(result).toEqual({
+                totalMessages: 157,
+                totalSessions: 42,
+                totalFeedback: 10,
+                positiveFeedback: 7
+            })
+        })
+
+        it('defaults to 0 when getRawOne returns undefined', async () => {
+            mockQb.getRawOne.mockResolvedValue(undefined)
+
+            const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
+
+            expect(result.totalSessions).toBe(0)
+            expect(result.totalFeedback).toBe(0)
+            expect(result.positiveFeedback).toBe(0)
+        })
+
+        it('runs 3 QueryBuilders and 1 count when no feedbackTypes filter is set', async () => {
+            await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
+
+            expect(mockMessageRepo.createQueryBuilder).toHaveBeenCalledTimes(3)
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(3)
+            expect(mockMessageRepo.count).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('chatTypes filter', () => {
+        it('uses In operator with the provided chatTypes', async () => {
+            const chatTypes: ChatType[] = [ChatType.INTERNAL]
+
+            await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, chatTypes, undefined, undefined, undefined)
+
+            const countWhere = mockMessageRepo.count.mock.calls[0][0].where
+            expect(countWhere.chatType.type).toBe('in')
+            expect(countWhere.chatType.value).toEqual(chatTypes)
+        })
+    })
+
+    describe('date range filter', () => {
+        it('uses Between when both startDate and endDate are provided', async () => {
+            await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, '2024-01-01', '2024-12-31', undefined)
+
+            const countWhere = mockMessageRepo.count.mock.calls[0][0].where
+            expect(countWhere.createdDate.type).toBe('between')
+        })
+
+        it('uses MoreThanOrEqual when only startDate is provided', async () => {
+            await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, '2024-01-01', undefined, undefined)
+
+            const countWhere = mockMessageRepo.count.mock.calls[0][0].where
+            expect(countWhere.createdDate.type).toBe('moreThanOrEqual')
+        })
+
+        it('uses LessThanOrEqual when only endDate is provided', async () => {
+            await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, '2024-12-31', undefined)
+
+            const countWhere = mockMessageRepo.count.mock.calls[0][0].where
+            expect(countWhere.createdDate.type).toBe('lessThanOrEqual')
+        })
+    })
+
+    describe('feedbackTypes filter', () => {
+        it('returns zeros immediately when no sessions match', async () => {
+            mockQb.getRawMany.mockResolvedValue([])
+
+            const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
+                ChatMessageRatingType.THUMBS_UP
+            ])
+
+            expect(result).toEqual({ totalMessages: 0, totalSessions: 0, totalFeedback: 0, positiveFeedback: 0 })
+            expect(mockMessageRepo.count).not.toHaveBeenCalled()
+            expect(mockQb.getRawOne).not.toHaveBeenCalled()
+        })
+
+        it('runs all 4 main queries when sessions match', async () => {
+            mockQb.getRawMany.mockResolvedValue([{ sessionId: 's1' }, { sessionId: 's2' }])
+            mockMessageRepo.count.mockResolvedValue(50)
+            mockQb.getRawOne.mockResolvedValue({ count: '5' })
+
+            const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
+                ChatMessageRatingType.THUMBS_UP
+            ])
+
+            expect(result.totalMessages).toBe(50)
+            expect(result.totalSessions).toBe(5)
+            expect(mockMessageRepo.count).toHaveBeenCalledTimes(1)
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(3)
+        })
+
+        it('passes the feedbackTypes to the sessionId subquery', async () => {
+            mockQb.getRawMany.mockResolvedValue([{ sessionId: 's1' }])
+
+            await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
+                ChatMessageRatingType.THUMBS_DOWN
+            ])
+
+            const feedbackCall = mockQb.andWhere.mock.calls.find((call: string[]) => call[0].includes('feedbackTypes'))
+            expect(feedbackCall).toBeDefined()
+            expect(feedbackCall![1]).toEqual(expect.objectContaining({ feedbackTypes: [ChatMessageRatingType.THUMBS_DOWN] }))
+        })
+    })
+
+    describe('error handling', () => {
+        it('wraps unexpected errors as InternalFlowiseError with 500 status', async () => {
+            mockMessageRepo.count.mockRejectedValue(new Error('DB connection lost'))
+
+            let caught: any
+            try {
+                await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
+            } catch (e) {
+                caught = e
+            }
+
+            expect(caught).toBeInstanceOf(InternalFlowiseError)
+            expect(caught.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+            expect(caught.message).toContain('statsService.getChatflowStats')
+        })
+    })
+})

--- a/packages/server/src/services/stats/index.test.ts
+++ b/packages/server/src/services/stats/index.test.ts
@@ -15,6 +15,7 @@ const mockQb: any = {
     select: jest.fn().mockReturnThis(),
     from: jest.fn().mockReturnThis(),
     innerJoin: jest.fn().mockReturnThis(),
+    leftJoin: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
     setParameters: jest.fn().mockReturnThis(),
@@ -54,6 +55,7 @@ describe('statsService.getChatflowStats', () => {
         mockQb.select.mockReturnThis()
         mockQb.from.mockReturnThis()
         mockQb.innerJoin.mockReturnThis()
+        mockQb.leftJoin.mockReturnThis()
         mockQb.where.mockReturnThis()
         mockQb.andWhere.mockReturnThis()
         mockQb.setParameters.mockReturnThis()
@@ -173,19 +175,29 @@ describe('statsService.getChatflowStats', () => {
             ])
 
             expect(result).toEqual({ totalMessages: 0, totalSessions: 0, totalFeedback: 0, positiveFeedback: 0 })
-            expect(mockQb.getRawOne).toHaveBeenCalledTimes(4)
+            // 4 main queries + 1 precedingCountQb = 5
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(5)
         })
 
-        it('runs all 4 count queries when feedbackTypes is set', async () => {
-            mockQb.getRawOne.mockResolvedValue({ count: '5' })
+        it('computes totalMessages as totalFeedback + precedingCount when feedbackTypes is set', async () => {
+            mockQb.getRawOne
+                .mockResolvedValueOnce({ count: '630' }) // totalMessages (unused when feedbackTypes active)
+                .mockResolvedValueOnce({ count: '42' }) // totalSessions
+                .mockResolvedValueOnce({ count: '67' }) // totalFeedback
+                .mockResolvedValueOnce({ count: '60' }) // positiveFeedback
+                .mockResolvedValueOnce({ count: '57' }) // precedingCount
 
             const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
                 ChatMessageRatingType.THUMBS_UP
             ])
 
-            expect(result.totalMessages).toBe(5)
-            expect(result.totalSessions).toBe(5)
-            expect(mockQb.getRawOne).toHaveBeenCalledTimes(4)
+            // totalMessages = totalFeedback(67) + precedingCount(57) = 124
+            expect(result.totalMessages).toBe(124)
+            expect(result.totalSessions).toBe(42)
+            expect(result.totalFeedback).toBe(67)
+            expect(result.positiveFeedback).toBe(60)
+            // 4 main queries + 1 precedingCountQb = 5
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(5)
         })
 
         it('passes the feedbackTypes to the session subquery', async () => {

--- a/packages/server/src/services/stats/index.test.ts
+++ b/packages/server/src/services/stats/index.test.ts
@@ -13,16 +13,20 @@ import { ChatFlow } from '../../database/entities/ChatFlow'
 
 const mockQb: any = {
     select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
     innerJoin: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
+    setParameters: jest.fn().mockReturnThis(),
+    subQuery: jest.fn().mockReturnThis(),
+    getQuery: jest.fn().mockReturnValue('(SELECT DISTINCT cm2.sessionId FROM chat_message cm2)'),
+    getParameters: jest.fn().mockReturnValue({}),
     getRawOne: jest.fn(),
     getRawMany: jest.fn()
 }
 
 const mockMessageRepo: any = {
-    createQueryBuilder: jest.fn().mockReturnValue(mockQb),
-    count: jest.fn()
+    createQueryBuilder: jest.fn().mockReturnValue(mockQb)
 }
 
 const mockChatFlowRepo: any = {
@@ -45,13 +49,17 @@ describe('statsService.getChatflowStats', () => {
         })
 
         mockChatFlowRepo.findOneBy.mockResolvedValue({ id: CHATFLOW_ID } as any)
-        mockMessageRepo.count.mockResolvedValue(0)
         mockQb.getRawOne.mockResolvedValue({ count: '0' })
         mockQb.getRawMany.mockResolvedValue([])
         mockQb.select.mockReturnThis()
+        mockQb.from.mockReturnThis()
         mockQb.innerJoin.mockReturnThis()
         mockQb.where.mockReturnThis()
         mockQb.andWhere.mockReturnThis()
+        mockQb.setParameters.mockReturnThis()
+        mockQb.subQuery.mockReturnThis()
+        mockQb.getQuery.mockReturnValue('(SELECT DISTINCT cm2.sessionId FROM chat_message cm2)')
+        mockQb.getParameters.mockReturnValue({})
         mockMessageRepo.createQueryBuilder.mockReturnValue(mockQb)
     })
 
@@ -71,7 +79,7 @@ describe('statsService.getChatflowStats', () => {
                 statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
             ).rejects.toBeInstanceOf(InternalFlowiseError)
 
-            expect(mockMessageRepo.count).not.toHaveBeenCalled()
+            expect(mockMessageRepo.createQueryBuilder).not.toHaveBeenCalled()
         })
 
         it('looks up chatflow with the correct workspaceId', async () => {
@@ -86,8 +94,8 @@ describe('statsService.getChatflowStats', () => {
 
     describe('no filters', () => {
         it('returns the correct shape with parsed integers', async () => {
-            mockMessageRepo.count.mockResolvedValue(157)
             mockQb.getRawOne
+                .mockResolvedValueOnce({ count: '157' })
                 .mockResolvedValueOnce({ count: '42' })
                 .mockResolvedValueOnce({ count: '10' })
                 .mockResolvedValueOnce({ count: '7' })
@@ -107,17 +115,17 @@ describe('statsService.getChatflowStats', () => {
 
             const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
 
+            expect(result.totalMessages).toBe(0)
             expect(result.totalSessions).toBe(0)
             expect(result.totalFeedback).toBe(0)
             expect(result.positiveFeedback).toBe(0)
         })
 
-        it('runs 3 QueryBuilders and 1 count when no feedbackTypes filter is set', async () => {
+        it('runs 4 QueryBuilders and getRawOne 4 times when no feedbackTypes filter is set', async () => {
             await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
 
-            expect(mockMessageRepo.createQueryBuilder).toHaveBeenCalledTimes(3)
-            expect(mockQb.getRawOne).toHaveBeenCalledTimes(3)
-            expect(mockMessageRepo.count).toHaveBeenCalledTimes(1)
+            expect(mockMessageRepo.createQueryBuilder).toHaveBeenCalledTimes(4)
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(4)
         })
     })
 
@@ -127,9 +135,9 @@ describe('statsService.getChatflowStats', () => {
 
             await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, chatTypes, undefined, undefined, undefined)
 
-            const countWhere = mockMessageRepo.count.mock.calls[0][0].where
-            expect(countWhere.chatType.type).toBe('in')
-            expect(countWhere.chatType.value).toEqual(chatTypes)
+            const whereArg = mockQb.where.mock.calls[0][0]
+            expect(whereArg.chatType.type).toBe('in')
+            expect(whereArg.chatType.value).toEqual(chatTypes)
         })
     })
 
@@ -137,56 +145,50 @@ describe('statsService.getChatflowStats', () => {
         it('uses Between when both startDate and endDate are provided', async () => {
             await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, '2024-01-01', '2024-12-31', undefined)
 
-            const countWhere = mockMessageRepo.count.mock.calls[0][0].where
-            expect(countWhere.createdDate.type).toBe('between')
+            const whereArg = mockQb.where.mock.calls[0][0]
+            expect(whereArg.createdDate.type).toBe('between')
         })
 
         it('uses MoreThanOrEqual when only startDate is provided', async () => {
             await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, '2024-01-01', undefined, undefined)
 
-            const countWhere = mockMessageRepo.count.mock.calls[0][0].where
-            expect(countWhere.createdDate.type).toBe('moreThanOrEqual')
+            const whereArg = mockQb.where.mock.calls[0][0]
+            expect(whereArg.createdDate.type).toBe('moreThanOrEqual')
         })
 
         it('uses LessThanOrEqual when only endDate is provided', async () => {
             await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, '2024-12-31', undefined)
 
-            const countWhere = mockMessageRepo.count.mock.calls[0][0].where
-            expect(countWhere.createdDate.type).toBe('lessThanOrEqual')
+            const whereArg = mockQb.where.mock.calls[0][0]
+            expect(whereArg.createdDate.type).toBe('lessThanOrEqual')
         })
     })
 
     describe('feedbackTypes filter', () => {
-        it('returns zeros immediately when no sessions match', async () => {
-            mockQb.getRawMany.mockResolvedValue([])
+        it('returns all zeros when no sessions have qualifying feedback', async () => {
+            mockQb.getRawOne.mockResolvedValue({ count: '0' })
 
             const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
                 ChatMessageRatingType.THUMBS_UP
             ])
 
             expect(result).toEqual({ totalMessages: 0, totalSessions: 0, totalFeedback: 0, positiveFeedback: 0 })
-            expect(mockMessageRepo.count).not.toHaveBeenCalled()
-            expect(mockQb.getRawOne).not.toHaveBeenCalled()
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(4)
         })
 
-        it('runs all 4 main queries when sessions match', async () => {
-            mockQb.getRawMany.mockResolvedValue([{ sessionId: 's1' }, { sessionId: 's2' }])
-            mockMessageRepo.count.mockResolvedValue(50)
+        it('runs all 4 count queries when feedbackTypes is set', async () => {
             mockQb.getRawOne.mockResolvedValue({ count: '5' })
 
             const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
                 ChatMessageRatingType.THUMBS_UP
             ])
 
-            expect(result.totalMessages).toBe(50)
+            expect(result.totalMessages).toBe(5)
             expect(result.totalSessions).toBe(5)
-            expect(mockMessageRepo.count).toHaveBeenCalledTimes(1)
-            expect(mockQb.getRawOne).toHaveBeenCalledTimes(3)
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(4)
         })
 
-        it('passes the feedbackTypes to the sessionId subquery', async () => {
-            mockQb.getRawMany.mockResolvedValue([{ sessionId: 's1' }])
-
+        it('passes the feedbackTypes to the session subquery', async () => {
             await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
                 ChatMessageRatingType.THUMBS_DOWN
             ])
@@ -195,11 +197,20 @@ describe('statsService.getChatflowStats', () => {
             expect(feedbackCall).toBeDefined()
             expect(feedbackCall![1]).toEqual(expect.objectContaining({ feedbackTypes: [ChatMessageRatingType.THUMBS_DOWN] }))
         })
+
+        it('appends the session subquery condition to all 4 count queries', async () => {
+            await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
+                ChatMessageRatingType.THUMBS_UP
+            ])
+
+            const sessionIdCalls = mockQb.andWhere.mock.calls.filter((call: string[]) => call[0].includes('cm.sessionId IN'))
+            expect(sessionIdCalls.length).toBe(4)
+        })
     })
 
     describe('error handling', () => {
         it('wraps unexpected errors as InternalFlowiseError with 500 status', async () => {
-            mockMessageRepo.count.mockRejectedValue(new Error('DB connection lost'))
+            mockQb.getRawOne.mockRejectedValue(new Error('DB connection lost'))
 
             let caught: any
             try {

--- a/packages/server/src/services/stats/index.test.ts
+++ b/packages/server/src/services/stats/index.test.ts
@@ -13,11 +13,13 @@ import { ChatFlow } from '../../database/entities/ChatFlow'
 
 const mockQb: any = {
     select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
     from: jest.fn().mockReturnThis(),
     innerJoin: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     andWhere: jest.fn().mockReturnThis(),
+    setParameter: jest.fn().mockReturnThis(),
     setParameters: jest.fn().mockReturnThis(),
     subQuery: jest.fn().mockReturnThis(),
     getQuery: jest.fn().mockReturnValue('(SELECT DISTINCT cm2.sessionId FROM chat_message cm2)'),
@@ -53,11 +55,13 @@ describe('statsService.getChatflowStats', () => {
         mockQb.getRawOne.mockResolvedValue({ count: '0' })
         mockQb.getRawMany.mockResolvedValue([])
         mockQb.select.mockReturnThis()
+        mockQb.addSelect.mockReturnThis()
         mockQb.from.mockReturnThis()
         mockQb.innerJoin.mockReturnThis()
         mockQb.leftJoin.mockReturnThis()
         mockQb.where.mockReturnThis()
         mockQb.andWhere.mockReturnThis()
+        mockQb.setParameter.mockReturnThis()
         mockQb.setParameters.mockReturnThis()
         mockQb.subQuery.mockReturnThis()
         mockQb.getQuery.mockReturnValue('(SELECT DISTINCT cm2.sessionId FROM chat_message cm2)')
@@ -96,11 +100,12 @@ describe('statsService.getChatflowStats', () => {
 
     describe('no filters', () => {
         it('returns the correct shape with parsed integers', async () => {
-            mockQb.getRawOne
-                .mockResolvedValueOnce({ count: '157' })
-                .mockResolvedValueOnce({ count: '42' })
-                .mockResolvedValueOnce({ count: '10' })
-                .mockResolvedValueOnce({ count: '7' })
+            mockQb.getRawOne.mockResolvedValueOnce({
+                totalMessages: '157',
+                totalSessions: '42',
+                totalFeedback: '10',
+                positiveFeedback: '7'
+            })
 
             const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
 
@@ -123,11 +128,11 @@ describe('statsService.getChatflowStats', () => {
             expect(result.positiveFeedback).toBe(0)
         })
 
-        it('runs 4 QueryBuilders and getRawOne 4 times when no feedbackTypes filter is set', async () => {
+        it('runs 1 QueryBuilder and getRawOne 1 time when no feedbackTypes filter is set', async () => {
             await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, undefined)
 
-            expect(mockMessageRepo.createQueryBuilder).toHaveBeenCalledTimes(4)
-            expect(mockQb.getRawOne).toHaveBeenCalledTimes(4)
+            expect(mockMessageRepo.createQueryBuilder).toHaveBeenCalledTimes(1)
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(1)
         })
     })
 
@@ -175,17 +180,14 @@ describe('statsService.getChatflowStats', () => {
             ])
 
             expect(result).toEqual({ totalMessages: 0, totalSessions: 0, totalFeedback: 0, positiveFeedback: 0 })
-            // 4 main queries + 1 precedingCountQb = 5
-            expect(mockQb.getRawOne).toHaveBeenCalledTimes(5)
+            // 1 combinedQb + 1 precedingCountQb = 2
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(2)
         })
 
         it('computes totalMessages as totalFeedback + precedingCount when feedbackTypes is set', async () => {
             mockQb.getRawOne
-                .mockResolvedValueOnce({ count: '630' }) // totalMessages (unused when feedbackTypes active)
-                .mockResolvedValueOnce({ count: '42' }) // totalSessions
-                .mockResolvedValueOnce({ count: '67' }) // totalFeedback
-                .mockResolvedValueOnce({ count: '60' }) // positiveFeedback
-                .mockResolvedValueOnce({ count: '57' }) // precedingCount
+                .mockResolvedValueOnce({ totalSessions: '42', totalFeedback: '67', positiveFeedback: '60' }) // combinedQb
+                .mockResolvedValueOnce({ count: '57' }) // precedingCountQb
 
             const result = await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
                 ChatMessageRatingType.THUMBS_UP
@@ -196,8 +198,8 @@ describe('statsService.getChatflowStats', () => {
             expect(result.totalSessions).toBe(42)
             expect(result.totalFeedback).toBe(67)
             expect(result.positiveFeedback).toBe(60)
-            // 4 main queries + 1 precedingCountQb = 5
-            expect(mockQb.getRawOne).toHaveBeenCalledTimes(5)
+            // 1 combinedQb + 1 precedingCountQb = 2
+            expect(mockQb.getRawOne).toHaveBeenCalledTimes(2)
         })
 
         it('passes the feedbackTypes to the session subquery', async () => {
@@ -210,13 +212,13 @@ describe('statsService.getChatflowStats', () => {
             expect(feedbackCall![1]).toEqual(expect.objectContaining({ feedbackTypes: [ChatMessageRatingType.THUMBS_DOWN] }))
         })
 
-        it('appends the session subquery condition to all 4 count queries', async () => {
+        it('appends the session subquery condition to the combined count query', async () => {
             await statsService.getChatflowStats(CHATFLOW_ID, WORKSPACE_ID, undefined, undefined, undefined, [
                 ChatMessageRatingType.THUMBS_UP
             ])
 
             const sessionIdCalls = mockQb.andWhere.mock.calls.filter((call: string[]) => call[0].includes('cm.sessionId IN'))
-            expect(sessionIdCalls.length).toBe(4)
+            expect(sessionIdCalls.length).toBe(1)
         })
     })
 

--- a/packages/server/src/services/stats/index.ts
+++ b/packages/server/src/services/stats/index.ts
@@ -45,34 +45,15 @@ const getChatflowStats = async (
         else if (startDate) baseWhere.createdDate = MoreThanOrEqual(new Date(startDate))
         else if (endDate) baseWhere.createdDate = LessThanOrEqual(new Date(endDate))
 
-        // (sessions that contain at least one message with that feedback rating)
-        if (feedbackTypes && feedbackTypes.length > 0) {
-            const rows = await repo
-                .createQueryBuilder('cm2')
-                .select('DISTINCT(cm2.sessionId)', 'sessionId')
-                .innerJoin(ChatMessageFeedback, 'f2', 'f2.messageId = cm2.id')
-                .where('cm2.chatflowid = :chatflowid', { chatflowid })
-                .andWhere('f2.rating IN (:...feedbackTypes)', { feedbackTypes })
-                .getRawMany()
-
-            const qualifyingSessionIds = rows.map((r) => r.sessionId)
-
-            // No matching sessions - return zeros immediately
-            if (qualifyingSessionIds.length === 0) {
-                return { totalMessages: 0, totalSessions: 0, totalFeedback: 0, positiveFeedback: 0 }
-            }
-
-            baseWhere.sessionId = In(qualifyingSessionIds)
-        }
-
+        // TypeORM 0.3.x QueryBuilder accepts FindOptionsWhere objects (including FindOperators
+        // like In/Between) in .where() — the same WHERE clause machinery used by repo.find().
+        const totalMessagesQb = repo.createQueryBuilder('cm').select('COUNT(*)', 'count').where(baseWhere)
         const totalSessionsQb = repo.createQueryBuilder('cm').select('COUNT(DISTINCT(cm.sessionId))', 'count').where(baseWhere)
-
         const totalFeedbackQb = repo
             .createQueryBuilder('cm')
             .select('COUNT(*)', 'count')
             .innerJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
             .where(baseWhere)
-
         const positiveFeedbackQb = repo
             .createQueryBuilder('cm')
             .select('COUNT(*)', 'count')
@@ -80,15 +61,34 @@ const getChatflowStats = async (
             .where(baseWhere)
             .andWhere('f.rating = :rating', { rating: ChatMessageRatingType.THUMBS_UP })
 
-        const [totalMessages, totalSessionsRaw, totalFeedbackRaw, positiveFeedbackRaw] = await Promise.all([
-            repo.count({ where: baseWhere }),
+        if (feedbackTypes && feedbackTypes.length > 0) {
+            const sessionSubQb = repo
+                .createQueryBuilder()
+                .subQuery()
+                .select('DISTINCT cm2.sessionId')
+                .from(ChatMessage, 'cm2')
+                .innerJoin(ChatMessageFeedback, 'f2', 'f2.messageId = cm2.id')
+                .where(baseWhere)
+                .andWhere('f2.rating IN (:...feedbackTypes)', { feedbackTypes })
+
+            const subSql = sessionSubQb.getQuery()
+            const subParams = sessionSubQb.getParameters()
+
+            for (const qb of [totalMessagesQb, totalSessionsQb, totalFeedbackQb, positiveFeedbackQb]) {
+                qb.andWhere(`cm.sessionId IN ${subSql}`)
+                qb.setParameters(subParams)
+            }
+        }
+
+        const [totalMessagesRaw, totalSessionsRaw, totalFeedbackRaw, positiveFeedbackRaw] = await Promise.all([
+            totalMessagesQb.getRawOne(),
             totalSessionsQb.getRawOne(),
             totalFeedbackQb.getRawOne(),
             positiveFeedbackQb.getRawOne()
         ])
 
         return {
-            totalMessages,
+            totalMessages: parseInt(totalMessagesRaw?.count ?? '0', 10),
             totalSessions: parseInt(totalSessionsRaw?.count ?? '0', 10),
             totalFeedback: parseInt(totalFeedbackRaw?.count ?? '0', 10),
             positiveFeedback: parseInt(positiveFeedbackRaw?.count ?? '0', 10)

--- a/packages/server/src/services/stats/index.ts
+++ b/packages/server/src/services/stats/index.ts
@@ -24,7 +24,6 @@ const getChatflowStats = async (
                 `Error: statsService.getChatflowStats - activeWorkspaceId not provided!`
             )
         }
-
         const appServer = getRunningExpressApp()
 
         const chatflow = await appServer.AppDataSource.getRepository(ChatFlow).findOneBy({
@@ -39,6 +38,7 @@ const getChatflowStats = async (
 
         const repo = appServer.AppDataSource.getRepository(ChatMessage)
 
+        // Build up queries that will be used for all stats
         const baseWhere: FindOptionsWhere<ChatMessage> = { chatflowid }
         if (chatTypes && chatTypes.length > 0) baseWhere.chatType = In(chatTypes)
         if (startDate && endDate) baseWhere.createdDate = Between(new Date(startDate), new Date(endDate))
@@ -51,15 +51,20 @@ const getChatflowStats = async (
         const totalSessionsQb = repo.createQueryBuilder('cm').select('COUNT(DISTINCT(cm.sessionId))', 'count').where(baseWhere)
         const totalFeedbackQb = repo
             .createQueryBuilder('cm')
-            .select('COUNT(*)', 'count')
+            .select('COUNT(DISTINCT cm.id)', 'count')
             .innerJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
             .where(baseWhere)
         const positiveFeedbackQb = repo
             .createQueryBuilder('cm')
-            .select('COUNT(*)', 'count')
+            .select('COUNT(DISTINCT cm.id)', 'count')
             .innerJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
             .where(baseWhere)
             .andWhere('f.rating = :rating', { rating: ChatMessageRatingType.THUMBS_UP })
+
+        // When feedback filter is active, narrow all queries to sessions that contain
+        // matching feedback, restrict feedback counts to selected types, and build a
+        // precedingCount query (totalMessages = feedback msgs + their preceding user msgs).
+        let precedingCountQb: ReturnType<typeof repo.createQueryBuilder> | null = null
 
         if (feedbackTypes && feedbackTypes.length > 0) {
             const sessionSubQb = repo
@@ -78,17 +83,49 @@ const getChatflowStats = async (
                 qb.andWhere(`cm.sessionId IN ${subSql}`)
                 qb.setParameters(subParams)
             }
+
+            totalFeedbackQb.andWhere('f.rating IN (:...ratingFilter)', { ratingFilter: feedbackTypes })
+            positiveFeedbackQb.andWhere('f.rating IN (:...posRatingFilter)', { posRatingFilter: feedbackTypes })
+
+            // Anti-join: count immediate predecessors of feedback messages that aren't
+            // themselves feedback messages (to avoid double-counting).
+            precedingCountQb = repo
+                .createQueryBuilder('prev')
+                .select('COUNT(DISTINCT prev.id)', 'count')
+                .innerJoin(
+                    ChatMessage,
+                    'fb_msg',
+                    'fb_msg.chatflowid = prev.chatflowid AND fb_msg.sessionId = prev.sessionId AND fb_msg.createdDate > prev.createdDate'
+                )
+                .innerJoin(ChatMessageFeedback, 'fb', 'fb.messageId = fb_msg.id')
+                .leftJoin(
+                    ChatMessage,
+                    'btwn',
+                    'btwn.chatflowid = prev.chatflowid AND btwn.sessionId = prev.sessionId AND btwn.createdDate > prev.createdDate AND btwn.createdDate < fb_msg.createdDate'
+                )
+                .leftJoin(ChatMessageFeedback, 'prev_fb', 'prev_fb.messageId = prev.id AND prev_fb.rating IN (:...ft2)', {
+                    ft2: feedbackTypes
+                })
+                .where(baseWhere)
+                .andWhere('fb.rating IN (:...ft)', { ft: feedbackTypes })
+                .andWhere('btwn.id IS NULL')
+                .andWhere('prev_fb.id IS NULL')
         }
 
-        const [totalMessagesRaw, totalSessionsRaw, totalFeedbackRaw, positiveFeedbackRaw] = await Promise.all([
+        const [totalMessagesRaw, totalSessionsRaw, totalFeedbackRaw, positiveFeedbackRaw, precedingRaw] = await Promise.all([
             totalMessagesQb.getRawOne(),
             totalSessionsQb.getRawOne(),
             totalFeedbackQb.getRawOne(),
-            positiveFeedbackQb.getRawOne()
+            positiveFeedbackQb.getRawOne(),
+            precedingCountQb?.getRawOne() ?? Promise.resolve(null)
         ])
 
+        const totalMessages = precedingRaw
+            ? parseInt(totalFeedbackRaw?.count ?? '0', 10) + parseInt(precedingRaw.count ?? '0', 10)
+            : parseInt(totalMessagesRaw?.count ?? '0', 10)
+
         return {
-            totalMessages: parseInt(totalMessagesRaw?.count ?? '0', 10),
+            totalMessages,
             totalSessions: parseInt(totalSessionsRaw?.count ?? '0', 10),
             totalFeedback: parseInt(totalFeedbackRaw?.count ?? '0', 10),
             positiveFeedback: parseInt(positiveFeedbackRaw?.count ?? '0', 10)

--- a/packages/server/src/services/stats/index.ts
+++ b/packages/server/src/services/stats/index.ts
@@ -1,47 +1,98 @@
 import { StatusCodes } from 'http-status-codes'
+import { Between, FindOptionsWhere, In, LessThanOrEqual, MoreThanOrEqual } from 'typeorm'
 import { ChatMessageRatingType, ChatType } from '../../Interface'
 import { ChatMessage } from '../../database/entities/ChatMessage'
-import { utilGetChatMessage } from '../../utils/getChatMessage'
 import { ChatMessageFeedback } from '../../database/entities/ChatMessageFeedback'
+import { ChatFlow } from '../../database/entities/ChatFlow'
 import { InternalFlowiseError } from '../../errors/internalFlowiseError'
 import { getErrorMessage } from '../../errors/utils'
+import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
 
 // get stats for showing in chatflow
 const getChatflowStats = async (
     chatflowid: string,
+    activeWorkspaceId: string,
     chatTypes: ChatType[] | undefined,
     startDate?: string,
     endDate?: string,
-    messageId?: string,
-    feedback?: boolean,
-    feedbackTypes?: ChatMessageRatingType[],
-    activeWorkspaceId?: string
+    feedbackTypes?: ChatMessageRatingType[]
 ): Promise<any> => {
     try {
-        const chatmessages = (await utilGetChatMessage({
-            chatflowid,
-            chatTypes,
-            startDate,
-            endDate,
-            messageId,
-            feedback,
-            feedbackTypes,
-            activeWorkspaceId
-        })) as Array<ChatMessage & { feedback?: ChatMessageFeedback }>
-        const totalMessages = chatmessages.length
-        const totalFeedback = chatmessages.filter((message) => message?.feedback).length
-        const positiveFeedback = chatmessages.filter((message) => message?.feedback?.rating === 'THUMBS_UP').length
-        // count the number of unique sessions in the chatmessages - count unique sessionId
-        const uniqueSessions = new Set(chatmessages.map((message) => message.sessionId))
-        const totalSessions = uniqueSessions.size
-        const dbResponse = {
-            totalMessages,
-            totalFeedback,
-            positiveFeedback,
-            totalSessions
+        if (!activeWorkspaceId) {
+            throw new InternalFlowiseError(
+                StatusCodes.UNAUTHORIZED,
+                `Error: statsService.getChatflowStats - activeWorkspaceId not provided!`
+            )
         }
 
-        return dbResponse
+        const appServer = getRunningExpressApp()
+
+        const chatflow = await appServer.AppDataSource.getRepository(ChatFlow).findOneBy({
+            id: chatflowid,
+            workspaceId: activeWorkspaceId
+        })
+        if (!chatflow)
+            throw new InternalFlowiseError(
+                StatusCodes.FORBIDDEN,
+                `Error: statsService.getChatflowStats - chatflow ${chatflowid} not found in workspace!`
+            )
+
+        const repo = appServer.AppDataSource.getRepository(ChatMessage)
+
+        const baseWhere: FindOptionsWhere<ChatMessage> = { chatflowid }
+        if (chatTypes && chatTypes.length > 0) baseWhere.chatType = In(chatTypes)
+        if (startDate && endDate) baseWhere.createdDate = Between(new Date(startDate), new Date(endDate))
+        else if (startDate) baseWhere.createdDate = MoreThanOrEqual(new Date(startDate))
+        else if (endDate) baseWhere.createdDate = LessThanOrEqual(new Date(endDate))
+
+        // (sessions that contain at least one message with that feedback rating)
+        if (feedbackTypes && feedbackTypes.length > 0) {
+            const rows = await repo
+                .createQueryBuilder('cm2')
+                .select('DISTINCT(cm2.sessionId)', 'sessionId')
+                .innerJoin(ChatMessageFeedback, 'f2', 'f2.messageId = cm2.id')
+                .where('cm2.chatflowid = :chatflowid', { chatflowid })
+                .andWhere('f2.rating IN (:...feedbackTypes)', { feedbackTypes })
+                .getRawMany()
+
+            const qualifyingSessionIds = rows.map((r) => r.sessionId)
+
+            // No matching sessions - return zeros immediately
+            if (qualifyingSessionIds.length === 0) {
+                return { totalMessages: 0, totalSessions: 0, totalFeedback: 0, positiveFeedback: 0 }
+            }
+
+            baseWhere.sessionId = In(qualifyingSessionIds)
+        }
+
+        const totalSessionsQb = repo.createQueryBuilder('cm').select('COUNT(DISTINCT(cm.sessionId))', 'count').where(baseWhere)
+
+        const totalFeedbackQb = repo
+            .createQueryBuilder('cm')
+            .select('COUNT(*)', 'count')
+            .innerJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
+            .where(baseWhere)
+
+        const positiveFeedbackQb = repo
+            .createQueryBuilder('cm')
+            .select('COUNT(*)', 'count')
+            .innerJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
+            .where(baseWhere)
+            .andWhere('f.rating = :rating', { rating: ChatMessageRatingType.THUMBS_UP })
+
+        const [totalMessages, totalSessionsRaw, totalFeedbackRaw, positiveFeedbackRaw] = await Promise.all([
+            repo.count({ where: baseWhere }),
+            totalSessionsQb.getRawOne(),
+            totalFeedbackQb.getRawOne(),
+            positiveFeedbackQb.getRawOne()
+        ])
+
+        return {
+            totalMessages,
+            totalSessions: parseInt(totalSessionsRaw?.count ?? '0', 10),
+            totalFeedback: parseInt(totalFeedbackRaw?.count ?? '0', 10),
+            positiveFeedback: parseInt(positiveFeedbackRaw?.count ?? '0', 10)
+        }
     } catch (error) {
         throw new InternalFlowiseError(
             StatusCodes.INTERNAL_SERVER_ERROR,

--- a/packages/server/src/services/stats/index.ts
+++ b/packages/server/src/services/stats/index.ts
@@ -38,35 +38,15 @@ const getChatflowStats = async (
 
         const repo = appServer.AppDataSource.getRepository(ChatMessage)
 
-        // Build up queries that will be used for all stats
+        // Build base WHERE conditions shared by all queries
         const baseWhere: FindOptionsWhere<ChatMessage> = { chatflowid }
         if (chatTypes && chatTypes.length > 0) baseWhere.chatType = In(chatTypes)
         if (startDate && endDate) baseWhere.createdDate = Between(new Date(startDate), new Date(endDate))
         else if (startDate) baseWhere.createdDate = MoreThanOrEqual(new Date(startDate))
         else if (endDate) baseWhere.createdDate = LessThanOrEqual(new Date(endDate))
 
-        // TypeORM 0.3.x QueryBuilder accepts FindOptionsWhere objects (including FindOperators
-        // like In/Between) in .where() — the same WHERE clause machinery used by repo.find().
-        const totalMessagesQb = repo.createQueryBuilder('cm').select('COUNT(*)', 'count').where(baseWhere)
-        const totalSessionsQb = repo.createQueryBuilder('cm').select('COUNT(DISTINCT(cm.sessionId))', 'count').where(baseWhere)
-        const totalFeedbackQb = repo
-            .createQueryBuilder('cm')
-            .select('COUNT(DISTINCT cm.id)', 'count')
-            .innerJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
-            .where(baseWhere)
-        const positiveFeedbackQb = repo
-            .createQueryBuilder('cm')
-            .select('COUNT(DISTINCT cm.id)', 'count')
-            .innerJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
-            .where(baseWhere)
-            .andWhere('f.rating = :rating', { rating: ChatMessageRatingType.THUMBS_UP })
-
-        // When feedback filter is active, narrow all queries to sessions that contain
-        // matching feedback, restrict feedback counts to selected types, and build a
-        // precedingCount query (totalMessages = feedback msgs + their preceding user msgs).
-        let precedingCountQb: ReturnType<typeof repo.createQueryBuilder> | null = null
-
         if (feedbackTypes && feedbackTypes.length > 0) {
+            // Scoping subquery: find sessions that contain qualifying feedback
             const sessionSubQb = repo
                 .createQueryBuilder()
                 .subQuery()
@@ -75,21 +55,24 @@ const getChatflowStats = async (
                 .innerJoin(ChatMessageFeedback, 'f2', 'f2.messageId = cm2.id')
                 .where(baseWhere)
                 .andWhere('f2.rating IN (:...feedbackTypes)', { feedbackTypes })
-
             const subSql = sessionSubQb.getQuery()
             const subParams = sessionSubQb.getParameters()
 
-            for (const qb of [totalMessagesQb, totalSessionsQb, totalFeedbackQb, positiveFeedbackQb]) {
-                qb.andWhere(`cm.sessionId IN ${subSql}`)
-                qb.setParameters(subParams)
-            }
-
-            totalFeedbackQb.andWhere('f.rating IN (:...ratingFilter)', { ratingFilter: feedbackTypes })
-            positiveFeedbackQb.andWhere('f.rating IN (:...posRatingFilter)', { posRatingFilter: feedbackTypes })
+            // Combined query: totalSessions, totalFeedback, positiveFeedback — scoped to qualifying sessions.
+            const combinedQb = repo
+                .createQueryBuilder('cm')
+                .select('COUNT(DISTINCT cm.sessionId)', 'totalSessions')
+                .addSelect('COUNT(DISTINCT f.id)', 'totalFeedback')
+                .addSelect('COUNT(DISTINCT CASE WHEN f.rating = :posRating THEN f.id END)', 'positiveFeedback')
+                .innerJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
+                .where(baseWhere)
+                .andWhere(`cm.sessionId IN ${subSql}`)
+                .andWhere('f.rating IN (:...ratingFilter)', { ratingFilter: feedbackTypes })
+                .setParameters({ ...subParams, posRating: ChatMessageRatingType.THUMBS_UP })
 
             // Anti-join: count immediate predecessors of feedback messages that aren't
             // themselves feedback messages (to avoid double-counting).
-            precedingCountQb = repo
+            const precedingCountQb = repo
                 .createQueryBuilder('prev')
                 .select('COUNT(DISTINCT prev.id)', 'count')
                 .innerJoin(
@@ -110,25 +93,34 @@ const getChatflowStats = async (
                 .andWhere('fb.rating IN (:...ft)', { ft: feedbackTypes })
                 .andWhere('btwn.id IS NULL')
                 .andWhere('prev_fb.id IS NULL')
+
+            const [combinedRaw, precedingRaw] = await Promise.all([combinedQb.getRawOne(), precedingCountQb.getRawOne()])
+
+            return {
+                totalMessages: parseInt(combinedRaw?.totalFeedback ?? '0', 10) + parseInt(precedingRaw?.count ?? '0', 10),
+                totalSessions: parseInt(combinedRaw?.totalSessions ?? '0', 10),
+                totalFeedback: parseInt(combinedRaw?.totalFeedback ?? '0', 10),
+                positiveFeedback: parseInt(combinedRaw?.positiveFeedback ?? '0', 10)
+            }
         }
 
-        const [totalMessagesRaw, totalSessionsRaw, totalFeedbackRaw, positiveFeedbackRaw, precedingRaw] = await Promise.all([
-            totalMessagesQb.getRawOne(),
-            totalSessionsQb.getRawOne(),
-            totalFeedbackQb.getRawOne(),
-            positiveFeedbackQb.getRawOne(),
-            precedingCountQb?.getRawOne() ?? Promise.resolve(null)
-        ])
-
-        const totalMessages = precedingRaw
-            ? parseInt(totalFeedbackRaw?.count ?? '0', 10) + parseInt(precedingRaw.count ?? '0', 10)
-            : parseInt(totalMessagesRaw?.count ?? '0', 10)
+        // Single query: total messages, sessions, and feedback counts with thumbs-up breakdown
+        const statsRaw = await repo
+            .createQueryBuilder('cm')
+            .select('COUNT(*)', 'totalMessages')
+            .addSelect('COUNT(DISTINCT cm.sessionId)', 'totalSessions')
+            .addSelect('COUNT(DISTINCT f.id)', 'totalFeedback')
+            .addSelect('COUNT(DISTINCT CASE WHEN f.rating = :thumbsUp THEN f.id END)', 'positiveFeedback')
+            .leftJoin(ChatMessageFeedback, 'f', 'f.messageId = cm.id')
+            .where(baseWhere)
+            .setParameter('thumbsUp', ChatMessageRatingType.THUMBS_UP)
+            .getRawOne()
 
         return {
-            totalMessages,
-            totalSessions: parseInt(totalSessionsRaw?.count ?? '0', 10),
-            totalFeedback: parseInt(totalFeedbackRaw?.count ?? '0', 10),
-            positiveFeedback: parseInt(positiveFeedbackRaw?.count ?? '0', 10)
+            totalMessages: parseInt(statsRaw?.totalMessages ?? '0', 10),
+            totalSessions: parseInt(statsRaw?.totalSessions ?? '0', 10),
+            totalFeedback: parseInt(statsRaw?.totalFeedback ?? '0', 10),
+            positiveFeedback: parseInt(statsRaw?.positiveFeedback ?? '0', 10)
         }
     } catch (error) {
         throw new InternalFlowiseError(


### PR DESCRIPTION
**Issue:**
`statsService.getChatflowStats` fetched every message row into the Node.js heap to just to calculate the `.length` of those `chat_message` rows.
When theres too many messages (like 100,000), it will overload the memory just to get the count of these messages.

**Change / Fix:**
Instead of getting ALL messages and their rows, we now just do four SQL queries (+ 1 more preceding messages if theres feedback types filter) that just gets the count / length number which is what `getChatflowStats` returns anyways.
Fixes: https://github.com/FlowiseAI/Flowise/issues/6038

**Note:**
- When dealing with this, I realize large chat message volumes is also crashing the Frontend when opening chat dialog, will open an issue / ticket and fix that seperately.

**Refactoring & Cleanup**
- Dead Code: Removed unused messageId and feedback parameters from the service signature.
- Error Handling: Migrated plain errors to InternalFlowiseError with appropriate HTTP codes (401/403).
- Testing: Added unit tests for authorization, filter operators (In, Between, etc.), and feedback subquery logic.

<details>
  <summary>Test Videos Demo</summary>

  <b>BEFORE-101k...-memory.mp4</b>
  <video src="https://github.com/user-attachments/assets/476c3b9f-9090-403d-b1f7-fe6171ea2c5e" controls width="100%"></video>

  <b>AFTER-101k-...-memory.mp4</b>
  <video src="https://github.com/user-attachments/assets/43e498b4-4c92-4d8b-b659-42c8f501cfaa" controls width="100%"></video>
</details>

<details>
  <summary>This is to show the functionality remains the same after using SQL queries, doesn't show the bug, OLD is get all chat messages method, NEW is the 4 + 1 sql query method. Both show the same thing</summary>
  <b>101k-OLD.mp4</b>
  <video src="https://github.com/user-attachments/assets/e7d6056a-d76c-4ee5-989c-06130ccbcec5" controls width="100%"></video>

  <b>101k-NEW.mp4</b>
  <video src="https://github.com/user-attachments/assets/2b82f25b-247d-4176-a8a9-4e39e68683a2" controls width="100%"></video>
</details>

<img width="309" height="84" alt="Screenshot 2026-04-13 at 1 15 54 PM" src="https://github.com/user-attachments/assets/cd0f09d7-8bc1-4726-8dac-250cf213a979" />

