### PR TITLE
feat(agentflow): make client-specific knowledge fields for agent nodes

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -273,6 +273,7 @@ class Agent_Agentflow implements INode {
                 name: 'agentKnowledgeDocumentStores',
                 type: 'array',
                 description: 'Give your agent context about different document sources. Document stores must be upserted in advance.',
+                client: ['agentflowv2'],
                 array: [
                     {
                         label: 'Document Store',
@@ -303,6 +304,7 @@ class Agent_Agentflow implements INode {
                 name: 'agentKnowledgeVSEmbeddings',
                 type: 'array',
                 description: 'Give your agent context about different document sources from existing vector stores and embeddings',
+                client: ['agentflowv2'],
                 array: [
                     {
                         label: 'Vector Store',

--- a/packages/server/src/services/nodes/nodes.test.ts
+++ b/packages/server/src/services/nodes/nodes.test.ts
@@ -214,6 +214,42 @@ describe('filterNodeByClient', () => {
         })
     })
 
+    describe('Agent node knowledge field filtering', () => {
+        const agentNode = makeNode({
+            inputs: [
+                { label: 'Agent Name', name: 'agentName', type: 'string' },
+                {
+                    label: 'Knowledge (Document Stores)',
+                    name: 'agentKnowledgeDocumentStores',
+                    type: 'array',
+                    client: ['agentflowv2']
+                },
+                {
+                    label: 'Knowledge (Vector Embeddings)',
+                    name: 'agentKnowledgeVSEmbeddings',
+                    type: 'array',
+                    client: ['agentflowv2']
+                }
+            ]
+        })
+
+        it('removes knowledge fields for agentflowsdk', () => {
+            const result = filterNodeByClient(agentNode, 'agentflowsdk')
+            const inputNames = result.inputs!.map((i: any) => i.name)
+            expect(inputNames).toContain('agentName')
+            expect(inputNames).not.toContain('agentKnowledgeDocumentStores')
+            expect(inputNames).not.toContain('agentKnowledgeVSEmbeddings')
+        })
+
+        it('keeps knowledge fields for agentflowv2', () => {
+            const result = filterNodeByClient(agentNode, 'agentflowv2')
+            const inputNames = result.inputs!.map((i: any) => i.name)
+            expect(inputNames).toContain('agentName')
+            expect(inputNames).toContain('agentKnowledgeDocumentStores')
+            expect(inputNames).toContain('agentKnowledgeVSEmbeddings')
+        })
+    })
+
     describe('immutability', () => {
         it('does not mutate the original node', () => {
             const node = makeNode({


### PR DESCRIPTION
- Updated Agent node to include 'client' property for 'agentKnowledgeDocumentStores' and 'agentKnowledgeVSEmbeddings', allowing differentiation between 'agentflowv2' and 'agentflowsdk'.
- Added tests to ensure correct filtering of knowledge fields based on client type.

FLOWISE-549

Before

<img width="1918" height="857" alt="agent-node-client-filter-before" src="https://github.com/user-attachments/assets/03e65fac-9568-4d40-892a-f196a175a6e3" />

After

<img width="1918" height="857" alt="agent-node-client-filter-after" src="https://github.com/user-attachments/assets/a212dd48-8a40-473f-8d84-4c49ff782417" />
