### PR TITLE
Bring canvas buttons to same z-index level

### DIFF
--- a/packages/agentflow/src/features/canvas/components/ValidationFeedback.tsx
+++ b/packages/agentflow/src/features/canvas/components/ValidationFeedback.tsx
@@ -151,7 +151,7 @@ function ValidationFeedbackComponent({ nodes, edges, availableNodes, setNodes }:
                         title='Validate flow'
                         onClick={handleToggle}
                         sx={{
-                            zIndex:10,
+                            zIndex: 10,
                             color: 'white',
                             backgroundColor: 'primary.main',
                             '&:hover': {

--- a/packages/agentflow/src/features/canvas/components/ValidationFeedback.tsx
+++ b/packages/agentflow/src/features/canvas/components/ValidationFeedback.tsx
@@ -151,6 +151,7 @@ function ValidationFeedbackComponent({ nodes, edges, availableNodes, setNodes }:
                         title='Validate flow'
                         onClick={handleToggle}
                         sx={{
+                            zIndex:10,
                             color: 'white',
                             backgroundColor: 'primary.main',
                             '&:hover': {

--- a/packages/agentflow/src/features/canvas/components/ValidationFeedback.tsx
+++ b/packages/agentflow/src/features/canvas/components/ValidationFeedback.tsx
@@ -172,7 +172,7 @@ function ValidationFeedbackComponent({ nodes, edges, availableNodes, setNodes }:
                                 right: 0,
                                 mt: 1.5,
                                 width: 400,
-                                zIndex: 1200
+                                zIndex: 10
                             }}
                         >
                             <Box sx={{ p: 2 }}>

--- a/packages/agentflow/src/features/node-palette/AddNodesDrawer.tsx
+++ b/packages/agentflow/src/features/node-palette/AddNodesDrawer.tsx
@@ -30,7 +30,7 @@ import { debounce, groupNodesByCategory, searchNodes } from './search'
 import { StyledFab } from './StyledFab'
 import { useDrawerMaxHeight } from './useDrawerMaxHeight'
 
-const Z_INDEX_DRAWER = 1000
+const Z_INDEX_DRAWER = 10
 
 export interface AddNodesDrawerProps {
     /** Available nodes to display */


### PR DESCRIPTION
Bring canvas buttons to z-index 10 so that they do not show over top containers using embedded canvas

<img width="855" height="758" alt="Screenshot 2026-04-16 at 12 47 29 PM" src="https://github.com/user-attachments/assets/f8cdc5b7-2a0a-423d-8fbe-62b2b049ebb5" />

<img width="1718" height="529" alt="Screenshot 2026-04-16 at 7 51 51 AM" src="https://github.com/user-attachments/assets/f0d2c9de-d8bc-49ba-8745-8b8ce2a013ca" />
