### PR TITLE
Chore/include action metadata from API responses

### DIFF
--- a/packages/server/src/queue/RedisEventPublisher.ts
+++ b/packages/server/src/queue/RedisEventPublisher.ts
@@ -198,6 +198,9 @@ export class RedisEventPublisher implements IServerSideEventStreamer {
             if (apiResponse.memoryType) {
                 metadataJson['memoryType'] = apiResponse.memoryType
             }
+            if (apiResponse.action) {
+                metadataJson['action'] = typeof apiResponse.action === 'string' ? JSON.parse(apiResponse.action) : apiResponse.action
+            }
             if (Object.keys(metadataJson).length > 0) {
                 this.streamCustomEvent(chatId, 'metadata', metadataJson)
             }

--- a/packages/server/src/utils/SSEStreamer.ts
+++ b/packages/server/src/utils/SSEStreamer.ts
@@ -231,6 +231,9 @@ export class SSEStreamer implements IServerSideEventStreamer {
             metadataJson['flowVariables'] =
                 typeof apiResponse.flowVariables === 'string' ? JSON.parse(apiResponse.flowVariables) : apiResponse.flowVariables
         }
+        if (apiResponse.action) {
+            metadataJson['action'] = typeof apiResponse.action === 'string' ? JSON.parse(apiResponse.action) : apiResponse.action
+        }
         if (Object.keys(metadataJson).length > 0) {
             this.streamCustomEvent(chatId, 'metadata', metadataJson)
         }

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -2331,6 +2331,7 @@ export const executeAgentFlow = async ({
     result.followUpPrompts = JSON.stringify(apiMessage.followUpPrompts)
     result.executionId = newExecution.id
     result.agentFlowExecutedData = agentFlowExecutedData
+    if (apiMessage.action) result.action = JSON.parse(apiMessage.action)
 
     if (sessionId) result.sessionId = sessionId
 

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -871,6 +871,7 @@ export const executeFlow = async ({
         if (result?.usedTools) apiMessage.usedTools = JSON.stringify(result.usedTools)
         if (result?.fileAnnotations) apiMessage.fileAnnotations = JSON.stringify(result.fileAnnotations)
         if (result?.artifacts) apiMessage.artifacts = JSON.stringify(result.artifacts)
+        if (result?.action) apiMessage.action = typeof result.action === 'string' ? result.action : JSON.stringify(result.action)
         if (chatflow.followUpPrompts) {
             const followUpPromptsConfig = JSON.parse(chatflow.followUpPrompts)
             const followUpPrompts = await generateFollowUpPrompts(followUpPromptsConfig, apiMessage.content, {


### PR DESCRIPTION
## Issue
When an agentflow hits a human-in-the-loop node (human input or agent tool approval), an action object is created containing approve/reject buttons and context data. This action is stored in the database and streamed via SSE to the UI — but it is not returned in the non-streaming prediction API response for agentflows. Developers building on the prediction API cannot detect when human input is needed without parsing SSE streams.

## Fix
Add action to agentflow non-streaming response