### PR TITLE
fix(agentflow): add onFlowChange notifications for deleteNode, deleteEdge, and duplicateNode actions

### DIFF
--- a/packages/agentflow/src/infrastructure/store/AgentflowContext.test.tsx
+++ b/packages/agentflow/src/infrastructure/store/AgentflowContext.test.tsx
@@ -1336,4 +1336,99 @@ describe('AgentflowContext', () => {
             expect(result.current.state.nodes.find((n) => n.id === 'Node 1_0')).toBeDefined()
         })
     })
+
+    describe('onFlowChange notifications', () => {
+        const mockOnFlowChange = jest.fn()
+
+        beforeEach(() => {
+            mockOnFlowChange.mockClear()
+        })
+
+        it('should call onFlowChange when deleteNode is called', () => {
+            const initialFlow: FlowData = {
+                nodes: [makeNode('node-1'), makeNode('node-2')],
+                edges: [makeEdge('node-1', 'node-2')]
+            }
+
+            const { result } = renderHook(() => useAgentflowContext(), {
+                wrapper: createWrapper(initialFlow)
+            })
+
+            act(() => {
+                result.current.registerOnFlowChange(mockOnFlowChange)
+            })
+
+            act(() => {
+                result.current.deleteNode('node-2')
+            })
+
+            expect(mockOnFlowChange).toHaveBeenCalledTimes(1)
+            expect(mockOnFlowChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    nodes: expect.arrayContaining([expect.objectContaining({ id: 'node-1' })]),
+                    edges: []
+                })
+            )
+            // Deleted node should not be in the callback payload
+            const callArgs = mockOnFlowChange.mock.calls[0][0]
+            expect(callArgs.nodes.find((n: FlowNode) => n.id === 'node-2')).toBeUndefined()
+        })
+
+        it('should call onFlowChange when deleteEdge is called', () => {
+            const initialFlow: FlowData = {
+                nodes: [makeNode('node-1'), makeNode('node-2')],
+                edges: [makeEdge('node-1', 'node-2'), makeEdge('node-2', 'node-1')]
+            }
+
+            const { result } = renderHook(() => useAgentflowContext(), {
+                wrapper: createWrapper(initialFlow)
+            })
+
+            act(() => {
+                result.current.registerOnFlowChange(mockOnFlowChange)
+            })
+
+            act(() => {
+                result.current.deleteEdge('node-1-node-2')
+            })
+
+            expect(mockOnFlowChange).toHaveBeenCalledTimes(1)
+            expect(mockOnFlowChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    nodes: expect.arrayContaining([expect.objectContaining({ id: 'node-1' }), expect.objectContaining({ id: 'node-2' })]),
+                    edges: [expect.objectContaining({ id: 'node-2-node-1' })]
+                })
+            )
+        })
+
+        it('should call onFlowChange when duplicateNode is called', () => {
+            const initialFlow: FlowData = {
+                nodes: [makeNode('node-1')],
+                edges: []
+            }
+
+            const { result } = renderHook(() => useAgentflowContext(), {
+                wrapper: createWrapper(initialFlow)
+            })
+
+            act(() => {
+                result.current.registerOnFlowChange(mockOnFlowChange)
+            })
+
+            act(() => {
+                result.current.duplicateNode('node-1')
+            })
+
+            expect(mockOnFlowChange).toHaveBeenCalledTimes(1)
+            expect(mockOnFlowChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    nodes: expect.arrayContaining([expect.objectContaining({ id: 'node-1' })]),
+                    edges: []
+                })
+            )
+            // Should have 2 nodes (original + duplicate)
+            const callArgs = mockOnFlowChange.mock.calls[0][0]
+            expect(callArgs.nodes).toHaveLength(2)
+        })
+    })
 })

--- a/packages/agentflow/src/infrastructure/store/AgentflowContext.tsx
+++ b/packages/agentflow/src/infrastructure/store/AgentflowContext.tsx
@@ -176,8 +176,14 @@ export function AgentflowStateProvider({ children, initialFlow }: AgentflowState
             const newNodes = state.nodes.filter((node) => node.id !== nodeId)
             const newEdges = state.edges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId)
             syncStateUpdate({ nodes: newNodes, edges: newEdges })
+
+            // Notify parent of flow change so the deletion is persisted
+            if (onFlowChangeRef.current) {
+                const viewport = state.reactFlowInstance?.getViewport() || { x: 0, y: 0, zoom: 1 }
+                onFlowChangeRef.current({ nodes: newNodes, edges: newEdges, viewport })
+            }
         },
-        [state.nodes, state.edges, syncStateUpdate]
+        [state.nodes, state.edges, state.reactFlowInstance, syncStateUpdate]
     )
 
     const duplicateNode = useCallback(
@@ -227,9 +233,16 @@ export function AgentflowStateProvider({ children, initialFlow }: AgentflowState
                 }
             }
 
-            syncStateUpdate({ nodes: [...state.nodes, newNode] })
+            const newNodes = [...state.nodes, newNode]
+            syncStateUpdate({ nodes: newNodes })
+
+            // Notify parent of flow change so the duplication is persisted
+            if (onFlowChangeRef.current) {
+                const viewport = state.reactFlowInstance?.getViewport() || { x: 0, y: 0, zoom: 1 }
+                onFlowChangeRef.current({ nodes: newNodes, edges: state.edges, viewport })
+            }
         },
-        [state.nodes, syncStateUpdate]
+        [state.nodes, state.edges, state.reactFlowInstance, syncStateUpdate]
     )
 
     const updateNodeData = useCallback(
@@ -261,8 +274,14 @@ export function AgentflowStateProvider({ children, initialFlow }: AgentflowState
         (edgeId: string) => {
             const newEdges = state.edges.filter((edge) => edge.id !== edgeId)
             syncStateUpdate({ edges: newEdges })
+
+            // Notify parent of flow change so the deletion is persisted
+            if (onFlowChangeRef.current) {
+                const viewport = state.reactFlowInstance?.getViewport() || { x: 0, y: 0, zoom: 1 }
+                onFlowChangeRef.current({ nodes: state.nodes, edges: newEdges, viewport })
+            }
         },
-        [state.edges, syncStateUpdate]
+        [state.nodes, state.edges, state.reactFlowInstance, syncStateUpdate]
     )
 
     // Dialog operations

--- a/packages/agentflow/src/infrastructure/store/AgentflowContext.tsx
+++ b/packages/agentflow/src/infrastructure/store/AgentflowContext.tsx
@@ -239,7 +239,7 @@ export function AgentflowStateProvider({ children, initialFlow }: AgentflowState
             // Notify parent of flow change so the duplication is persisted
             if (onFlowChangeRef.current) {
                 const viewport = state.reactFlowInstance?.getViewport() || { x: 0, y: 0, zoom: 1 }
-                onFlowChangeRef.current({ nodes: newNodes, edges: state.edges, viewport })
+                onFlowChangeRef.current({ nodes: normalizeNodes(newNodes), edges: state.edges, viewport })
             }
         },
         [state.nodes, state.edges, state.reactFlowInstance, syncStateUpdate]


### PR DESCRIPTION
- Updated context state management to include viewport information during flow changes.
- Improved test coverage for flow change notifications to ensure correct behavior on node and edge modifications.

FLOWISE-493

Before:

https://github.com/user-attachments/assets/f526dec7-bc89-4ac3-a427-58980fa7b869

After:

https://github.com/user-attachments/assets/807a99d2-088f-4596-8d1c-1102e5c76a76