### PR TITLE
fix(mcp): preserve tool input schema types and required fields

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -743,7 +743,7 @@ class Agent_Agentflow implements INode {
                 }
                 const componentNode = options.componentNodes[agentSelectedTool]
 
-                const jsonSchema = zodToJsonSchema(tool.schema as any)
+                const jsonSchema: any = (tool.schema as any)?._def ? zodToJsonSchema(tool.schema as any) : { ...(tool.schema as any) }
                 if (jsonSchema.$schema) {
                     delete jsonSchema.$schema
                 }

--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -19,7 +19,7 @@ import { ILLMMessage, IResponseMetadata } from '../Interface.Agentflow'
 import { Tool } from '@langchain/core/tools'
 import { ARTIFACTS_PREFIX, SOURCE_DOCUMENTS_PREFIX, TOOL_ARGS_PREFIX } from '../../../src/agents'
 import { flatten } from 'lodash'
-import zodToJsonSchema from 'zod-to-json-schema'
+import { toolSchemaToJsonSchema, type ToolJsonSchema } from '../../../src/utils'
 import { getErrorMessage } from '../../../src/error'
 import { DataSource } from 'typeorm'
 import { randomBytes } from 'crypto'
@@ -67,7 +67,7 @@ interface IKnowledgeBaseVSEmbeddings {
 interface ISimpliefiedTool {
     name: string
     description: string
-    schema: any
+    schema: ToolJsonSchema
     toolNode: {
         label: string
         name: string
@@ -743,10 +743,7 @@ class Agent_Agentflow implements INode {
                 }
                 const componentNode = options.componentNodes[agentSelectedTool]
 
-                const jsonSchema: any = (tool.schema as any)?._def ? zodToJsonSchema(tool.schema as any) : { ...(tool.schema as any) }
-                if (jsonSchema.$schema) {
-                    delete jsonSchema.$schema
-                }
+                const jsonSchema = toolSchemaToJsonSchema(tool.schema)
 
                 return {
                     name: tool.name,
@@ -800,10 +797,7 @@ class Agent_Agentflow implements INode {
 
                     toolsInstance.push(retrieverToolInstance as Tool)
 
-                    const jsonSchema = zodToJsonSchema(retrieverToolInstance.schema)
-                    if (jsonSchema.$schema) {
-                        delete jsonSchema.$schema
-                    }
+                    const jsonSchema = toolSchemaToJsonSchema(retrieverToolInstance.schema)
                     const componentNode = options.componentNodes['retrieverTool']
 
                     availableTools.push({
@@ -875,10 +869,7 @@ class Agent_Agentflow implements INode {
 
                     toolsInstance.push(retrieverToolInstance as Tool)
 
-                    const jsonSchema = zodToJsonSchema(retrieverToolInstance.schema)
-                    if (jsonSchema.$schema) {
-                        delete jsonSchema.$schema
-                    }
+                    const jsonSchema = toolSchemaToJsonSchema(retrieverToolInstance.schema)
                     const componentNode = options.componentNodes['retrieverTool']
 
                     availableTools.push({

--- a/packages/components/nodes/agentflow/Tool/Tool.ts
+++ b/packages/components/nodes/agentflow/Tool/Tool.ts
@@ -3,7 +3,7 @@ import { updateFlowState } from '../utils'
 import { processTemplateVariables } from '../../../src/utils'
 import { Tool } from '@langchain/core/tools'
 import { ARTIFACTS_PREFIX, TOOL_ARGS_PREFIX } from '../../../src/agents'
-import zodToJsonSchema from 'zod-to-json-schema'
+import { toolSchemaToJsonSchema } from '../../../src/utils'
 
 interface IToolInputArgs {
     inputArgName: string
@@ -153,27 +153,16 @@ class Tool_Agentflow implements INode {
                     // Combine schemas from all tools in the array
                     const allProperties = toolInstance.reduce((acc, tool) => {
                         if (tool?.schema) {
-                            const schema: Record<string, any> = (tool.schema as any)?._def
-                                ? zodToJsonSchema(tool.schema)
-                                : { ...(tool.schema as any) }
+                            const schema = toolSchemaToJsonSchema(tool.schema) as { properties?: ICommonObject }
                             return { ...acc, ...(schema.properties || {}) }
                         }
                         return acc
                     }, {})
                     toolInputArgs = { properties: allProperties }
+                } else if (!toolInstance.schema) {
+                    toolInputArgs = {}
                 } else {
-                    // Handle single tool instance
-                    if (!toolInstance.schema) {
-                        toolInputArgs = {}
-                    } else if ((toolInstance.schema as any)?._def) {
-                        toolInputArgs = zodToJsonSchema(toolInstance.schema as any)
-                    } else {
-                        toolInputArgs = { ...(toolInstance.schema as any) }
-                    }
-                }
-
-                if (toolInputArgs && Object.keys(toolInputArgs).length > 0) {
-                    delete toolInputArgs.$schema
+                    toolInputArgs = toolSchemaToJsonSchema(toolInstance.schema) as ICommonObject
                 }
 
                 return Object.keys(toolInputArgs.properties || {}).map((item) => ({

--- a/packages/components/nodes/agentflow/Tool/Tool.ts
+++ b/packages/components/nodes/agentflow/Tool/Tool.ts
@@ -153,7 +153,9 @@ class Tool_Agentflow implements INode {
                     // Combine schemas from all tools in the array
                     const allProperties = toolInstance.reduce((acc, tool) => {
                         if (tool?.schema) {
-                            const schema: Record<string, any> = zodToJsonSchema(tool.schema)
+                            const schema: Record<string, any> = (tool.schema as any)?._def
+                                ? zodToJsonSchema(tool.schema)
+                                : { ...(tool.schema as any) }
                             return { ...acc, ...(schema.properties || {}) }
                         }
                         return acc
@@ -161,7 +163,13 @@ class Tool_Agentflow implements INode {
                     toolInputArgs = { properties: allProperties }
                 } else {
                     // Handle single tool instance
-                    toolInputArgs = toolInstance.schema ? zodToJsonSchema(toolInstance.schema as any) : {}
+                    if (!toolInstance.schema) {
+                        toolInputArgs = {}
+                    } else if ((toolInstance.schema as any)?._def) {
+                        toolInputArgs = zodToJsonSchema(toolInstance.schema as any)
+                    } else {
+                        toolInputArgs = { ...(toolInstance.schema as any) }
+                    }
                 }
 
                 if (toolInputArgs && Object.keys(toolInputArgs).length > 0) {

--- a/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
+++ b/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
@@ -1163,7 +1163,7 @@ interface JSONSchema {
 }
 
 const formatToOpenAIAssistantTool = (tool: any): OpenAI.Beta.FunctionTool => {
-    const parameters = zodToJsonSchema(tool.schema) as JSONSchema
+    const parameters = (tool.schema?._def ? zodToJsonSchema(tool.schema) : { ...tool.schema }) as JSONSchema
 
     // For strict tools, we need to:
     // 1. Set additionalProperties to false

--- a/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
+++ b/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
@@ -12,7 +12,7 @@ import OpenAI from 'openai'
 import { DataSource } from 'typeorm'
 import { getCredentialData, getCredentialParam } from '../../../src/utils'
 import fetch from 'node-fetch'
-import { flatten, uniqWith, isEqual } from 'lodash'
+import { flatten, uniqWith, isEqual, cloneDeep } from 'lodash'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import { AnalyticHandler } from '../../../src/handler'
 import { Moderation, checkInputs, streamResponse } from '../../moderation/Moderation'
@@ -1163,7 +1163,7 @@ interface JSONSchema {
 }
 
 const formatToOpenAIAssistantTool = (tool: any): OpenAI.Beta.FunctionTool => {
-    const parameters = (tool.schema?._def ? zodToJsonSchema(tool.schema) : { ...tool.schema }) as JSONSchema
+    const parameters = (tool.schema?._def ? zodToJsonSchema(tool.schema) : cloneDeep(tool.schema)) as JSONSchema
 
     // For strict tools, we need to:
     // 1. Set additionalProperties to false

--- a/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
+++ b/packages/components/nodes/agents/OpenAIAssistant/OpenAIAssistant.ts
@@ -12,8 +12,8 @@ import OpenAI from 'openai'
 import { DataSource } from 'typeorm'
 import { getCredentialData, getCredentialParam } from '../../../src/utils'
 import fetch from 'node-fetch'
-import { flatten, uniqWith, isEqual, cloneDeep } from 'lodash'
-import { zodToJsonSchema } from 'zod-to-json-schema'
+import { flatten, uniqWith, isEqual } from 'lodash'
+import { toolSchemaToJsonSchema } from '../../../src/utils'
 import { AnalyticHandler } from '../../../src/handler'
 import { Moderation, checkInputs, streamResponse } from '../../moderation/Moderation'
 import { formatResponse } from '../../outputparsers/OutputParserHelpers'
@@ -1163,7 +1163,7 @@ interface JSONSchema {
 }
 
 const formatToOpenAIAssistantTool = (tool: any): OpenAI.Beta.FunctionTool => {
-    const parameters = (tool.schema?._def ? zodToJsonSchema(tool.schema) : cloneDeep(tool.schema)) as JSONSchema
+    const parameters = toolSchemaToJsonSchema(tool.schema) as JSONSchema
 
     // For strict tools, we need to:
     // 1. Set additionalProperties to false

--- a/packages/components/nodes/tools/MCP/Pipedream/PipedreamMCP.ts
+++ b/packages/components/nodes/tools/MCP/Pipedream/PipedreamMCP.ts
@@ -4,7 +4,6 @@ import { getCredentialData, getCredentialParam, getVars, prepareSandboxVars } fr
 import { DataSource } from 'typeorm'
 import { MCPToolkit } from '../core'
 import axios from 'axios'
-import { z, ZodTypeAny } from 'zod'
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { CallToolRequest, CallToolResult, TextContent, Tool as McpTool } from '@modelcontextprotocol/sdk/types.js'
 
@@ -38,17 +37,6 @@ Once the user has connected their account, retry the original request.`
     }
 
     return text
-}
-
-function createSchemaModel(inputSchema: { type: string; properties?: Record<string, any> }): z.ZodObject<any> {
-    if (inputSchema.type !== 'object' || !inputSchema.properties) {
-        throw new Error('Invalid schema type or missing properties')
-    }
-    const schemaProperties = Object.entries(inputSchema.properties).reduce((acc, [key]) => {
-        acc[key] = z.any()
-        return acc
-    }, {} as Record<string, ZodTypeAny>)
-    return z.object(schemaProperties)
 }
 
 async function createPipedreamTool(toolkit: MCPToolkit, name: string, description: string, argsSchema: any): Promise<Tool> {
@@ -345,7 +333,7 @@ class Pipedream_MCP implements INode {
             }
 
             const toolPromises = rawTools.map((t: McpTool) =>
-                createPipedreamTool(toolkit, t.name, t.description || t.name, createSchemaModel(t.inputSchema))
+                createPipedreamTool(toolkit, t.name, t.description || t.name, t.inputSchema ?? { type: 'object', properties: {} })
             )
             const settled = await Promise.allSettled(toolPromises)
             const tools = settled.filter((r): r is PromiseFulfilledResult<Tool> => r.status === 'fulfilled').map((r) => r.value)

--- a/packages/components/nodes/tools/MCP/core.ts
+++ b/packages/components/nodes/tools/MCP/core.ts
@@ -2,7 +2,6 @@ import { CallToolRequest, CallToolResultSchema, ListToolsResult, ListToolsResult
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport, StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { BaseToolkit, tool, Tool } from '@langchain/core/tools'
-import { z, type ZodTypeAny } from 'zod/v3'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { checkDenyList, secureFetch } from '../../../src/httpSecurity'
@@ -124,11 +123,12 @@ export class MCPToolkit extends BaseToolkit {
             if (this.client === null) {
                 throw new Error('Client is not initialized')
             }
+            const argsSchema = tool.inputSchema ?? { type: 'object', properties: {} }
             return await MCPTool({
                 toolkit: this,
                 name: tool.name,
                 description: tool.description || tool.name,
-                argsSchema: createSchemaModel(tool.inputSchema)
+                argsSchema
             })
         })
         const res = await Promise.allSettled(toolsPromises)
@@ -175,24 +175,6 @@ export async function MCPTool({
             schema: argsSchema
         }
     )
-}
-
-function createSchemaModel(
-    inputSchema: {
-        type: 'object'
-        properties?: Record<string, unknown>
-    } & { [k: string]: unknown }
-): z.ZodObject<Record<string, ZodTypeAny>> {
-    if (inputSchema.type !== 'object' || !inputSchema.properties) {
-        throw new Error('Invalid schema type or missing properties')
-    }
-
-    const schemaProperties = Object.entries(inputSchema.properties).reduce((acc, [key]) => {
-        acc[key] = z.any()
-        return acc
-    }, {} as Record<string, ZodTypeAny>)
-
-    return z.object(schemaProperties)
 }
 
 export const validateArgsForLocalFileAccess = (args: string[]): void => {

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -2320,7 +2320,7 @@ type ZodToJsonSchemaInput = Parameters<typeof zodToJsonSchema>[0]
  * whichever Zod major version (`^3 || ^4`) TypeScript resolves at the call site.
  */
 export const isZodSchema = (schema: unknown): schema is ZodToJsonSchemaInput =>
-    typeof schema === 'object' && schema !== null && '_def' in schema
+    typeof schema === 'object' && schema !== null && '_def' in schema && typeof (schema as { parse?: unknown }).parse === 'function'
 
 /**
  * Normalizes a tool schema into a plain JSON Schema object.
@@ -2331,10 +2331,11 @@ export const isZodSchema = (schema: unknown): schema is ZodToJsonSchemaInput =>
  * `$schema` marker so the result is safe to embed in LLM tool definitions.
  */
 export const toolSchemaToJsonSchema = (schema: unknown): ToolJsonSchema => {
+    if (schema == null) return { type: 'object', properties: {} }
     const jsonSchema: ToolJsonSchema = isZodSchema(schema)
         ? (zodToJsonSchema(schema) as ToolJsonSchema)
         : cloneDeep(schema as ToolJsonSchema)
-    if (jsonSchema && jsonSchema.$schema) {
+    if (jsonSchema.$schema) {
         delete jsonSchema.$schema
     }
     return jsonSchema

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -22,6 +22,7 @@ import { NodeVM } from 'vm2'
 import { Sandbox } from '@e2b/code-interpreter'
 import { secureFetch, checkDenyList, secureAxiosRequest } from './httpSecurity'
 import JSON5 from 'json5'
+import zodToJsonSchema, { type JsonSchema7Type } from 'zod-to-json-schema'
 
 export const numberOrExpressionRegex = '^(\\d+\\.?\\d*|{{.*}})$' //return true if string consists only numbers OR expression {{}}
 export const notEmptyRegex = '(.|\\s)*\\S(.|\\s)*' //return true if string is not empty or blank
@@ -2302,4 +2303,39 @@ export const isReasoningModelOpenAI = (name: string): boolean => {
     if (name.includes('gpt-5') && name.includes('-chat')) return false
     if (name.includes('gpt-5')) return true
     return false
+}
+
+/**
+ * JSON Schema shape returned by {@link toolSchemaToJsonSchema}, extended with the
+ * optional `$schema` marker that `zod-to-json-schema` emits.
+ */
+export type ToolJsonSchema = JsonSchema7Type & { $schema?: string; [key: string]: unknown }
+
+type ZodToJsonSchemaInput = Parameters<typeof zodToJsonSchema>[0]
+
+/**
+ * Type guard detecting a Zod schema without importing Zod's types directly.
+ *
+ * Using `Parameters<typeof zodToJsonSchema>[0]` keeps the guard compatible with
+ * whichever Zod major version (`^3 || ^4`) TypeScript resolves at the call site.
+ */
+export const isZodSchema = (schema: unknown): schema is ZodToJsonSchemaInput =>
+    typeof schema === 'object' && schema !== null && '_def' in schema
+
+/**
+ * Normalizes a tool schema into a plain JSON Schema object.
+ *
+ * LangChain tools may expose their `schema` as either a Zod schema (has `_def`)
+ * or an already-plain JSON Schema (e.g. MCP tools). This helper handles both,
+ * deep-clones plain objects to prevent accidental mutation, and strips the
+ * `$schema` marker so the result is safe to embed in LLM tool definitions.
+ */
+export const toolSchemaToJsonSchema = (schema: unknown): ToolJsonSchema => {
+    const jsonSchema: ToolJsonSchema = isZodSchema(schema)
+        ? (zodToJsonSchema(schema) as ToolJsonSchema)
+        : cloneDeep(schema as ToolJsonSchema)
+    if (jsonSchema && jsonSchema.$schema) {
+        delete jsonSchema.$schema
+    }
+    return jsonSchema
 }


### PR DESCRIPTION
## Summary

- MCP tools were losing all type information and `required` fields because `createSchemaModel` mapped every property to `z.any()`
- Rather than reimplement a JSON-Schema-to-Zod converter (lossy for `$ref`, `allOf`, `anyOf`, enums, nested objects), pass the MCP server's `inputSchema` straight through to LangChain's `tool()` — the `JsonSchema7Type` overload has been supported since `@langchain/core` 1.1.x.
- Downstream tool serializers (`Agent`, `Tool`, `OpenAIAssistant`) to uptake these changes

## Before / After

### Example 1 — typed params with required fields

MCP server with the following `inputSchema` for a `create_issue` tool:

```json
{
  "type": "object",
  "properties": {
    "owner":      { "type": "string",  "description": "Repo owner" },
    "repo":       { "type": "string",  "description": "Repo name" },
    "title":      { "type": "string" },
    "project_id": { "type": "integer" },
    "draft":      { "type": "boolean" }
  },
  "required": ["owner", "repo", "title"]
}
```

**Before** — what the LLM saw after `createSchemaModel`:

```json
{
  "type": "object",
  "properties": {
    "owner":      {},
    "repo":       {},
    "title":      {},
    "project_id": {},
    "draft":      {}
  }
}
```

LLM response:

```json
{ "name": "create_issue", "arguments": {} }
```

Tool call fails — `owner`, `repo`, `title` missing. OpenAI strict mode rejects the schema outright because property `type` keys are absent.

**After** — we straightaway pass the raw `inputSchema` and preserve everything. LLM response:

```json
{
  "name": "create_issue",
  "arguments": {
    "owner": "flowiseai",
    "repo":  "Flowise",
    "title": "Fix MCP schema handling"
  }
}
```

### Example 2 — enum constraints

```json
{
  "type": "object",
  "properties": {
    "priority": { "type": "string", "enum": ["low", "medium", "high"] }
  },
  "required": ["priority"]
}
```

**Before:** `priority` was `z.any()` — LLM would pass `"urgent"`, `"P1"`, or anything else.
**After:** the enum is preserved; the model provider enforces one of `low | medium | high`.

### Example 3 — nested object

```json
{
  "type": "object",
  "properties": {
    "filter": {
      "type": "object",
      "properties": {
        "status": { "type": "string" },
        "since":  { "type": "string", "format": "date-time" }
      },
      "required": ["status"]
    }
  },
  "required": ["filter"]
}
```

**Before:** nested `filter` became `z.any()` — the LLM received no guidance on inner structure and commonly sent `"filter": "open"` as a string.
**After:** full nested schema reaches the model; inner `required` and `format` are preserved.

### Example 4 — no input schema

A tool like `get_current_time` with no params.

**Before:** `createSchemaModel` threw `Invalid schema type or missing properties`; the tool was silently dropped from the toolkit because `Promise.allSettled` swallowed the rejection.
**After:** tool registers correctly with an empty object schema.

