### PR TITLE
Optimize Docker Build: Integrated File Ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,12 @@ ENV NODE_OPTIONS=--max-old-space-size=8192
 WORKDIR /usr/src/flowise
 
 # Copy app source
-COPY . .
-
+COPY --chown=node:node . .
 # Install dependencies and build
 RUN pnpm install && \
     pnpm build
 
-# Give the node user ownership of the application files
-RUN chown -R node:node .
+
 
 # Switch to non-root user (node user already exists in node:20-alpine)
 USER node


### PR DESCRIPTION
Refactored the build process to use the --chown flag directly within the COPY instruction. This replaces the secondary RUN chown -R command, eliminating a massive file-system layer and bypassing the high-latency overhead of recursive ownership changes. This change significantly reduces build times and shrinks the final image footprint by avoiding redundant data duplication.