### PR TITLE
fix(tools): make queryParams required when queryParamsSchema is defined

### DIFF
--- a/packages/components/nodes/tools/RequestsDelete/core.ts
+++ b/packages/components/nodes/tools/RequestsDelete/core.ts
@@ -51,7 +51,7 @@ const createRequestsDeleteSchema = (queryParamsSchema?: string) => {
 
             if (Object.keys(queryParamsObject).length > 0) {
                 return z.object({
-                    queryParams: z.object(queryParamsObject).optional().describe('Query parameters for the request')
+                    queryParams: z.object(queryParamsObject).describe('Query parameters for the request')
                 })
             }
         } catch (error) {

--- a/packages/components/nodes/tools/RequestsGet/core.ts
+++ b/packages/components/nodes/tools/RequestsGet/core.ts
@@ -51,7 +51,7 @@ const createRequestsGetSchema = (queryParamsSchema?: string) => {
 
             if (Object.keys(queryParamsObject).length > 0) {
                 return z.object({
-                    queryParams: z.object(queryParamsObject).optional().describe('Query parameters for the request')
+                    queryParams: z.object(queryParamsObject).describe('Query parameters for the request')
                 })
             }
         } catch (error) {


### PR DESCRIPTION
Fixes #5940

## Problem

When using the **Requests Get** or **Requests Delete** node with a Query Params Schema containing **2 or more optional parameters**, the `queryParams` field is absent from the tool call — causing the LLM to send no query parameters in the HTTP request.

Root cause: `createRequestsGetSchema` and `createRequestsDeleteSchema` wrapped the `queryParams` object with `.optional()`. When all inner fields are also optional, the LLM correctly interprets that the entire `queryParams` argument is optional and omits it. With a single required parameter the LLM is forced to provide `queryParams` (since it contains a required field), which is why 1-param schemas worked.

## Solution

Remove `.optional()` from the `queryParams` field when a `queryParamsSchema` is explicitly provided. When a schema is defined, `queryParams` should always be provided by the LLM — even if all individual params are optional — so the model can choose which ones to include.

The fallback generic schema (used when no `queryParamsSchema` is configured) intentionally retains `.optional()` since no structured params are expected.

Changes:
- `packages/components/nodes/tools/RequestsGet/core.ts`
- `packages/components/nodes/tools/RequestsDelete/core.ts`

## Testing

Tested by verifying that the Zod schema generated for a 2-optional-param schema now marks `queryParams` as required, so the LLM is expected to provide the object on every tool call.