### PR TITLE
fix(Jira): update endpoint for issue search to use 'search/jql' inste…

### DIFF
--- a/packages/components/nodes/tools/Jira/core.ts
+++ b/packages/components/nodes/tools/Jira/core.ts
@@ -245,7 +245,7 @@ class ListIssuesTool extends BaseJiraTool {
         if (params.maxResults) queryParams.append('maxResults', params.maxResults.toString())
         if (params.startAt) queryParams.append('startAt', params.startAt.toString())
 
-        const endpoint = `search?${queryParams.toString()}`
+        const endpoint = `search/jql?${queryParams.toString()}`
 
         try {
             const response = await this.makeJiraRequest({ endpoint, params })


### PR DESCRIPTION
…ad of 'search'

in it's current state, using the list_issues tool for Jira results in the following tool output:
```Error listing issues: Error: Jira API Error 410: Gone - {"errorMessages":["The requested API has been removed. Please migrate to the /rest/api/3/search/jql API. A full migration guideline is available at https://developer.atlassian.com/changelog/#CHANGE-2046"],"errors":{}}```

This pull request resolves that error.