### PR TITLE
docs: fix broken environment variable docs links in markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ Flowise has 3 different modules in a single mono repository.
 
 ## 🌱 Env Variables
 
-Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder. Read [more](https://docs.flowiseai.com/environment-variables)
+Flowise support different environment variables to configure your instance. You can specify the following variables in the `.env` file inside `packages/server` folder. Read [more](https://docs.flowiseai.com/configuration/environment-variables)
 
 | Variable                             | Description                                                                                                                                                                                                                                                                       | Type                                             | Default                             |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- |

--- a/i18n/CONTRIBUTING-ZH.md
+++ b/i18n/CONTRIBUTING-ZH.md
@@ -116,37 +116,37 @@ Flowise 在一个单一的单体存储库中有 3 个不同的模块。
 
 ## 🌱 环境变量
 
-Flowise 支持不同的环境变量来配置您的实例。您可以在 `packages/server` 文件夹中的 `.env` 文件中指定以下变量。阅读[更多信息](https://docs.flowiseai.com/environment-variables)
+Flowise 支持不同的环境变量来配置您的实例。您可以在 `packages/server` 文件夹中的 `.env` 文件中指定以下变量。阅读[更多信息](https://docs.flowiseai.com/configuration/environment-variables)
 
-| 变量名                       | 描述                                                    | 类型                                            | 默认值                              |
-|-----------------------------|---------------------------------------------------------|-------------------------------------------------|-------------------------------------|
-| `PORT`                      | Flowise 运行的 HTTP 端口                                | 数字                                            | 3000                                |
-| `FLOWISE_FILE_SIZE_LIMIT`   | 上传文件大小限制                                        | 字符串                                          | 50mb                                |
-| `DEBUG`                     | 打印组件的日志                                          | 布尔值                                          |                                     |
-| `LOG_PATH`                  | 存储日志文件的位置                                      | 字符串                                          | `your-path/Flowise/logs`            |
-| `LOG_LEVEL`                 | 日志的不同级别                                          | 枚举字符串: `error`, `info`, `verbose`, `debug` | `info`                              |
-| `TOOL_FUNCTION_BUILTIN_DEP` | 用于工具函数的 NodeJS 内置模块                          | 字符串                                          |                                     |
-| `TOOL_FUNCTION_EXTERNAL_DEP`| 用于工具函数的外部模块                                  | 字符串                                          |                                     |
-| `DATABASE_TYPE`             | 存储 Flowise 数据的数据库类型                           | 枚举字符串: `sqlite`, `mysql`, `postgres`       | `sqlite`                            |
-| `DATABASE_PATH`             | 数据库保存的位置（当 `DATABASE_TYPE` 是 sqlite 时）     | 字符串                                          | `your-home-dir/.flowise`            |
-| `DATABASE_HOST`             | 主机 URL 或 IP 地址（当 `DATABASE_TYPE` 不是 sqlite 时）| 字符串                                          |                                     |
-| `DATABASE_PORT`             | 数据库端口（当 `DATABASE_TYPE` 不是 sqlite 时）         | 字符串                                          |                                     |
-| `DATABASE_USERNAME`         | 数据库用户名（当 `DATABASE_TYPE` 不是 sqlite 时）       | 字符串                                          |                                     |
-| `DATABASE_PASSWORD`         | 数据库密码（当 `DATABASE_TYPE` 不是 sqlite 时）         | 字符串                                          |                                     |
-| `DATABASE_NAME`             | 数据库名称（当 `DATABASE_TYPE` 不是 sqlite 时）         | 字符串                                          |                                     |
-| `SECRETKEY_PATH`            | 保存加密密钥（用于加密/解密凭据）的位置                 | 字符串                                          | `your-path/Flowise/packages/server` |
-| `FLOWISE_SECRETKEY_OVERWRITE`| 加密密钥用于替代存储在 `SECRETKEY_PATH` 中的密钥        | 字符串                                          |                                     |
-| `MODEL_LIST_CONFIG_JSON`    | 加载模型的位置                                          | 字符串                                          | `/your_model_list_config_file_path` |
-| `STORAGE_TYPE`              | 上传文件的存储类型                                      | 枚举字符串: `local`, `s3`                       | `local`                             |
-| `BLOB_STORAGE_PATH`         | 本地上传文件存储路径（当 `STORAGE_TYPE` 为 `local`）    | 字符串                                          | `your-home-dir/.flowise/storage`    |
-| `S3_STORAGE_BUCKET_NAME`    | S3 存储文件夹路径（当 `STORAGE_TYPE` 为 `s3`）          | 字符串                                          |                                     |
-| `S3_STORAGE_ACCESS_KEY_ID`  | AWS 访问密钥 (Access Key)                               | 字符串                                          |                                     |
-| `S3_STORAGE_SECRET_ACCESS_KEY` | AWS 密钥 (Secret Key)                                | 字符串                                          |                                     |
-| `S3_STORAGE_REGION`         | S3 存储地区                                             | 字符串                                          |                                     |
-| `S3_ENDPOINT_URL`           | S3 端点 URL                                             | 字符串                                          |                                     |
-| `S3_FORCE_PATH_STYLE`       | 设置为 true 以强制请求使用路径样式寻址                  | 布尔值                                          | false                               |
-| `SHOW_COMMUNITY_NODES`      | 显示由社区创建的节点                                    | 布尔值                                          |                                     |
-| `DISABLED_NODES`            | 从界面中隐藏节点（以逗号分隔的节点名称列表）            | 字符串                                          |                                     |
+| 变量名                         | 描述                                                     | 类型                                            | 默认值                              |
+| ------------------------------ | -------------------------------------------------------- | ----------------------------------------------- | ----------------------------------- |
+| `PORT`                         | Flowise 运行的 HTTP 端口                                 | 数字                                            | 3000                                |
+| `FLOWISE_FILE_SIZE_LIMIT`      | 上传文件大小限制                                         | 字符串                                          | 50mb                                |
+| `DEBUG`                        | 打印组件的日志                                           | 布尔值                                          |                                     |
+| `LOG_PATH`                     | 存储日志文件的位置                                       | 字符串                                          | `your-path/Flowise/logs`            |
+| `LOG_LEVEL`                    | 日志的不同级别                                           | 枚举字符串: `error`, `info`, `verbose`, `debug` | `info`                              |
+| `TOOL_FUNCTION_BUILTIN_DEP`    | 用于工具函数的 NodeJS 内置模块                           | 字符串                                          |                                     |
+| `TOOL_FUNCTION_EXTERNAL_DEP`   | 用于工具函数的外部模块                                   | 字符串                                          |                                     |
+| `DATABASE_TYPE`                | 存储 Flowise 数据的数据库类型                            | 枚举字符串: `sqlite`, `mysql`, `postgres`       | `sqlite`                            |
+| `DATABASE_PATH`                | 数据库保存的位置（当 `DATABASE_TYPE` 是 sqlite 时）      | 字符串                                          | `your-home-dir/.flowise`            |
+| `DATABASE_HOST`                | 主机 URL 或 IP 地址（当 `DATABASE_TYPE` 不是 sqlite 时） | 字符串                                          |                                     |
+| `DATABASE_PORT`                | 数据库端口（当 `DATABASE_TYPE` 不是 sqlite 时）          | 字符串                                          |                                     |
+| `DATABASE_USERNAME`            | 数据库用户名（当 `DATABASE_TYPE` 不是 sqlite 时）        | 字符串                                          |                                     |
+| `DATABASE_PASSWORD`            | 数据库密码（当 `DATABASE_TYPE` 不是 sqlite 时）          | 字符串                                          |                                     |
+| `DATABASE_NAME`                | 数据库名称（当 `DATABASE_TYPE` 不是 sqlite 时）          | 字符串                                          |                                     |
+| `SECRETKEY_PATH`               | 保存加密密钥（用于加密/解密凭据）的位置                  | 字符串                                          | `your-path/Flowise/packages/server` |
+| `FLOWISE_SECRETKEY_OVERWRITE`  | 加密密钥用于替代存储在 `SECRETKEY_PATH` 中的密钥         | 字符串                                          |                                     |
+| `MODEL_LIST_CONFIG_JSON`       | 加载模型的位置                                           | 字符串                                          | `/your_model_list_config_file_path` |
+| `STORAGE_TYPE`                 | 上传文件的存储类型                                       | 枚举字符串: `local`, `s3`                       | `local`                             |
+| `BLOB_STORAGE_PATH`            | 本地上传文件存储路径（当 `STORAGE_TYPE` 为 `local`）     | 字符串                                          | `your-home-dir/.flowise/storage`    |
+| `S3_STORAGE_BUCKET_NAME`       | S3 存储文件夹路径（当 `STORAGE_TYPE` 为 `s3`）           | 字符串                                          |                                     |
+| `S3_STORAGE_ACCESS_KEY_ID`     | AWS 访问密钥 (Access Key)                                | 字符串                                          |                                     |
+| `S3_STORAGE_SECRET_ACCESS_KEY` | AWS 密钥 (Secret Key)                                    | 字符串                                          |                                     |
+| `S3_STORAGE_REGION`            | S3 存储地区                                              | 字符串                                          |                                     |
+| `S3_ENDPOINT_URL`              | S3 端点 URL                                              | 字符串                                          |                                     |
+| `S3_FORCE_PATH_STYLE`          | 设置为 true 以强制请求使用路径样式寻址                   | 布尔值                                          | false                               |
+| `SHOW_COMMUNITY_NODES`         | 显示由社区创建的节点                                     | 布尔值                                          |                                     |
+| `DISABLED_NODES`               | 从界面中隐藏节点（以逗号分隔的节点名称列表）             | 字符串                                          |                                     |
 
 您也可以在使用 `npx` 时指定环境变量。例如：
 

--- a/packages/server/README-ZH.md
+++ b/packages/server/README-ZH.md
@@ -24,7 +24,7 @@
 
 ## 🌱 环境变量
 
-Flowise 支持不同的环境变量来配置您的实例。您可以在`packages/server`文件夹中的`.env`文件中指定以下变量。阅读[更多](https://docs.flowiseai.com/environment-variables)
+Flowise 支持不同的环境变量来配置您的实例。您可以在`packages/server`文件夹中的`.env`文件中指定以下变量。阅读[更多](https://docs.flowiseai.com/configuration/environment-variables)
 
 您还可以在使用`npx`时指定环境变量。例如：
 


### PR DESCRIPTION
This PR fixes a broken "Read more" link in the documentation. The link was previously pointing to a 404 path (/environment-variables). I have updated it to point to the correct existing configuration page.

Changes:

Updated link target to /configuration/environment-variables.

Related Issue:
Closes #6254 