### PR TITLE
fix(embeddings): default encodingFormat to float for OpenAI Custom Embedding with local servers

### DIFF
--- a/packages/components/nodes/embeddings/OpenAIEmbeddingCustom/OpenAIEmbeddingCustom.ts
+++ b/packages/components/nodes/embeddings/OpenAIEmbeddingCustom/OpenAIEmbeddingCustom.ts
@@ -17,7 +17,7 @@ class OpenAIEmbeddingCustom_Embeddings implements INode {
     constructor() {
         this.label = 'OpenAI Custom Embedding'
         this.name = 'openAIEmbeddingsCustom'
-        this.version = 3.0
+        this.version = 3.1
         this.type = 'OpenAIEmbeddingsCustom'
         this.icon = 'openai.svg'
         this.category = 'Embeddings'
@@ -94,6 +94,8 @@ class OpenAIEmbeddingCustom_Embeddings implements INode {
                         name: 'base64'
                     }
                 ],
+                default: 'float',
+                description: 'Format for the embedding values. Use "float" for compatibility with local servers (LMStudio, Ollama, LiteLLM, etc.).',
                 optional: true,
                 additionalParams: true
             }
@@ -122,7 +124,12 @@ class OpenAIEmbeddingCustom_Embeddings implements INode {
         if (timeout) obj.timeout = parseInt(timeout, 10)
         if (modelName) obj.modelName = modelName
         if (dimensions) obj.dimensions = parseInt(dimensions, 10)
-        if (encodingFormat) obj.encodingFormat = encodingFormat
+
+        // When using a custom base path (local server), default to 'float' encoding for compatibility.
+        // Many local servers (LMStudio, Ollama, LiteLLM, Infinity, etc.) do not support base64 encoding
+        // and may return zero vectors when base64 is requested.
+        const effectiveEncodingFormat = encodingFormat || (basePath ? 'float' : undefined)
+        if (effectiveEncodingFormat) obj.encodingFormat = effectiveEncodingFormat
 
         let parsedBaseOptions: any | undefined = undefined
         if (baseOptions) {


### PR DESCRIPTION
Fixes #5499

## Problem

When using the **OpenAI Custom Embedding** node with local embedding servers (LMStudio, Ollama, LiteLLM, Infinity, etc.), embeddings are stored as all-zero vectors. This causes dimension-mismatch errors and incorrect similarity search results in vector stores.

The root cause is that many local servers do not support `base64` encoding format for embedding responses. When `base64` is requested (or becomes the default in newer LangChain versions), these servers silently return zero vectors instead of raising an error.

This is also related to #5693, where a different local embedding server (LiteLLM + Infinity) produces unexpected dimension mismatches.

## Solution

- Set the default value of `encodingFormat` to `float` in the node parameter UI
- In the `init` function, when a custom `basePath` is configured and no encoding format is explicitly specified, automatically use `float` encoding for compatibility with local servers
- Add a descriptive hint in the parameter description explaining the recommendation for local servers
- Bump node version from 3.0 to 3.1

Users who need `base64` encoding (e.g., when using the standard OpenAI API for performance) can still explicitly select it.

## Testing

- Verified the node initializes correctly with and without `basePath` set
- `float` encoding is used when `basePath` is set and no format is specified
- Explicit `base64` selection overrides the default in all cases
- Existing behavior for standard OpenAI API (no `basePath`) is unchanged