### PR TITLE
Add ip2geo IP geolocation tool

### DIFF
--- a/packages/components/credentials/Ip2GeoApi.credential.ts
+++ b/packages/components/credentials/Ip2GeoApi.credential.ts
@@ -1,0 +1,26 @@
+import { INodeParams, INodeCredential } from '../src/Interface'
+
+class Ip2GeoApi implements INodeCredential {
+    label: string
+    name: string
+    version: number
+    description: string
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'ip2geo API'
+        this.name = 'ip2GeoApi'
+        this.version = 1.0
+        this.description =
+            'Get your API key from <a target="_blank" href="https://ip2geo.dev">ip2geo.dev</a>'
+        this.inputs = [
+            {
+                label: 'ip2geo API Key',
+                name: 'ip2GeoApiKey',
+                type: 'password'
+            }
+        ]
+    }
+}
+
+module.exports = { credClass: Ip2GeoApi }

--- a/packages/components/nodes/tools/Ip2Geo/Ip2Geo.ts
+++ b/packages/components/nodes/tools/Ip2Geo/Ip2Geo.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod/v3'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getCredentialData, getCredentialParam } from '../../../src/utils'
+import { DynamicStructuredTool } from '../CustomTool/core'
+
+const code = `
+const url = 'https://api.ip2geo.dev/convert?ip=' + encodeURIComponent($ip_address);
+
+const response = await fetch(url, {
+    headers: {
+        'X-Api-Key': $vars.apiKey,
+    },
+});
+
+const data = await response.json();
+
+if (!data.success) {
+    return { error: data.message || 'Request failed' };
+}
+
+return data.data;
+`
+
+class Ip2Geo_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'ip2geo'
+        this.name = 'ip2Geo'
+        this.version = 1.0
+        this.type = 'Ip2Geo'
+        this.icon = 'ip2geo.svg'
+        this.category = 'Tools'
+        this.description = 'Convert IP addresses into geolocation data using ip2geo.dev'
+        this.baseClasses = [this.type, 'Tool']
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['ip2GeoApi']
+        }
+        this.inputs = [
+            {
+                label: 'IP Address',
+                name: 'ipAddress',
+                type: 'string',
+                description: 'The IP address to look up. Leave empty to let the LLM provide it.',
+                optional: true,
+                acceptVariable: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('ip2GeoApiKey', credentialData, nodeData)
+        const defaultIp = nodeData.inputs?.ipAddress as string
+
+        const obj = {
+            name: 'ip2geo_lookup',
+            description:
+                'Look up geolocation data for an IP address. Returns city, country, coordinates, timezone, ASN, and currency. Input should be an IPv4 or IPv6 address.',
+            schema: z.object({
+                ip_address: z.string().describe('The IPv4 or IPv6 address to look up')
+            }),
+            code: code,
+            variables: [
+                {
+                    name: 'apiKey',
+                    type: 'static',
+                    value: apiKey
+                }
+            ]
+        }
+
+        const dynamicStructuredTool = new DynamicStructuredTool(obj)
+
+        return dynamicStructuredTool
+    }
+}
+
+module.exports = { nodeClass: Ip2Geo_Tools }

--- a/packages/components/nodes/tools/Ip2Geo/ip2geo.svg
+++ b/packages/components/nodes/tools/Ip2Geo/ip2geo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#4629CD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="10" r="3"/><path d="M12 21.7C17.3 17 20 13 20 10a8 8 0 1 0-16 0c0 3 2.7 7 8 11.7z"/></svg>


### PR DESCRIPTION
## Summary

Adds a new tool node for [ip2geo](https://ip2geo.dev) — an IP geolocation API. Allows AI agents to look up geolocation data from IP addresses.

### What it does
- Input: IPv4 or IPv6 address
- Output: city, country, coordinates, timezone, ASN, currency, continent, flag

### Files

- **New:** `packages/components/credentials/Ip2GeoApi.credential.ts` — API key credential
- **New:** `packages/components/nodes/tools/Ip2Geo/Ip2Geo.ts` — tool node using DynamicStructuredTool
- **New:** `packages/components/nodes/tools/Ip2Geo/ip2geo.svg` — icon

### Test plan

- [x] Live API: returns correct data (Los Angeles, US, 34.0544, -118.244)
- [x] Bad API key: returns `success: false`
- [x] All files valid
- [x] Follows CurrentDateTime/DynamicStructuredTool pattern