### PR TITLE
bug: Block read_pickle and class definitions, restrict custom CSV field to read_csv() only

### DIFF
--- a/packages/components/nodes/agents/CSVAgent/CSVAgent.ts
+++ b/packages/components/nodes/agents/CSVAgent/CSVAgent.ts
@@ -5,7 +5,7 @@ import { ConsoleCallbackHandler, CustomChainHandler, additionalCallbacks } from 
 import { ICommonObject, INode, INodeData, INodeParams, IServerSideEventStreamer, PromptTemplate } from '../../../src/Interface'
 import { getBaseClasses } from '../../../src/utils'
 import { LoadPyodide, finalSystemPrompt, systemPrompt } from './core'
-import { validatePythonCodeForDataFrame } from '../../../src/pythonCodeValidator'
+import { validatePythonCodeForDataFrame, validateCustomReadCSVFunction } from '../../../src/pythonCodeValidator'
 import { checkInputs, Moderation } from '../../moderation/Moderation'
 import { formatResponse } from '../../outputparsers/OutputParserHelpers'
 import { getFileFromStorage } from '../../../src'
@@ -144,12 +144,12 @@ class CSV_Agents implements INode {
         // For example using titanic.csv: {'PassengerId': 'int64', 'Survived': 'int64', 'Pclass': 'int64', 'Name': 'object', 'Sex': 'object', 'Age': 'float64', 'SibSp': 'int64', 'Parch': 'int64', 'Ticket': 'object', 'Fare': 'float64', 'Cabin': 'object', 'Embarked': 'object'}
         let dataframeColDict = ''
         let customReadCSVFunc = _customReadCSV ? _customReadCSV : 'read_csv(csv_data)'
-        const csvReadValidation = validatePythonCodeForDataFrame(customReadCSVFunc)
+        const csvReadValidation = validateCustomReadCSVFunction(customReadCSVFunc)
         if (!csvReadValidation.valid) {
             throw new Error(
                 `Custom read_csv code was rejected for security reasons (${
                     csvReadValidation.reason ?? 'unsafe construct'
-                }). Please use only safe pandas read_csv operations.`
+                }). Only a single read_csv(...) call is permitted.`
             )
         }
         try {

--- a/packages/components/src/pythonCodeValidator.ts
+++ b/packages/components/src/pythonCodeValidator.ts
@@ -64,7 +64,7 @@ const FORBIDDEN_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
     { pattern: /\b__dict__\b/g, reason: '__dict__ (attribute reflection)' },
     { pattern: /\b__module__\b/g, reason: '__module__ (module reflection)' },
     // Unsafe deserialization — read_pickle() executes arbitrary Python objects
-    { pattern: /\bread_pickle\s*\(/g, reason: 'read_pickle() (unsafe deserialization / RCE)' },
+    { pattern: /\bread_pickle\b/g, reason: 'read_pickle (unsafe deserialization / RCE)' },
     { pattern: /\bpickle\b/g, reason: 'pickle module (unsafe deserialization)' },
     { pattern: /\bmarshal\b/g, reason: 'marshal module (unsafe deserialization)' },
     // Class definitions — used to synthesise file-like objects that smuggle pickle payloads

--- a/packages/components/src/pythonCodeValidator.ts
+++ b/packages/components/src/pythonCodeValidator.ts
@@ -1,8 +1,15 @@
 /**
- * Validates LLM-generated Python code before execution in Pyodide to prevent
- * remote code execution (RCE). Only allows code that is safe for pandas
- * DataFrame operations. Rejects imports, exec/eval, file/system access, and
- * other dangerous constructs that could escape the intended DataFrame context.
+ * Validates Python code before execution in Pyodide to prevent remote code
+ * execution (RCE). Two entry points are provided:
+ *
+ *  - validateCustomReadCSVFunction  allowlist-based check for the user-supplied
+ *    "Custom Pandas Read_CSV Code" field; only a bare read_csv(...) call is
+ *    permitted.
+ *
+ *  - validatePythonCodeForDataFrame  denylist-based check for LLM-generated
+ *    DataFrame operation code.
+ *
+ * Both checks must pass before code is handed to pyodide.runPythonAsync().
  */
 
 export interface PythonCodeValidationResult {
@@ -55,7 +62,13 @@ const FORBIDDEN_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
     { pattern: /\bvars\s*\(/g, reason: 'vars()' },
     { pattern: /\bdir\s*\(/g, reason: 'dir()' },
     { pattern: /\b__dict__\b/g, reason: '__dict__ (attribute reflection)' },
-    { pattern: /\b__module__\b/g, reason: '__module__ (module reflection)' }
+    { pattern: /\b__module__\b/g, reason: '__module__ (module reflection)' },
+    // Unsafe deserialization — read_pickle() executes arbitrary Python objects
+    { pattern: /\bread_pickle\s*\(/g, reason: 'read_pickle() (unsafe deserialization / RCE)' },
+    { pattern: /\bpickle\b/g, reason: 'pickle module (unsafe deserialization)' },
+    { pattern: /\bmarshal\b/g, reason: 'marshal module (unsafe deserialization)' },
+    // Class definitions — used to synthesise file-like objects that smuggle pickle payloads
+    { pattern: /\bclass\s+\w/g, reason: 'class definition' }
 ]
 
 /**
@@ -71,4 +84,33 @@ export function validatePythonCodeForDataFrame(code: string): PythonCodeValidati
     }
 
     return { valid: true }
+}
+
+/**
+ * Strict allowlist validator for the user-supplied "Custom Pandas Read_CSV Code"
+ * field.  Only a single read_csv(...) call is permitted — no newlines, no
+ * semicolons, and no additional statements.  The denylist is also applied as a
+ * second layer of defence.
+ *
+ * Valid examples:  read_csv(csv_data)
+ *                  read_csv(csv_data, sep=';', header=0)
+ */
+export function validateCustomReadCSVFunction(code: string): PythonCodeValidationResult {
+    const trimmed = code.trim()
+
+    // Allowlist: must be a single read_csv() call
+    if (!trimmed.startsWith('read_csv(')) {
+        return { valid: false, reason: 'Custom read_csv code must start with read_csv(' }
+    }
+
+    // No newlines or semicolons — prevents class definitions and multi-statement payloads
+    if (/[\n\r;]/.test(trimmed)) {
+        return {
+            valid: false,
+            reason: 'Custom read_csv code must be a single function call with no newlines or semicolons'
+        }
+    }
+
+    // Apply the denylist as a second layer
+    return validatePythonCodeForDataFrame(trimmed)
 }


### PR DESCRIPTION
### The vulnerability                                                                                                          
                                                                                                                                 
  The CSV Agent node lets users supply a "Custom Pandas Read_CSV Code" field. This input is injected into                        
  `pd.${customReadCSVFunc}` and executed via Pyodide. A denylist blocks dangerous Python keywords, but `pd.read_pickle()` wasn't on it — allowing an attacker to deserialize a malicious pickle payload and achieve remote code execution.                      
                                                                                                                                 
  ### How the fix works      

  **Two independent layers — either one blocks the PoC.**
                                                                                                                                 
  **1. Allowlist for the user-supplied field**
                                                                                                                                 
  The field is meant for `read_csv()` calls only, so we now enforce exactly that:
  - Must start with `read_csv(`                                                                                                  
  - Must be a single line (no newlines or semicolons)
  - Denylist still applied on top as a safety net                                                                                
                                                                                                                                 
  This rejects the PoC's `isnull("") class MiniBytesIO: ... pd.read_pickle(...)` payload at the very first check.                
                                                                                                                                 
  **2. New denylist entries**                                                                                                    
                             
  Four patterns added, protecting both user input and LLM-generated code:                                                        
  - `read_pickle` — the direct RCE vector
  - `pickle` — the deserialization module                                                                                        
  - `marshal` — another unsafe deserializer                                                                                      
  - `class` definitions — used in the PoC to build a fake file-like object
                                                                                                                                 
  ### How the PoC is blocked 
                                                                                                                                 
  | What the PoC does | What stops it |                                                                                          
  |---|---|
  | Starts with `isnull("")` instead of `read_csv(` | Allowlist rejects it |                                                     
  | Defines a `class MiniBytesIO` | Allowlist blocks newlines; denylist blocks `class` |
  | Calls `pd.read_pickle(...)` | Denylist blocks `read_pickle` |                                                                
  | References pickle data | Denylist blocks `pickle` |
                                             