### PR TITLE
feat(agentflow): add client filtering for form input options in Start node

### DIFF
--- a/packages/components/nodes/agentflow/Start/Start.ts
+++ b/packages/components/nodes/agentflow/Start/Start.ts
@@ -39,7 +39,8 @@ class Start_Agentflow implements INode {
                     {
                         label: 'Form Input',
                         name: 'formInput',
-                        description: 'Start the workflow with form inputs'
+                        description: 'Start the workflow with form inputs',
+                        client: ['agentflowv2']
                     }
                 ],
                 default: 'chatInput'

--- a/packages/server/src/services/nodes/nodes.test.ts
+++ b/packages/server/src/services/nodes/nodes.test.ts
@@ -178,6 +178,42 @@ describe('filterNodeByClient', () => {
         })
     })
 
+    describe('Start node form input filtering', () => {
+        const startNode = makeNode({
+            inputs: [
+                {
+                    label: 'Input Type',
+                    name: 'startInputType',
+                    type: 'options',
+                    options: [
+                        { label: 'Chat Input', name: 'chatInput' },
+                        { label: 'Form Input', name: 'formInput', client: ['agentflowv2'] }
+                    ],
+                    default: 'chatInput'
+                },
+                { label: 'Form Title', name: 'formTitle', type: 'string' },
+                { label: 'Form Description', name: 'formDescription', type: 'string' },
+                { label: 'Form Input Types', name: 'formInputTypes', type: 'array' },
+                { label: 'Ephemeral Memory', name: 'startEphemeralMemory', type: 'boolean' },
+                { label: 'Flow State', name: 'startState', type: 'array' }
+            ]
+        })
+
+        it('removes formInput option for agentflowsdk', () => {
+            const result = filterNodeByClient(startNode, 'agentflowsdk')
+            const optionNames = result.inputs![0].options!.map((o: any) => o.name)
+            expect(optionNames).toContain('chatInput')
+            expect(optionNames).not.toContain('formInput')
+        })
+
+        it('keeps formInput option for agentflowv2', () => {
+            const result = filterNodeByClient(startNode, 'agentflowv2')
+            const optionNames = result.inputs![0].options!.map((o: any) => o.name)
+            expect(optionNames).toContain('chatInput')
+            expect(optionNames).toContain('formInput')
+        })
+    })
+
     describe('immutability', () => {
         it('does not mutate the original node', () => {
             const node = makeNode({


### PR DESCRIPTION
- Enhanced Start node to include a client property for the form input option, allowing differentiation between 'agentflowv2' and 'agentflowsdk'.
- Added tests to verify that the 'formInput' option is correctly filtered based on the client type.

FLOWISE-510


https://github.com/user-attachments/assets/a0b4250f-eed8-4be8-bdb3-9b1bdedf69cb