### PR TITLE
feat(components): Add support for Anthropic Claude Opus 4.7

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -704,13 +704,6 @@
             "name": "chatAnthropic_LlamaIndex",
             "models": [
                 {
-                    "label": "claude-opus-4-7",
-                    "name": "claude-opus-4-7",
-                    "description": "Claude 4.7 Opus",
-                    "input_cost": 0.000005,
-                    "output_cost": 0.000025
-                },
-                {
                     "label": "claude-3-haiku",
                     "name": "claude-3-haiku",
                     "description": "Fastest and most compact model, designed for near-instant responsiveness",
@@ -954,6 +947,13 @@
                     "name": "gemini-1.0-pro-vision",
                     "input_cost": 1.25e-7,
                     "output_cost": 3.75e-7
+                },
+                {
+                    "label": "claude-opus-4-7",
+                    "name": "claude-opus-4-7",
+                    "description": "Claude 4.7 Opus",
+                    "input_cost": 0.000005,
+                    "output_cost": 0.000025
                 },
                 {
                     "label": "claude-opus-4-6",

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -4,6 +4,13 @@
             "name": "awsChatBedrock",
             "models": [
                 {
+                    "label": "anthropic.claude-opus-4-7-v1",
+                    "name": "anthropic.claude-opus-4-7-v1",
+                    "description": "Claude 4.7 Opus",
+                    "input_cost": 0.000005,
+                    "output_cost": 0.000025
+                },
+                {
                     "label": "anthropic.claude-opus-4-6-v1",
                     "name": "anthropic.claude-opus-4-6-v1",
                     "description": "Claude 4.6 Opus",
@@ -587,6 +594,13 @@
             "name": "chatAnthropic",
             "models": [
                 {
+                    "label": "claude-opus-4-7",
+                    "name": "claude-opus-4-7",
+                    "description": "Claude 4.7 Opus",
+                    "input_cost": 0.000005,
+                    "output_cost": 0.000025
+                },
+                {
                     "label": "claude-opus-4-6",
                     "name": "claude-opus-4-6",
                     "description": "Claude 4.6 Opus",
@@ -689,6 +703,13 @@
         {
             "name": "chatAnthropic_LlamaIndex",
             "models": [
+                {
+                    "label": "claude-opus-4-7",
+                    "name": "claude-opus-4-7",
+                    "description": "Claude 4.7 Opus",
+                    "input_cost": 0.000005,
+                    "output_cost": 0.000025
+                },
                 {
                     "label": "claude-3-haiku",
                     "name": "claude-3-haiku",

--- a/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
@@ -81,7 +81,7 @@ class ChatAnthropic_ChatModels implements INode {
                 optional: true,
                 additionalParams: true,
                 hide: {
-                    modelName: ['claude-opus-4-6', 'claude-sonnet-4-6']
+                    modelName: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6']
                 }
             },
             {
@@ -97,7 +97,7 @@ class ChatAnthropic_ChatModels implements INode {
                     extendedThinking: true
                 },
                 hide: {
-                    modelName: ['claude-opus-4-6', 'claude-sonnet-4-6']
+                    modelName: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6']
                 }
             },
             {
@@ -110,7 +110,7 @@ class ChatAnthropic_ChatModels implements INode {
                 optional: true,
                 additionalParams: true,
                 show: {
-                    modelName: ['claude-opus-4-6', 'claude-sonnet-4-6']
+                    modelName: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6']
                 }
             },
             {
@@ -141,7 +141,7 @@ class ChatAnthropic_ChatModels implements INode {
                 additionalParams: true,
                 show: {
                     adaptiveThinking: true,
-                    modelName: ['claude-opus-4-6', 'claude-sonnet-4-6']
+                    modelName: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6']
                 }
             },
             {

--- a/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
@@ -135,7 +135,7 @@ class ChatAnthropic_ChatModels implements INode {
                     {
                         label: 'Max',
                         name: 'max',
-                        description: 'Absolute maximum capability with no constraints on token spending. Opus 4.6 only'
+                        description: 'Absolute maximum capability with no constraints on token spending. Opus 4.6 and newer only'
                     }
                 ],
                 additionalParams: true,


### PR DESCRIPTION
This PR introduces full support for Anthropic's flagship **Claude Opus 4.7** model across our chat integrations, updating both the model registry and the frontend node logic required to handle its advanced parameters. 

### Changes Made
- **Model Registry (`models.json`)**: Added `claude-opus-4-7` to `awsChatBedrock`, `chatAnthropic`, and `chatAnthropic_LlamaIndex` with the most recent API token costs.
- **Node UI Logic (`ChatAnthropic.ts`)**: Added `claude-opus-4-7` to the conditional rendering arrays. This correctly hides the legacy `Extended Thinking` sliders and activates the modern `Adaptive Thinking` configuration required by the new Opus architecture.

### Type of change
- [x] New feature (non-breaking change which adds model functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of changes made in component node configurations
- [x] New base pricing and UI handling logic matches official Anthropic API documentation
