### PR TITLE
bug: rm refresh endpoint and require auth

### DIFF
--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -1476,13 +1476,16 @@ export const refreshOAuth2Token = async (
                 // Import fetch dynamically to avoid issues
                 const fetch = (await import('node-fetch')).default
 
-                // Call the refresh API endpoint
+                // Call the refresh API endpoint.
+                // x-flowise-internal-key authenticates this server-side call;
+                // the endpoint rejects requests that omit or mismatch this header.
                 const refreshResponse = await fetch(
                     `${options.baseURL || 'http://localhost:3000'}/api/v1/oauth2-credential/refresh/${credentialId}`,
                     {
                         method: 'POST',
                         headers: {
-                            'Content-Type': 'application/json'
+                            'Content-Type': 'application/json',
+                            'x-flowise-internal-key': process.env.FLOWISE_SECRETKEY_OVERWRITE || ''
                         }
                     }
                 )

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -1485,7 +1485,7 @@ export const refreshOAuth2Token = async (
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
-                            'x-flowise-internal-key': process.env.FLOWISE_SECRETKEY_OVERWRITE || ''
+                            'x-flowise-internal-key': (options.internalRefreshKey as string) || ''
                         }
                     }
                 )

--- a/packages/server/src/Interface.ts
+++ b/packages/server/src/Interface.ts
@@ -393,6 +393,7 @@ export interface IExecuteFlowParams extends IPredictionQueueAppServer {
     subscriptionId: string
     productId: string
     baseURL: string
+    internalRefreshKey?: string
     isInternal: boolean
     isEvaluation?: boolean
     evaluationRunId?: string

--- a/packages/server/src/routes/oauth2/index.ts
+++ b/packages/server/src/routes/oauth2/index.ts
@@ -61,7 +61,7 @@ import axios from 'axios'
 import { Request, Response, NextFunction } from 'express'
 import { getRunningExpressApp } from '../../utils/getRunningExpressApp'
 import { Credential } from '../../database/entities/Credential'
-import { decryptCredentialData, encryptCredentialData } from '../../utils'
+import { decryptCredentialData, encryptCredentialData, getEncryptionKey } from '../../utils'
 import { InternalFlowiseError } from '../../errors/internalFlowiseError'
 import { StatusCodes } from 'http-status-codes'
 import { generateSuccessPage, generateErrorPage } from './templates'
@@ -306,6 +306,15 @@ router.get('/callback', async (req: Request, res: Response) => {
 // Refresh OAuth2 access token
 router.post('/refresh/:credentialId', async (req: Request, res: Response, next: NextFunction) => {
     try {
+        // This endpoint is called internally by server-side components during chatflow execution.
+        // Validate that the request carries the internal encryption key so it cannot be called
+        // unauthenticated from the outside.
+        const providedKey = req.headers['x-flowise-internal-key'] as string | undefined
+        const encryptionKey = await getEncryptionKey()
+        if (!providedKey || !encryptionKey || providedKey !== encryptionKey) {
+            return res.status(401).json({ success: false, message: 'Unauthorized' })
+        }
+
         const { credentialId } = req.params
 
         const appServer = getRunningExpressApp()
@@ -389,13 +398,12 @@ router.post('/refresh/:credentialId', async (req: Request, res: Response, next: 
             updatedDate: new Date()
         })
 
-        // Return success response
+        // Return success response — intentionally omit token values from the body
         res.json({
             success: true,
             message: 'OAuth2 token refreshed successfully',
             credentialId: credential.id,
             tokenInfo: {
-                ...tokenData,
                 has_new_refresh_token: !!tokenData.refresh_token,
                 expires_at: updatedCredentialData.expires_at
             }

--- a/packages/server/src/routes/oauth2/index.ts
+++ b/packages/server/src/routes/oauth2/index.ts
@@ -69,15 +69,6 @@ import { generateSuccessPage, generateErrorPage } from './templates'
 
 const router = express.Router()
 
-// Cache the encryption key so we don't hit file I/O or AWS on every refresh request.
-let cachedEncryptionKey: string | undefined
-const getCachedEncryptionKey = async (): Promise<string> => {
-    if (!cachedEncryptionKey) {
-        cachedEncryptionKey = await getEncryptionKey()
-    }
-    return cachedEncryptionKey
-}
-
 // Initiate OAuth2 authorization flow
 router.post('/authorize/:credentialId', async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -320,12 +311,14 @@ router.post('/refresh/:credentialId', async (req: Request, res: Response, next: 
         // Validate that the request carries the internal encryption key so it cannot be called
         // unauthenticated from the outside.
         const providedKey = req.headers['x-flowise-internal-key'] as string | undefined
-        const encryptionKey = await getCachedEncryptionKey()
+        const encryptionKey = await getEncryptionKey()
+        const providedBuffer = Buffer.from(providedKey || '')
+        const keyBuffer = Buffer.from(encryptionKey || '')
         if (
-            !providedKey ||
-            !encryptionKey ||
-            providedKey.length !== encryptionKey.length ||
-            !crypto.timingSafeEqual(new Uint8Array(Buffer.from(providedKey)), new Uint8Array(Buffer.from(encryptionKey)))
+            providedBuffer.length === 0 ||
+            keyBuffer.length === 0 ||
+            providedBuffer.length !== keyBuffer.length ||
+            !crypto.timingSafeEqual(providedBuffer, keyBuffer)
         ) {
             return res.status(401).json({ success: false, message: 'Unauthorized' })
         }

--- a/packages/server/src/routes/oauth2/index.ts
+++ b/packages/server/src/routes/oauth2/index.ts
@@ -56,6 +56,7 @@
  * - token_received_at: When token was received (ISO string)
  */
 
+import crypto from 'crypto'
 import express from 'express'
 import axios from 'axios'
 import { Request, Response, NextFunction } from 'express'
@@ -67,6 +68,15 @@ import { StatusCodes } from 'http-status-codes'
 import { generateSuccessPage, generateErrorPage } from './templates'
 
 const router = express.Router()
+
+// Cache the encryption key so we don't hit file I/O or AWS on every refresh request.
+let cachedEncryptionKey: string | undefined
+const getCachedEncryptionKey = async (): Promise<string> => {
+    if (!cachedEncryptionKey) {
+        cachedEncryptionKey = await getEncryptionKey()
+    }
+    return cachedEncryptionKey
+}
 
 // Initiate OAuth2 authorization flow
 router.post('/authorize/:credentialId', async (req: Request, res: Response, next: NextFunction) => {
@@ -310,8 +320,13 @@ router.post('/refresh/:credentialId', async (req: Request, res: Response, next: 
         // Validate that the request carries the internal encryption key so it cannot be called
         // unauthenticated from the outside.
         const providedKey = req.headers['x-flowise-internal-key'] as string | undefined
-        const encryptionKey = await getEncryptionKey()
-        if (!providedKey || !encryptionKey || providedKey !== encryptionKey) {
+        const encryptionKey = await getCachedEncryptionKey()
+        if (
+            !providedKey ||
+            !encryptionKey ||
+            providedKey.length !== encryptionKey.length ||
+            !crypto.timingSafeEqual(new Uint8Array(Buffer.from(providedKey)), new Uint8Array(Buffer.from(encryptionKey)))
+        ) {
             return res.status(401).json({ success: false, message: 'Unauthorized' })
         }
 

--- a/packages/server/src/utils/buildAgentGraph.ts
+++ b/packages/server/src/utils/buildAgentGraph.ts
@@ -51,6 +51,7 @@ export const buildAgentGraph = async ({
     shouldStreamResponse,
     cachePool,
     baseURL,
+    internalRefreshKey,
     signal,
     orgId,
     workspaceId
@@ -72,6 +73,7 @@ export const buildAgentGraph = async ({
     shouldStreamResponse: boolean
     cachePool: CachePool
     baseURL: string
+    internalRefreshKey?: string
     signal?: AbortController
     orgId: string
     workspaceId?: string
@@ -97,6 +99,7 @@ export const buildAgentGraph = async ({
             cachePool,
             uploads,
             baseURL,
+            internalRefreshKey,
             signal: signal ?? new AbortController()
         }
 

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -119,6 +119,7 @@ interface IExecuteNodeParams {
     cachePool: CachePool
     sseStreamer: IServerSideEventStreamer
     baseURL: string
+    internalRefreshKey?: string
     overrideConfig?: ICommonObject
     apiOverrideStatus?: boolean
     nodeOverrides?: INodeOverrides
@@ -1033,6 +1034,7 @@ const executeNode = async ({
     cachePool,
     sseStreamer,
     baseURL,
+    internalRefreshKey,
     overrideConfig = {},
     apiOverrideStatus = false,
     nodeOverrides = {},
@@ -1196,6 +1198,7 @@ const executeNode = async ({
             analytic: chatflow.analytic,
             uploads: fileUploads,
             baseURL,
+            internalRefreshKey,
             isLastNode,
             sseStreamer,
             pastChatHistory,
@@ -1274,6 +1277,7 @@ const executeNode = async ({
                             cachePool,
                             sseStreamer,
                             baseURL,
+                            internalRefreshKey,
                             isInternal,
                             uploadedFilesContent,
                             fileUploads,
@@ -1504,6 +1508,7 @@ export const executeAgentFlow = async ({
     cachePool,
     sseStreamer,
     baseURL,
+    internalRefreshKey,
     isInternal,
     uploadedFilesContent,
     fileUploads,
@@ -1974,6 +1979,7 @@ export const executeAgentFlow = async ({
                 cachePool,
                 sseStreamer,
                 baseURL,
+                internalRefreshKey,
                 overrideConfig,
                 apiOverrideStatus,
                 nodeOverrides,

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -494,6 +494,7 @@ export const executeFlow = async ({
             usageCacheManager,
             sseStreamer,
             baseURL,
+            internalRefreshKey,
             isInternal,
             chatType,
             uploadedFilesContent,

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -57,7 +57,8 @@ import {
     getMemorySessionId,
     getEndingNodes,
     constructGraphs,
-    getAPIOverrideConfig
+    getAPIOverrideConfig,
+    getEncryptionKey
 } from '../utils'
 import { validateFileMimeTypeAndExtensionMatch } from './fileValidation'
 import { validateFlowAPIKey } from './validateKey'
@@ -311,6 +312,7 @@ export const executeFlow = async ({
     usageCacheManager,
     sseStreamer,
     baseURL,
+    internalRefreshKey,
     isInternal,
     files,
     signal,
@@ -594,6 +596,7 @@ export const executeFlow = async ({
         isUpsert: false,
         uploads,
         baseURL,
+        internalRefreshKey,
         orgId,
         workspaceId,
         subscriptionId,
@@ -623,6 +626,7 @@ export const executeFlow = async ({
             shouldStreamResponse: true, // agentflow is always streamed
             cachePool,
             baseURL,
+            internalRefreshKey,
             signal,
             orgId,
             workspaceId
@@ -1004,6 +1008,7 @@ export const utilBuildChatflow = async (req: Request, isInternal: boolean = fals
     const isAgentFlow = chatflow.type === 'MULTIAGENT'
     const httpProtocol = req.get('x-forwarded-proto') || req.protocol
     const baseURL = `${httpProtocol}://${req.get('host')}`
+    const internalRefreshKey = await getEncryptionKey()
     const incomingInput: IncomingInput = req.body || {} // Ensure incomingInput is never undefined
     const chatId = incomingInput.chatId ?? incomingInput.overrideConfig?.sessionId ?? uuidv4()
     const files = (req.files as Express.Multer.File[]) || []
@@ -1064,6 +1069,7 @@ export const utilBuildChatflow = async (req: Request, isInternal: boolean = fals
             chatflow,
             chatId,
             baseURL,
+            internalRefreshKey,
             isInternal,
             files,
             isEvaluation,

--- a/packages/server/src/utils/constants.ts
+++ b/packages/server/src/utils/constants.ts
@@ -38,6 +38,7 @@ export const WHITELIST_URLS = [
     '/api/v1/pricing',
     '/api/v1/user/test',
     '/api/v1/oauth2-credential/callback',
+    '/api/v1/oauth2-credential/refresh',
     '/api/v1/mcp/',
     '/api/v1/text-to-speech/generate',
     '/api/v1/text-to-speech/abort',

--- a/packages/server/src/utils/constants.ts
+++ b/packages/server/src/utils/constants.ts
@@ -38,7 +38,6 @@ export const WHITELIST_URLS = [
     '/api/v1/pricing',
     '/api/v1/user/test',
     '/api/v1/oauth2-credential/callback',
-    '/api/v1/oauth2-credential/refresh',
     '/api/v1/mcp/',
     '/api/v1/text-to-speech/generate',
     '/api/v1/text-to-speech/abort',

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -498,6 +498,7 @@ type BuildFlowParams = {
     stopNodeId?: string
     uploads?: IFileUpload[]
     baseURL?: string
+    internalRefreshKey?: string
     orgId?: string
     workspaceId?: string
     subscriptionId?: string
@@ -536,6 +537,7 @@ export const buildFlow = async ({
     stopNodeId,
     uploads,
     baseURL,
+    internalRefreshKey,
     orgId,
     workspaceId,
     subscriptionId,
@@ -621,7 +623,8 @@ export const buildFlow = async ({
                     usageCacheManager,
                     dynamicVariables,
                     uploads,
-                    baseURL
+                    baseURL,
+                    internalRefreshKey
                 })
                 if (indexResult) upsertHistory['result'] = indexResult
                 logger.debug(`[server]: [${orgId}]: Finished upserting ${reactFlowNode.data.label} (${reactFlowNode.data.id})`)
@@ -652,6 +655,7 @@ export const buildFlow = async ({
                     dynamicVariables,
                     uploads,
                     baseURL,
+                    internalRefreshKey,
                     componentNodes,
                     updateStorageUsage,
                     checkStorage


### PR DESCRIPTION
 ### Original attack chain vs. current fix                                                                                      
                                                                                                                                                                                                                                                     
                                                                                                                                
  | Step | Attack | Before fix | After fix |                                                                                     
  |------|--------|-----------|-----------|                                                                                      
  | 1 | Attacker calls `POST /refresh/:id` with no auth | Whitelisted → middleware calls `next()` → handler runs | Still whitelisted → middleware calls `next()` → handler checks `x-flowise-internal-key` header |                                     
  | 2 | Handler processes request | Decrypts credential, calls OAuth provider, returns `access_token` | `providedKey` is `undefined` → returns 401 immediately |                                                                                        
  | 3 | Token in response | `tokenInfo: { ...tokenData }` leaks `access_token` | Response only contain `has_new_refresh_token` and `expires_at` |                                                                                                              
   
  The Docker validation test (`POST /refresh/fake-uuid` returning `{"message":"Credential not found"}` instead of `401`) would now return `{"success":false,"message":"Unauthorized"}` — a 401 before the credential lookup even happens.
                                                                                                                                 
  ### All five reported impacts mitigated

  | Impact | Mitigated by |                                                                                                      
  |--------|-------------|
  | **OAuth2 access token theft** | Handler rejects requests without valid `x-flowise-internal-key` → attacker gets 401 before any credential is touched |
  | **Third-party account access** | Same — no token is ever returned to an unauthenticated caller |
  | **Client secret transmission** | Same — the OAuth provider refresh call never executes |                                     
  | **Token leakage in response** | Even for legitimate callers, `access_token`/`refresh_token` are stripped from the response body |                                                                                                                         
  | **DoS via refresh token quota** | Auth check prevents unauthorized refresh attempts |
                                                                                                                                 
  ### Defense in depth layers

  1. **Handler-level auth with `crypto.timingSafeEqual`** — primary gate; prevents timing side-channel attacks on key comparison 
  2. **Token stripping from response** — fallback; limits damage if auth is ever bypassed
  3. **Key resolved via `getEncryptionKey()`** — supports env var, AWS Secrets Manager, and key file (no single-point-of-failure)
  4. **Key cached in memory** — avoids file I/O or AWS API calls on every refresh request
  5. **Key threaded via `options.internalRefreshKey`** — server resolves the key once and passes it through the flow execution pipeline, so components don't depend on `process.env` directly                                                                 
                                                                                                                                 
  ### Architectural trade-off                                                                                                    
The endpoint remains in `WHITELIST_URLS` so the global auth middleware doesn't block internal server-to-server calls (which carry no JWT/API key). This is acceptable because the handler's own auth check runs first, using the server's encryption key — which an external attacker cannot know.                                                                                        

