### PR TITLE
fix/agentflow: Update default values and auto-add Start node for empty state

### DIFF
--- a/packages/agentflow/examples/src/demos/CustomUIExample.tsx
+++ b/packages/agentflow/examples/src/demos/CustomUIExample.tsx
@@ -12,26 +12,6 @@ import { Agentflow } from '@flowiseai/agentflow'
 
 import { apiBaseUrl, token } from '../config'
 
-const initialFlow: FlowData = {
-    nodes: [
-        {
-            id: 'startAgentflow_0',
-            type: 'agentflowNode',
-            position: { x: 300, y: 200 },
-            data: {
-                id: 'startAgentflow_0',
-                name: 'startAgentflow',
-                label: 'Start',
-                color: '#7EE787',
-                hideInput: true,
-                outputAnchors: [{ id: 'startAgentflow_0-output-0', name: 'start', label: 'Start', type: 'start' }]
-            }
-        }
-    ],
-    edges: [],
-    viewport: { x: 0, y: 0, zoom: 1 }
-}
-
 // Custom header component
 function CustomHeader({ flowName, isDirty, onSave, onExport, onValidate }: HeaderRenderProps) {
     const [validationStatus, setValidationStatus] = useState<'valid' | 'invalid' | null>(null)
@@ -259,11 +239,11 @@ export function CustomUIExample() {
                     ref={agentflowRef}
                     apiBaseUrl={apiBaseUrl}
                     token={token ?? undefined}
-                    initialFlow={initialFlow}
                     renderHeader={(props: HeaderRenderProps) => <CustomHeader {...props} />}
                     renderNodePalette={(props: PaletteRenderProps) => <CustomPalette {...props} />}
                     showDefaultHeader={false}
                     showDefaultPalette={false}
+                    enableGenerator={false}
                     onSave={(flow: FlowData) => {
                         console.log('Saving flow:', flow)
                         alert('Flow saved! Check console.')
@@ -277,10 +257,10 @@ export function CustomUIExample() {
 export const CustomUIExampleProps = {
     apiBaseUrl: '{from environment variables}',
     token: '{from environment variables}',
-    initialFlow: 'FlowData',
     renderHeader: '(props: HeaderRenderProps) => ReactNode',
     renderNodePalette: '(props: PaletteRenderProps) => ReactNode',
     showDefaultHeader: false,
     showDefaultPalette: false,
+    enableGenerator: false,
     onSave: '(flow: FlowData) => void'
 }

--- a/packages/agentflow/src/Agentflow.test.tsx
+++ b/packages/agentflow/src/Agentflow.test.tsx
@@ -6,13 +6,16 @@
 import { createRef } from 'react'
 
 import { fireEvent, render, waitFor } from '@testing-library/react'
+import mockAxios from 'axios'
 
-import type { AgentFlowInstance, FlowData } from './core/types'
+import type { AgentFlowInstance, AgentflowProps, FlowData } from './core/types'
 import { Agentflow } from './Agentflow'
 
 // Mock external dependencies - implementations in __mocks__/
 jest.mock('reactflow')
 jest.mock('axios')
+
+const mockGet = mockAxios.get as jest.Mock
 
 // Mock GenerateFlowDialog to expose callbacks for testing
 jest.mock('./features/generator', () => ({
@@ -480,6 +483,108 @@ describe('Agentflow Component', () => {
             unmount()
 
             expect(document.getElementById('agentflow-css-variables')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('Auto Start Node Initialization', () => {
+        const startNodeSchema = {
+            name: 'startAgentflow',
+            label: 'Start',
+            type: 'Start',
+            category: 'Agent Flows',
+            description: 'Start node',
+            baseClasses: ['Start'],
+            inputs: [],
+            outputs: [],
+            version: 1
+        }
+
+        beforeEach(() => {
+            // Mock API to return a startAgentflow node definition
+            mockGet.mockImplementation((url: string) => {
+                if (typeof url === 'string' && url.includes('/nodes')) {
+                    return Promise.resolve({ data: [startNodeSchema] })
+                }
+                return Promise.resolve({ data: [] })
+            })
+        })
+
+        afterEach(() => {
+            // Restore default mock (empty array)
+            mockGet.mockImplementation(() => Promise.resolve({ data: [] }))
+        })
+
+        /** Helper: render without initialFlow and assert Start node via ref */
+        const renderAndGetNodes = async (initialFlow?: FlowData | null) => {
+            const ref = createRef<AgentFlowInstance>()
+            const props: Record<string, unknown> = { apiBaseUrl: 'https://example.com', ref }
+            if (initialFlow !== undefined) props.initialFlow = initialFlow
+
+            render(<Agentflow {...(props as unknown as AgentflowProps)} />)
+
+            await waitFor(() => {
+                expect(ref.current).toBeDefined()
+                const flow = ref.current!.getFlow()
+                expect(flow.nodes.length).toBeGreaterThan(0)
+            })
+            return ref.current!.getFlow().nodes
+        }
+
+        it('should auto-add Start node when initialFlow is undefined', async () => {
+            const nodes = await renderAndGetNodes()
+            expect(nodes).toHaveLength(1)
+            expect(nodes[0].id).toBe('startAgentflow_0')
+            expect(nodes[0].data.name).toBe('startAgentflow')
+            expect(nodes[0].data.label).toBe('Start')
+        })
+
+        it('should auto-add Start node when initialFlow is null', async () => {
+            const nodes = await renderAndGetNodes(null)
+            expect(nodes).toHaveLength(1)
+            expect(nodes[0].data.name).toBe('startAgentflow')
+        })
+
+        it('should auto-add Start node when initialFlow has empty nodes', async () => {
+            const emptyFlow: FlowData = { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } }
+            const nodes = await renderAndGetNodes(emptyFlow)
+            expect(nodes).toHaveLength(1)
+            expect(nodes[0].data.name).toBe('startAgentflow')
+        })
+
+        it('should auto-add Start node when initialFlow is empty object', async () => {
+            const nodes = await renderAndGetNodes({} as FlowData)
+            expect(nodes).toHaveLength(1)
+            expect(nodes[0].data.name).toBe('startAgentflow')
+        })
+
+        it('should handle initialFlow with unrelated fields without errors', async () => {
+            const illegalFlow = { foo: 'bar', baz: 123 } as unknown as FlowData
+            const nodes = await renderAndGetNodes(illegalFlow)
+
+            expect(nodes).toHaveLength(1)
+            expect(nodes[0].data.name).toBe('startAgentflow')
+        })
+
+        it('should handle initialFlow with wrong types for nodes/edges without crashing', async () => {
+            const illegalFlow = { nodes: 'not-an-array', edges: 42 } as unknown as FlowData
+            const nodes = await renderAndGetNodes(illegalFlow)
+
+            // Non-array nodes/edges are safely ignored, auto-init adds Start node
+            expect(nodes).toHaveLength(1)
+            expect(nodes[0].data.name).toBe('startAgentflow')
+        })
+
+        it('should not auto-add Start node when initialFlow has nodes', async () => {
+            const ref = createRef<AgentFlowInstance>()
+            render(<Agentflow {...defaultProps} initialFlow={mockFlow} ref={ref} />)
+
+            await waitFor(() => {
+                expect(ref.current).toBeDefined()
+            })
+            const nodes = ref.current!.getFlow().nodes
+            // Should only have the one node from mockFlow, no duplicate Start added
+            const startNodes = nodes.filter((n) => n.data.name === 'startAgentflow')
+            expect(startNodes).toHaveLength(1)
         })
     })
 })

--- a/packages/agentflow/src/Agentflow.tsx
+++ b/packages/agentflow/src/Agentflow.tsx
@@ -6,6 +6,7 @@ import { IconSparkles } from '@tabler/icons-react'
 
 import { tokens } from './core/theme'
 import type { AgentFlowInstance, AgentflowProps, FlowData, FlowDataCallback, FlowEdge, FlowNode } from './core/types'
+import { initNode, resolveNodeType } from './core/utils'
 import { applyValidationErrorsToNodes, validateFlow } from './core/validation'
 import {
     AgentflowHeader,
@@ -80,8 +81,10 @@ function AgentflowCanvas({
         }
     }, [isDarkMode])
 
-    const [nodes, setLocalNodes, onNodesChange] = useNodesState(initialFlow?.nodes || [])
-    const [edges, setLocalEdges, onEdgesChange] = useEdgesState(initialFlow?.edges || [])
+    const safeInitialNodes = Array.isArray(initialFlow?.nodes) ? initialFlow.nodes : []
+    const safeInitialEdges = Array.isArray(initialFlow?.edges) ? initialFlow.edges : []
+    const [nodes, setLocalNodes, onNodesChange] = useNodesState(safeInitialNodes)
+    const [edges, setLocalEdges, onEdgesChange] = useEdgesState(safeInitialEdges)
     const [showGenerateDialog, setShowGenerateDialog] = useState(false)
 
     // Constraint violation snackbar state
@@ -97,6 +100,29 @@ function AgentflowCanvas({
 
     // Load available nodes
     const { availableNodes } = useFlowNodes()
+
+    // Auto-add Start node when creating a new (empty) canvas.
+    // Only runs once: when availableNodes first loads and the canvas has no initial flow.
+    const hasInitialFlow = safeInitialNodes.length > 0
+    const startNodeInitialized = useRef(false)
+    useEffect(() => {
+        if (hasInitialFlow || startNodeInitialized.current) return
+        if (availableNodes.length === 0) return
+
+        const startNodeDef = availableNodes.find((n) => n.name === 'startAgentflow')
+        if (!startNodeDef) return
+
+        startNodeInitialized.current = true
+        const startNodeId = 'startAgentflow_0'
+        const startNodeData = initNode(startNodeDef, startNodeId, true)
+        const startNode: FlowNode = {
+            id: startNodeId,
+            type: resolveNodeType(startNodeDef.type ?? ''),
+            position: { x: 100, y: 100 },
+            data: { ...startNodeData, label: 'Start' }
+        }
+        setLocalNodes([startNode])
+    }, [hasInitialFlow, availableNodes, setLocalNodes])
 
     // Register local state setters with context on mount
     useEffect(() => {

--- a/packages/agentflow/src/atoms/ArrayInput.test.tsx
+++ b/packages/agentflow/src/atoms/ArrayInput.test.tsx
@@ -302,7 +302,7 @@ describe('ArrayInput', () => {
 
         expect(mockOnDataChange).toHaveBeenCalledWith({
             inputParam: inputParamWithTypes,
-            newValue: [{ str: '', num: 0, bool: false, arr: [] }]
+            newValue: [{ str: '', num: '', bool: false, arr: [] }]
         })
     })
 

--- a/packages/agentflow/src/atoms/MessagesInput.test.tsx
+++ b/packages/agentflow/src/atoms/MessagesInput.test.tsx
@@ -136,14 +136,14 @@ describe('MessagesInput', () => {
 
     // --- Add ---
 
-    it('should add a new message with default role "user" and empty content', () => {
+    it('should add a new message with empty role and empty content', () => {
         render(<MessagesInput inputParam={mockInputParam} data={mockNodeData} onDataChange={mockOnDataChange} />)
 
         fireEvent.click(screen.getByRole('button', { name: /Add Messages/i }))
 
         expect(mockOnDataChange).toHaveBeenCalledWith({
             inputParam: mockInputParam,
-            newValue: [{ role: 'user', content: '' }]
+            newValue: [{ role: '', content: '' }]
         })
     })
 
@@ -163,7 +163,7 @@ describe('MessagesInput', () => {
             inputParam: mockInputParam,
             newValue: [
                 { role: 'system', content: 'Hello' },
-                { role: 'user', content: '' }
+                { role: '', content: '' }
             ]
         })
     })

--- a/packages/agentflow/src/atoms/MessagesInput.tsx
+++ b/packages/agentflow/src/atoms/MessagesInput.tsx
@@ -22,7 +22,7 @@ const MESSAGE_ROLES = [
 type MessageRole = (typeof MESSAGE_ROLES)[number]['value']
 
 export interface MessageEntry {
-    role: MessageRole
+    role: MessageRole | ''
     content: string
 }
 
@@ -77,7 +77,7 @@ export function MessagesInput({ inputParam, data, disabled = false, variableItem
     )
 
     const handleAddMessage = useCallback(() => {
-        const newMessage: MessageEntry = { role: 'user', content: '' }
+        const newMessage: MessageEntry = { role: '', content: '' }
         onDataChange?.({ inputParam, newValue: [...messages, newMessage] })
     }, [messages, inputParam, onDataChange])
 

--- a/packages/agentflow/src/core/primitives/inputDefaults.test.ts
+++ b/packages/agentflow/src/core/primitives/inputDefaults.test.ts
@@ -15,8 +15,8 @@ describe('getDefaultValueForType', () => {
         expect(getDefaultValueForType({ type: 'boolean' })).toBe(false)
     })
 
-    it('returns 0 for number', () => {
-        expect(getDefaultValueForType({ type: 'number' })).toBe(0)
+    it("returns '' for number without explicit default", () => {
+        expect(getDefaultValueForType({ type: 'number' })).toBe('')
     })
 
     it("returns '{}' for json", () => {
@@ -27,22 +27,26 @@ describe('getDefaultValueForType', () => {
         expect(getDefaultValueForType({ type: 'array' })).toEqual([])
     })
 
-    it('returns first option name for object options', () => {
+    it("returns '' for options without explicit default", () => {
         expect(
             getDefaultValueForType({
                 type: 'options',
                 options: [{ name: 'first' }, { name: 'second' }]
             })
-        ).toBe('first')
-    })
-
-    it('returns first option value for string options', () => {
-        expect(getDefaultValueForType({ type: 'options', options: ['alpha', 'beta'] })).toBe('alpha')
-    })
-
-    it("returns '' for options with no options", () => {
+        ).toBe('')
+        expect(getDefaultValueForType({ type: 'options', options: ['alpha', 'beta'] })).toBe('')
         expect(getDefaultValueForType({ type: 'options' })).toBe('')
         expect(getDefaultValueForType({ type: 'options', options: [] })).toBe('')
+    })
+
+    it('returns explicit default for options when provided', () => {
+        expect(
+            getDefaultValueForType({
+                type: 'options',
+                default: 'second',
+                options: [{ name: 'first' }, { name: 'second' }]
+            })
+        ).toBe('second')
     })
 
     it("returns '' for string", () => {

--- a/packages/agentflow/src/core/primitives/inputDefaults.ts
+++ b/packages/agentflow/src/core/primitives/inputDefaults.ts
@@ -8,8 +8,7 @@
  */
 export function getDefaultValueForType({
     type,
-    default: defaultValue,
-    options
+    default: defaultValue
 }: {
     type: string
     default?: unknown
@@ -21,16 +20,12 @@ export function getDefaultValueForType({
         case 'boolean':
             return false
         case 'number':
-            return 0
+            return ''
         case 'json':
             return '{}'
         case 'array':
             return []
-        case 'options': {
-            const first = options?.[0]
-            if (!first) return ''
-            return typeof first === 'string' ? first : first.name
-        }
+        case 'options':
         case 'string':
         case 'password':
         default:

--- a/packages/agentflow/src/infrastructure/store/AgentflowContext.tsx
+++ b/packages/agentflow/src/infrastructure/store/AgentflowContext.tsx
@@ -99,8 +99,8 @@ interface AgentflowStateProviderProps {
 export function AgentflowStateProvider({ children, initialFlow }: AgentflowStateProviderProps) {
     const [state, dispatch] = useReducer(agentflowReducer, {
         ...initialState,
-        nodes: normalizeNodes(initialFlow?.nodes || []),
-        edges: initialFlow?.edges || []
+        nodes: normalizeNodes(Array.isArray(initialFlow?.nodes) ? initialFlow.nodes : []),
+        edges: Array.isArray(initialFlow?.edges) ? initialFlow.edges : []
     })
 
     // Store ReactFlow local state setters in refs which are populated by AgentflowCanvas


### PR DESCRIPTION
- Implemented auto-add functionality for Start node in Agentflow when creating a new canvas.
- Updated default values for number and options types to return empty strings instead of zero or first option name.
- Adjusted MessagesInput and ArrayInput tests to reflect changes in default values.

FLOWISE-497 FLOWISE-509 FLOWISE-494


https://github.com/user-attachments/assets/efabb9da-d52b-4009-bf05-1494575a8944

https://github.com/user-attachments/assets/4f0cc50f-b0af-4c8d-9bf2-793daa2f63a2
