### PR TITLE
fix: guard against undefined user in auth permissions handler

### DIFF
--- a/packages/server/src/enterprise/controllers/auth/index.test.ts
+++ b/packages/server/src/enterprise/controllers/auth/index.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, beforeEach } from '@jest/globals'
+import { Request, Response, NextFunction } from 'express'
+
+// Mock logger before importing the module under test
+jest.mock('../../../utils/logger', () => ({
+    __esModule: true,
+    default: { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() }
+}))
+
+// Mock getRunningExpressApp
+const mockGetRunningExpressApp = jest.fn()
+jest.mock('../../../utils/getRunningExpressApp', () => ({
+    getRunningExpressApp: () => mockGetRunningExpressApp()
+}))
+
+import authController from './index'
+
+describe('auth controller', () => {
+    describe('getAllPermissions', () => {
+        it('should return 401 when req.user is undefined', async () => {
+            const req = {
+                params: { type: 'resolve' },
+                user: undefined
+            } as unknown as Request
+
+            const json = jest.fn()
+            const status = jest.fn().mockReturnValue({ json })
+            const res = { status } as unknown as Response
+            const next = jest.fn() as unknown as NextFunction
+
+            // Mock the running app with identity manager
+            mockGetRunningExpressApp.mockReturnValue({
+                identityManager: {
+                    getPermissions: () => ({ toJSON: () => ({}) }),
+                    getPlatformType: () => 'OPEN_SOURCE'
+                }
+            })
+
+            await authController.getAllPermissions(req, res, next)
+
+            expect(status).toHaveBeenCalledWith(401)
+            expect(json).toHaveBeenCalledWith({ error: 'Unauthorized Access' })
+            expect(next).not.toHaveBeenCalled()
+        })
+
+        it('should return permissions when req.user is present', async () => {
+            const req = {
+                params: { type: 'ROLE' },
+                user: {
+                    isOrganizationAdmin: true,
+                    permissions: [],
+                    features: {}
+                }
+            } as unknown as Request
+
+            const json = jest.fn()
+            const status = jest.fn().mockReturnValue({ json })
+            const res = { status } as unknown as Response
+            const next = jest.fn() as unknown as NextFunction
+
+            const mockPermissions = {
+                chatflows: [{ key: 'chatflows:read', value: 'Read Chatflows' }]
+            }
+
+            mockGetRunningExpressApp.mockReturnValue({
+                identityManager: {
+                    getPermissions: () => ({ toJSON: () => mockPermissions }),
+                    getPlatformType: () => 'OPEN_SOURCE'
+                }
+            })
+
+            await authController.getAllPermissions(req, res, next)
+
+            expect(status).toHaveBeenCalledWith(200)
+            expect(json).toHaveBeenCalledWith(mockPermissions)
+        })
+    })
+})

--- a/packages/server/src/enterprise/controllers/auth/index.ts
+++ b/packages/server/src/enterprise/controllers/auth/index.ts
@@ -9,7 +9,10 @@ const getAllPermissions = async (req: Request, res: Response, next: NextFunction
         const appServer = getRunningExpressApp()
         const type = req.params.type as string
         const allPermissions = appServer.identityManager.getPermissions().toJSON()
-        const user = req.user as LoggedInUser
+        const user = req.user as LoggedInUser | undefined
+        if (!user) {
+            return res.status(StatusCodes.UNAUTHORIZED).json({ error: 'Unauthorized Access' })
+        }
 
         let permissions: { [key: string]: { key: string; value: string }[] } = allPermissions
 


### PR DESCRIPTION
## Summary

Fixes #6105 — `/api/v1/auth/resolve` returns 500 Internal Server Error on all Flowise 3.x versions, breaking the login flow.

## Root Cause

The `GET /api/v1/auth/:type` route (in `enterprise/controllers/auth/index.ts`) uses a `:type` parameter that matches **any** path segment, including `resolve`. When the UI calls `GET /api/v1/auth/resolve`:

1. The request is **whitelisted** (skips JWT authentication), so `req.user` is `undefined`
2. The `getAllPermissions` handler casts `req.user` to `LoggedInUser` and accesses `user.isOrganizationAdmin` (line 77)
3. This throws `TypeError: Cannot read properties of undefined (reading 'isOrganizationAdmin')`
4. Express catches it and returns 500

Note: The actual `POST /api/v1/auth/resolve` handler (registered in passport middleware) works fine — the issue is the `:type` catch-all route intercepting GET requests.

## Fix

Added a null check for `req.user` at the top of `getAllPermissions`. Returns `401 Unauthorized` before accessing any user properties.

```diff
-        const user = req.user as LoggedInUser
+        const user = req.user as LoggedInUser | undefined
+        if (!user) {
+            return res.status(StatusCodes.UNAUTHORIZED).json({ error: 'Unauthorized Access' })
+        }
```

## Test Plan

- [x] Added co-located test `index.test.ts` with 2 cases:
  - `req.user` undefined → returns 401 (fails before fix, passes after)
  - `req.user` present → returns permissions normally
- [x] Existing server tests pass with no regressions

cc @HenryHengZJ @chungyau97