### PR TITLE
feat(observe): add initial package structure and configuration for @flowiseai/observe

### DIFF
--- a/packages/observe/.eslintrc.js
+++ b/packages/observe/.eslintrc.js
@@ -1,0 +1,168 @@
+const features = ['executions']
+const crossFeatureRules = features.map((feature) => ({
+    target: `./src/features/${feature}`,
+    from: './src/features',
+    except: [`./${feature}`],
+    message: 'Features cannot import from other features. Move shared logic to core.'
+}))
+
+module.exports = {
+    root: true,
+    extends: [
+        'eslint:recommended',
+        'plugin:markdown/recommended',
+        'plugin:react/recommended',
+        'plugin:react/jsx-runtime',
+        'plugin:react-hooks/recommended',
+        'plugin:jsx-a11y/recommended',
+        'plugin:@typescript-eslint/recommended',
+        'plugin:prettier/recommended'
+    ],
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: {
+            jsx: true
+        }
+    },
+    settings: {
+        react: {
+            version: 'detect'
+        },
+        'import/resolver': {
+            typescript: {
+                project: './tsconfig.json'
+            }
+        }
+    },
+    plugins: ['react', 'react-hooks', '@typescript-eslint', 'unused-imports', 'jsx-a11y', 'simple-import-sort', 'import'],
+    ignorePatterns: ['dist', 'node_modules', 'build', 'vite.config.ts', 'examples/dist', '**/*.json'],
+    rules: {
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+        '@typescript-eslint/no-explicit-any': 'warn',
+        '@typescript-eslint/no-unused-vars': 'off',
+        'no-unused-vars': 'off',
+        'unused-imports/no-unused-imports': 'warn',
+        'unused-imports/no-unused-vars': [
+            'warn',
+            {
+                vars: 'all',
+                varsIgnorePattern: '^_',
+                args: 'after-used',
+                argsIgnorePattern: '^_'
+            }
+        ],
+        'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
+        'react/prop-types': 'off',
+        'react/react-in-jsx-scope': 'off',
+        'simple-import-sort/imports': [
+            'error',
+            {
+                groups: [
+                    ['^\\u0000'],
+                    ['^react', '^react-dom'],
+                    ['^@?\\w'],
+                    ['^@/'],
+                    ['^\\.\\.(?!/?$)', '^\\.\\./?$'],
+                    ['^\\./(?=.*/)(?!/?$)', '^\\.(?!/?$)', '^\\./?$'],
+                    ['^.+\\.?(css|scss)$']
+                ]
+            }
+        ],
+        'simple-import-sort/exports': 'error',
+        'import/first': 'error',
+        'import/newline-after-import': 'error',
+        'import/no-duplicates': 'error',
+        'jsx-a11y/no-autofocus': ['error', { ignoreNonDOM: true }],
+        'prettier/prettier': 'error',
+        'no-restricted-imports': [
+            'error',
+            {
+                patterns: [
+                    {
+                        group: ['@/features', '@/features/*'],
+                        message:
+                            '@/features alias is not allowed. Features use relative imports internally; other layers cannot import from features.'
+                    }
+                ]
+            }
+        ],
+        'import/no-restricted-paths': [
+            'error',
+            {
+                zones: [
+                    {
+                        target: './src/atoms',
+                        from: './src/features',
+                        message: 'Atoms cannot import from features. Keep atoms dumb and reusable.'
+                    },
+                    {
+                        target: './src/atoms',
+                        from: './src/infrastructure',
+                        message: 'Atoms cannot import from infrastructure. Use props instead of contexts.'
+                    },
+                    {
+                        target: './src/atoms',
+                        from: './src/core',
+                        except: ['./types', './theme', './primitives'],
+                        message: 'Atoms can only import from core/types, core/theme, and core/primitives.'
+                    },
+                    {
+                        target: './src/core',
+                        from: './src/atoms',
+                        message: 'Core is a leaf node and cannot import from atoms.'
+                    },
+                    {
+                        target: './src/core',
+                        from: './src/features',
+                        message: 'Core is a leaf node and cannot import from features.'
+                    },
+                    {
+                        target: './src/core',
+                        from: './src/infrastructure',
+                        message: 'Core is a leaf node and cannot import from infrastructure.'
+                    },
+                    {
+                        target: './src/infrastructure',
+                        from: './src/atoms',
+                        message: 'Infrastructure cannot import from atoms. Move shared code to core.'
+                    },
+                    {
+                        target: './src/infrastructure',
+                        from: './src/features',
+                        message: 'Infrastructure cannot import from features. Move shared code to core.'
+                    },
+                    ...crossFeatureRules
+                ]
+            }
+        ]
+    },
+    env: {
+        browser: true,
+        es2021: true,
+        node: true
+    },
+    overrides: [
+        {
+            files: ['examples/**/*.{js,jsx,ts,tsx}', '**/*.md/**'],
+            rules: {
+                'no-console': 'off',
+                '@typescript-eslint/no-non-null-assertion': 'off',
+                // Code blocks in docs are illustrative snippets, not compilable modules
+                'react/jsx-no-undef': 'off',
+                'no-undef': 'off',
+                'simple-import-sort/imports': 'off',
+                'import/first': 'off',
+                'prettier/prettier': 'off',
+                'unused-imports/no-unused-vars': 'off'
+            }
+        },
+        {
+            files: ['src/__test_utils__/**/*.js'],
+            rules: {
+                '@typescript-eslint/no-require-imports': 'off'
+            }
+        }
+    ]
+}

--- a/packages/observe/.prettierrc
+++ b/packages/observe/.prettierrc
@@ -1,0 +1,9 @@
+{
+    "printWidth": 140,
+    "singleQuote": true,
+    "jsxSingleQuote": true,
+    "trailingComma": "none",
+    "tabWidth": 4,
+    "semi": false,
+    "endOfLine": "auto"
+}

--- a/packages/observe/ARCHITECTURE.md
+++ b/packages/observe/ARCHITECTURE.md
@@ -1,0 +1,396 @@
+# @flowiseai/observe - Architecture
+
+This document describes the internal architecture of the `@flowiseai/observe` package.
+
+## Overview
+
+The package follows a **Domain-Driven Modular Architecture** with clear separation of concerns — the same four-layer structure as `@flowiseai/agentflow`. The goal is to keep UI primitives, business logic, API communication, and domain features cleanly separated, so individual features (executions, evaluations, chat history) can be added, tested, and removed without disturbing each other.
+
+```
+src/
+├── index.ts                    # Public Package API ("Public Face")
+│
+├── atoms/                      # ⚛️ UI Primitives ("What it looks like" (Dumb))
+├── features/                   # 🧩 Domain Features ("What it does" (Smart))
+├── core/                       # 🧠 Business Logic ("Business Rules" (Types/Logic))
+└── infrastructure/             # 🌐 External Services ("Outside World" (API/Storage))
+```
+
+---
+
+## Directory Structure
+
+### `atoms/` - UI Primitives
+
+**"What it looks like."** Tiny, irreducible UI components with no business logic. Shared building blocks used across features.
+
+```
+atoms/
+├── StatusIcon.tsx          # Execution / node status icon (INPROGRESS, FINISHED, ERROR…)
+├── MetricsDisplay.tsx      # Token / cost / time metrics row
+└── index.ts                # Central export
+```
+
+**Rules:**
+
+-   Must be "dumb" and stateless (or minimal local state for animations)
+-   No business logic
+-   No API calls
+-   Imported by features, never the reverse
+-   **Forbidden**: Importing from `features/` or `infrastructure/` — only `core/types`, `core/theme`, and `core/primitives`
+
+**Goal:** 100% visual consistency across all observe features.
+
+---
+
+### `features/` - Domain Features
+
+**"What it does."** Self-contained domain modules. Each feature owns its components, hooks, and feature-local utilities. Adding a new observability feature (evaluations, chat history, MALT) means adding a new directory here — it does not touch existing feature exports.
+
+```
+features/
+├── executions/             # Execution viewer
+│   ├── components/
+│   │   ├── ExecutionsViewer.tsx      # Filterable list + pagination (global or scoped via agentflowId)
+│   │   ├── ExecutionDetail.tsx       # Resizable split-pane: tree + node detail
+│   │   ├── NodeExecutionDetail.tsx   # Step viewer: markdown/JSON/code/HTML renderers, HITL
+│   │   └── ExecutionsListTable.tsx   # Sortable/selectable MUI table
+│   ├── hooks/
+│   │   ├── useExecutionPoll.ts       # Auto-poll while INPROGRESS, stop on terminal state
+│   │   └── useExecutionTree.ts       # Build ExecutionTreeNode[] from flat NodeExecutionData[]
+│   └── index.ts                      # Public API for this feature
+│
+└── (evaluations/)          # Future — GA
+    └── (chat-history/)     # Future — GA
+```
+
+**Rules:**
+
+-   Each feature has an `index.ts` gatekeeper — only re-export what consumers need
+-   **Features never import from other features directly** — if two features share logic, move it to `core/`
+-   Feature-specific utilities stay in the feature folder
+-   Hooks are co-located with their feature
+
+**Goal:** High cohesion. Deleting a feature folder should not break other features.
+
+---
+
+### `core/` - Business Logic
+
+**"The Brain."** Framework-agnostic types, utilities, and the MUI theme factory. No React components, no API calls.
+
+```
+core/
+├── types/
+│   ├── execution.ts        # Execution, ExecutionState, NodeExecutionData,
+│   │                       # ExecutionTreeNode, HumanInputParams
+│   ├── observe.ts          # ObserveBaseProps (provider props), ExecutionsViewerProps,
+│   │                       # ExecutionDetailProps, ExecutionFilters
+│   └── index.ts
+│
+├── primitives/             # Domain-free, safe to import from atoms/
+│   └── index.ts
+│
+└── theme/
+    ├── tokens.ts               # Color palette, spacing, shadows
+    ├── createObserveTheme.ts   # MUI theme factory (isDarkMode toggle)
+    └── index.ts
+```
+
+**Rules:**
+
+-   **No React components** — pure TypeScript only
+-   No browser-specific APIs unless unavoidable
+-   No side effects
+-   Can be tested in isolation
+
+#### `core/primitives/` vs `core/utils/`
+
+-   **`primitives/`** — Domain-free utilities with no knowledge of executions or node data. **Safe to import from `atoms/`.**
+-   **`utils/`** — Domain-aware utilities (e.g., execution state helpers). **Only importable by `features/` and `infrastructure/`.**
+
+When adding a utility, ask: _"Does this function need to know what an Execution or NodeExecutionData is?"_ If no → `primitives/`. If yes → `utils/`.
+
+**Goal:** Framework-agnostic source of truth.
+
+---
+
+### `infrastructure/` - External Services
+
+**"The Outside World."** API client factory and React context providers.
+
+```
+infrastructure/
+├── api/
+│   ├── client.ts           # bindApiClient(apiBaseUrl, token) — axios with Bearer header
+│   ├── executions.ts       # createExecutionsApi(client): getAllExecutions, getExecutionById,
+│   │                       # deleteExecutions, updateExecution
+│   └── index.ts
+│
+└── store/
+    └── ObserveContext.tsx  # ObserveProvider, useObserveApi(), useObserveConfig()
+```
+
+**Rules:**
+
+-   All external communication goes through `infrastructure/api/`
+-   Contexts are internal — composed in `ObserveProvider`, not exported directly to consumers
+-   `useObserveApi()` throws if called outside `ObserveProvider` (fast failure)
+
+**Goal:** Wrap external dependencies so they can be mocked in tests.
+
+---
+
+## Dependency Flow
+
+**Dependencies must only flow downwards.**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                  Root Files (Public API)                │
+│                       (index.ts)                        │
+│                   "The Public Face"                     │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│                      features/                          │
+│   (executions, evaluations, chat-history, …)            │
+│                   "What it does"                        │
+└─────────────────────────────────────────────────────────┘
+          │                                    │
+          ▼                                    ▼
+┌──────────────────┐              ┌────────────────────────┐
+│      atoms/      │              │    infrastructure/     │
+│  (UI primitives) │              │    (api, store)        │
+│ "What it looks   │              │ "The Outside World"    │
+│     like"        │              │                        │
+└──────────────────┘              └────────────────────────┘
+          │                                    │
+          └──────────────┬─────────────────────┘
+                         ▼
+              ┌─────────────────────┐
+              │        core/        │
+              │  (types, theme,     │
+              │   primitives)       │
+              │     "The Brain"     │
+              └─────────────────────┘
+```
+
+**Import Rules:**
+
+-   `features` → `atoms`, `infrastructure`, `core` ✅
+-   `infrastructure` → `core` ✅
+-   `atoms` → `core/types`, `core/theme`, `core/primitives` only ✅
+-   `core` → nothing (leaf node) ✅
+-   **No reverse imports** — enforced by ESLint `import/no-restricted-paths`
+
+---
+
+## Observe-Specific Patterns
+
+### `ObserveProvider` — Root Provider
+
+`ObserveProvider` composes three providers:
+
+```tsx
+<ThemeProvider theme={createObserveTheme(isDarkMode)}>
+    <ObserveApiContext.Provider value={api}>
+        <ObserveConfigContext.Provider value={config}>{children}</ObserveConfigContext.Provider>
+    </ObserveApiContext.Provider>
+</ThemeProvider>
+```
+
+-   `ObserveApiContext` — holds the bound axios client (created once from `apiBaseUrl` + `token` + `requestInterceptor`)
+-   `ObserveConfigContext` — holds `isDarkMode` and other display config
+-   Features call `useObserveApi()` to get the client; they never construct it themselves
+
+### Request Interceptor — Auth Bridging
+
+The SDK sends `Authorization: Bearer <token>` by default. Different consumers authenticate differently:
+
+| Consumer                     | Auth mechanism                              | How to configure                                       |
+| ---------------------------- | ------------------------------------------- | ------------------------------------------------------ |
+| DevSite                      | AgentForge proxy headers                    | `requestInterceptor` to inject proxy token             |
+| OSS (embedded in Flowise UI) | Session cookie + `x-request-from: internal` | `requestInterceptor` to set `withCredentials` + header |
+| OSS (standalone / external)  | Flowise API key                             | `token` prop (default)                                 |
+
+`requestInterceptor` is a callback on the Axios request config, identical in shape to the one in `@flowiseai/agentflow`:
+
+```ts
+interface ObserveBaseProps {
+    requestInterceptor?: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig
+}
+```
+
+It is passed to `bindApiClient` and registered via `axios.interceptors.request.use`. If the callback throws, the error is caught, logged, and the original unmodified config is used so the request still proceeds safely.
+
+**OSS session auth example:**
+
+```tsx
+<ObserveProvider
+    apiBaseUrl='http://localhost:3000'
+    requestInterceptor={(config) => {
+        config.withCredentials = true
+        config.headers['x-request-from'] = 'internal'
+        return config
+    }}
+>
+    <ExecutionsViewer agentflowId='...' />
+</ObserveProvider>
+```
+
+`requestInterceptor` should only be provided by trusted, developer-authored code — never from user input or dynamically evaluated strings.
+
+### Auto-Poll (`useExecutionPoll`)
+
+`useExecutionPoll` sets up a `setInterval` while `execution.state === 'INPROGRESS'`:
+
+```
+INPROGRESS → polls every pollInterval ms
+FINISHED | ERROR | TERMINATED | TIMEOUT | STOPPED → interval cleared immediately
+```
+
+-   `pollInterval={0}` disables auto-poll entirely
+-   `refresh()` is returned for manual refresh buttons
+-   The hook clears the interval on unmount
+
+### Execution Tree (`useExecutionTree`)
+
+`useExecutionTree` converts the flat `NodeExecutionData[]` stored as JSON in `execution.executionData` into a hierarchical `ExecutionTreeNode[]`:
+
+1. Parse `executionData` JSON
+2. Separate top-level nodes (no `parentNodeId`) from iteration children
+3. Group children by `(parentNodeId, iterationIndex)`
+4. Insert virtual container nodes labeled `Iteration #N` with `isVirtualNode: true`
+
+The tree is used by `ExecutionDetail` to render the sidebar node list.
+
+### HITL Callback — Opaque Consumer Contract
+
+The `onHumanInput` prop is intentionally opaque:
+
+```ts
+interface ExecutionsViewerProps {
+    onHumanInput?: (agentflowId: string, params: HumanInputParams) => Promise<void>
+}
+```
+
+-   In OSS: consumer calls the Flowise prediction endpoint directly
+-   In DevSite: consumer routes through the AgentForge proxy
+
+The SDK never calls the prediction API itself. Approve/Reject buttons are only rendered when `onHumanInput` is provided AND the node is a human input node in INPROGRESS state. This keeps auth and routing logic entirely out of the SDK.
+
+### Tenant Isolation
+
+Tenant isolation is handled server-side by Flowise's `ExtendRequestContextMiddleware` via request headers. The SDK does not accept or pass a `tenantId` prop — the API returns only what the authenticated token is permitted to see.
+
+---
+
+## Gatekeeper Pattern
+
+Each module exposes only what's needed via its `index.ts`:
+
+```typescript
+// features/executions/index.ts
+// ✅ Public API — components and types needed by index.ts
+export { ExecutionsViewer } from './components/ExecutionsViewer'
+export { ExecutionDetail } from './components/ExecutionDetail'
+export { NodeExecutionDetail } from './components/NodeExecutionDetail'
+export { useExecutionPoll } from './hooks/useExecutionPoll'
+export { useExecutionTree } from './hooks/useExecutionTree'
+
+// ❌ Internal sub-components and helpers stay private
+```
+
+---
+
+## Adding a New Feature
+
+Adding evaluations, chat history, or MALT follows the same pattern:
+
+1. Create a folder under `features/`:
+
+    ```
+    features/evaluations/
+    ├── components/
+    │   └── EvaluationsViewer.tsx
+    ├── hooks/
+    │   └── useEvaluationPoll.ts
+    └── index.ts
+    ```
+
+2. Add the API module under `infrastructure/api/`:
+
+    ```
+    infrastructure/api/
+    └── evaluations.ts   # createEvaluationsApi(client)
+    ```
+
+3. Add any new types to `core/types/` (e.g., `evaluation.ts`)
+
+4. Export only from the feature's `index.ts`, then re-export from the package `src/index.ts`
+
+5. Import from infrastructure/core, never from other features:
+
+    ```typescript
+    // ✅ Good
+    import { useObserveApi } from '../../../infrastructure/store'
+    import type { Execution } from '../../../core/types'
+
+    // ❌ Bad — cross-feature import
+    import { ExecutionDetail } from '../executions/components/ExecutionDetail'
+    ```
+
+---
+
+## Root Files (`src/index.ts`)
+
+The barrel export exposes only the public surface:
+
+```typescript
+// Components
+export { ExecutionsViewer } from './features/executions'
+export { ExecutionDetail } from './features/executions'
+export { NodeExecutionDetail } from './features/executions'
+export { ObserveProvider } from './infrastructure/store'
+
+// Types
+export type { ExecutionsViewerProps, ExecutionDetailProps, ExecutionFilters } from './core/types'
+export type { Execution, ExecutionState, NodeExecutionData, HumanInputParams } from './core/types'
+```
+
+Everything else is internal implementation detail.
+
+---
+
+## Development Principles
+
+### Barrel Exports
+
+Every directory has an `index.ts` gatekeeper.
+
+**✅ Good:**
+
+```typescript
+import { StatusIcon } from '../../atoms'
+import { useObserveApi } from '../../infrastructure/store'
+```
+
+**❌ Bad:**
+
+```typescript
+// Never deep-link into files
+import { StatusIcon } from '../../atoms/StatusIcon'
+import { useObserveApi } from '../../infrastructure/store/ObserveContext'
+```
+
+### Naming Conventions
+
+| Type        | Convention                  | Example                      |
+| ----------- | --------------------------- | ---------------------------- |
+| Component   | PascalCase.tsx              | `ExecutionDetail.tsx`        |
+| Hook        | camelCase.ts (`use` prefix) | `useExecutionPoll.ts`        |
+| Logic/Types | camelCase.ts                | `execution.ts`, `observe.ts` |
+| API module  | camelCase.ts                | `executions.ts`              |
+| Styles      | kebab-case (co-located)     | `executions.css`             |

--- a/packages/observe/README.md
+++ b/packages/observe/README.md
@@ -1,0 +1,327 @@
+# @flowiseai/observe
+
+[![Version](https://img.shields.io/npm/v/@flowiseai/observe)](https://www.npmjs.com/package/@flowiseai/observe)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/FlowiseAI/Flowise/blob/main/LICENSE.md)
+
+> Embeddable React components for visualizing AI agent runtime observability — executions, evaluations, and more
+
+## ⚠️ Status
+
+**This package is currently under active development.**
+
+-   🚧 Components are not yet fully functional
+-   ❌ End-to-end functionality is not complete
+-   🔄 Features are still being implemented and tested
+-   ⚡ APIs may change before stable release
+-   📝 Documentation is being updated as development progresses
+
+**Cannot be used in production. For development and testing purposes only.**
+
+## Overview
+
+`@flowiseai/observe` is the runtime observability SDK for Flowise. It provides embeddable React components for viewing execution traces, node-level step details, and human-in-the-loop interactions for AI agent workflows built with Flowise.
+
+This is the "Observe" layer of the Build-Run-Observe trio alongside `@flowiseai/agentflow` (Build).
+
+## Features
+
+-   **Execution List** — Filterable, paginated table of agent executions across all agentflows, or scoped to a single agentflow via `agentflowId`
+-   **Execution Detail** — Resizable split-pane with a sidebar node tree and a right-side step viewer
+-   **Node Step Viewer** — Renders markdown, JSON, raw code, and HTML output per node step, with rendered/raw toggle
+-   **Token / Cost / Time Metrics** — Per-node execution metrics displayed inline
+-   **Auto-Poll** — Automatically refreshes while a run is `INPROGRESS`, stops on terminal state
+-   **HITL Support** — Approve/Reject buttons for human-input nodes when `onHumanInput` callback is provided
+-   **State + Date Filters** — Filter by execution state and date range
+-   **Single-Row and Bulk Delete** — Opt-in trash icon on row hover, plus bulk delete via checkbox selection
+-   **Dark Mode** — Full light/dark theme support via design tokens and CSS variables
+-   **SDK-Owned Theme** — No host theme required; `ObserveProvider` injects its own MUI theme
+
+## Installation
+
+```bash
+pnpm add @flowiseai/observe
+```
+
+**Peer Dependencies:**
+
+```bash
+pnpm add react react-dom @mui/material @mui/icons-material @emotion/react @emotion/styled
+```
+
+> Note: ReactFlow is **not** a peer dependency. `@flowiseai/observe` is a viewer only — no canvas.
+
+## Basic Usage
+
+### Execution List
+
+Displays all executions across every agentflow. Pass `agentflowId` to scope the list to a single flow — useful when embedding next to a specific agentflow canvas.
+
+```tsx
+import { ExecutionsViewer, ObserveProvider } from '@flowiseai/observe'
+import '@flowiseai/observe/observe.css'
+
+export default function App() {
+    return (
+        <ObserveProvider apiBaseUrl='http://localhost:3000' token='your-api-key'>
+            {/* All agentflows */}
+            <ExecutionsViewer allowDelete={true} pollInterval={3000} />
+
+            {/* Scoped to one agentflow */}
+            <ExecutionsViewer agentflowId='uuid-of-the-agentflow' allowDelete={true} pollInterval={3000} />
+        </ObserveProvider>
+    )
+}
+```
+
+### Standalone Execution Detail
+
+Renders the full step viewer for a single execution by ID — useful for deep-linking into a specific trace.
+
+```tsx
+import { ExecutionDetail, ObserveProvider } from '@flowiseai/observe'
+import '@flowiseai/observe/observe.css'
+
+export default function App() {
+    return (
+        <ObserveProvider apiBaseUrl='http://localhost:3000' token='your-api-key'>
+            <ExecutionDetail executionId='uuid-of-the-execution' pollInterval={3000} />
+        </ObserveProvider>
+    )
+}
+```
+
+### With HITL Callback
+
+The `onHumanInput` callback is how the host application handles human-in-the-loop responses. The SDK delegates routing entirely to the consumer — OSS calls Flowise directly, DevSite routes through the AgentForge proxy.
+
+```tsx
+<ExecutionsViewer
+    onHumanInput={async (agentflowId, params) => {
+        // OSS: call Flowise prediction endpoint directly
+        await fetch(`/api/v1/prediction/${agentflowId}`, {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}` },
+            body: JSON.stringify(params.humanInput)
+        })
+        // DevSite: route through AgentForge proxy instead
+    }}
+/>
+```
+
+When `onHumanInput` is not provided, Approve/Reject buttons are not rendered. No auth complexity leaks into the SDK.
+
+### With Request Interceptor
+
+`token` and `requestInterceptor` are both optional and compose: if both are provided, the Bearer header is set first, then the interceptor runs and can extend or override it.
+
+**API key (default):**
+
+```tsx
+// token alone — sets Authorization: Bearer header automatically
+<ObserveProvider apiBaseUrl='http://localhost:3000' token='your-api-key'>
+    {/* your app */}
+</ObserveProvider>
+```
+
+**OSS session auth** — embedding inside the Flowise UI where a session cookie already exists:
+
+```tsx
+<ObserveProvider
+    apiBaseUrl='http://localhost:3000'
+    requestInterceptor={(config) => {
+        config.withCredentials = true
+        config.headers['x-request-from'] = 'internal'
+        return config
+    }}
+>
+    <ExecutionsViewer agentflowId='...' />
+</ObserveProvider>
+```
+
+**DevSite proxy auth** — inject AgentForge proxy headers:
+
+```tsx
+<ObserveProvider
+    apiBaseUrl='https://...'
+    requestInterceptor={(config) => {
+        config.headers['x-agentforge-token'] = getProxyToken()
+        return config
+    }}
+>
+    {/* your app */}
+</ObserveProvider>
+```
+
+If the interceptor throws, the error is caught, logged, and the original unmodified config is used so the request still proceeds. Only pass trusted, developer-authored functions — never user-generated input.
+
+## Props
+
+### `<ObserveProvider>`
+
+Root provider. Wraps `ExecutionsViewer` or `ExecutionDetail`. Injects the MUI theme, API client, and config context.
+
+<!-- prettier-ignore -->
+| Prop                  | Type                                                                      | Default        | Description                                                                                   |
+| --------------------- | ------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------- |
+| `apiBaseUrl`          | `string`                                                                  | **(required)** | Flowise API server base URL                                                                   |
+| `token`               | `string`                                                                  | —              | API key — sets `Authorization: Bearer <token>`. Optional when using `requestInterceptor`. |
+| `requestInterceptor`  | `(config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig`     | —              | Customize outgoing requests. Runs after Bearer header is set — can extend or override it. See [Request Interceptor](#with-request-interceptor) below. |
+| `isDarkMode`          | `boolean`                                                                 | `false`        | Use dark mode theme                                                                           |
+| `children`            | `ReactNode`                                                               | **(required)** | `ExecutionsViewer`, `ExecutionDetail`, or both                                                |
+
+### `<ExecutionsViewer>`
+
+Filterable, paginated list of executions. Clicking a row opens `ExecutionDetail` in a side drawer. Must be rendered inside `<ObserveProvider>`.
+
+<!-- prettier-ignore -->
+| Prop             | Type                                                                | Default | Description                                                                         |
+| ---------------- | ------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `agentflowId`    | `string`                                                            | —       | Scope list to a single agentflow. Omit for full cross-agent list.                   |
+| `allowDelete`    | `boolean`                                                           | `false` | Show trash icon on row hover with inline confirm dialog                             |
+| `pollInterval`   | `number`                                                            | `3000`  | Auto-poll interval in ms while any execution is INPROGRESS. `0` = off              |
+| `initialFilters` | `Partial<ExecutionFilters>`                                         | —       | Pre-set filter values on mount                                                      |
+| `onHumanInput`   | `(agentflowId: string, params: HumanInputParams) => Promise<void>` | —       | HITL callback. Approve/Reject buttons hidden when not provided                      |
+
+### `<ExecutionDetail>`
+
+Resizable split-pane viewer for a single execution. Left sidebar shows the node tree; right panel shows `NodeExecutionDetail` for the selected step. Must be rendered inside `<ObserveProvider>`.
+
+<!-- prettier-ignore -->
+| Prop           | Type                                                                | Default        | Description                                                        |
+| -------------- | ------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------ |
+| `executionId`  | `string`                                                            | **(required)** | UUID of the execution to display                                   |
+| `pollInterval` | `number`                                                            | `3000`         | Auto-poll interval in ms while execution is INPROGRESS. `0` = off |
+| `onHumanInput` | `(agentflowId: string, params: HumanInputParams) => Promise<void>` | —              | HITL callback. Approve/Reject buttons hidden when not provided     |
+| `onClose`      | `() => void`                                                        | —              | Called when the panel is dismissed (dismissible contexts only)     |
+
+### Auto-Poll Behavior
+
+Both `ExecutionsViewer` and `ExecutionDetail` auto-refresh while `state === 'INPROGRESS'`:
+
+```
+INPROGRESS → polls every pollInterval ms
+FINISHED | ERROR | TERMINATED | TIMEOUT | STOPPED → polling stops immediately
+```
+
+Set `pollInterval={0}` to disable auto-poll and rely on the manual refresh button only.
+
+### Deletion
+
+Opt-in via `allowDelete={true}` on `ExecutionsViewer`. Shows a trash icon on row hover. Clicking opens an inline confirm dialog. The SDK calls `DELETE /api/v1/executions` internally on confirm.
+
+> Bulk delete is available via checkbox selection in the table header.
+
+## Types
+
+```typescript
+type ExecutionState = 'INPROGRESS' | 'FINISHED' | 'ERROR' | 'TERMINATED' | 'TIMEOUT' | 'STOPPED'
+
+interface Execution {
+    id: string
+    executionData: string // JSON-serialized NodeExecutionData[]
+    state: ExecutionState
+    agentflowId: string
+    sessionId?: string
+    isPublic: boolean
+    createdDate: string
+    updatedDate: string
+    agentflow?: { id: string; name: string }
+}
+
+interface NodeExecutionData {
+    nodeLabel: string
+    nodeId: string
+    data: unknown // rendered content (markdown string, object, etc.)
+    previousNodeIds: string[]
+    status: ExecutionState
+    name?: string
+    iterationIndex?: number
+    parentNodeId?: string
+    output?: unknown
+}
+
+interface HumanInputParams {
+    question: string
+    chatId: string
+    humanInput: {
+        type: 'proceed' | 'reject'
+        startNodeId: string
+        feedback?: string
+    }
+}
+
+interface ExecutionFilters {
+    state: ExecutionState | ''
+    startDate: string
+    endDate: string
+    sessionId: string
+    agentflowName: string // M2 only
+}
+```
+
+## Development
+
+```bash
+# Install dependencies (from monorepo root)
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run examples dev server
+cd examples && pnpm install && pnpm dev
+```
+
+Copy `examples/.env.example` to `examples/.env` and fill in your values before running the dev server.
+
+Visit the [examples](./examples/README.md) directory for usage demos. See [ARCHITECTURE.md](./ARCHITECTURE.md) for internal structure and design patterns.
+
+## Publishing
+
+### Version Update
+
+```bash
+# Prerelease (for testing / EA)
+npm version prerelease --preid=dev   # 0.0.0-dev.1 → 0.0.0-dev.2
+
+# Patch / Minor / Major (stable)
+npm version patch                    # 0.0.1
+npm version minor                    # 0.1.0
+npm version major                    # 1.0.0
+```
+
+### Verify Before Publishing
+
+```bash
+pnpm build
+npm pack --dry-run
+npm publish --dry-run
+```
+
+### Publish
+
+```bash
+# EA / prerelease — tagged so npm install won't pick it up by default
+npm publish --tag dev
+
+# Stable release
+npm publish
+```
+
+> The `prepublishOnly` script runs `clean` and `build` automatically before every publish.
+
+## Documentation
+
+-   [ARCHITECTURE.md](./ARCHITECTURE.md) — Internal architecture, layer rules, and patterns
+-   [Examples](./examples/README.md) — Running the demo app
+
+## License
+
+Apache-2.0 — see the repository root [LICENSE.md](https://github.com/FlowiseAI/Flowise/blob/main/LICENSE.md) for details.
+
+---
+
+Part of the [Flowise](https://github.com/FlowiseAI/Flowise) ecosystem

--- a/packages/observe/TESTS.md
+++ b/packages/observe/TESTS.md
@@ -1,0 +1,85 @@
+# @flowiseai/observe — Testing Guide
+
+## Running Tests
+
+```bash
+pnpm test              # Fast run (no coverage)
+pnpm test:coverage     # With coverage enforcement
+pnpm test:watch        # Watch mode during development
+```
+
+## Test Strategy
+
+Tests are prioritized by impact. When modifying a file, add or update tests in the same PR.
+
+### Tier 1 — Core Logic (must test)
+
+Pure business logic in `infrastructure/` and critical hooks. These carry the highest risk — a bug here affects every consumer of the SDK. Always test in the same PR when modifying.
+
+**What belongs here:** API client methods, context/store, data-transformation hooks (`useExecutionTree`).
+
+### Tier 2 — Feature Hooks (test when changing)
+
+Feature-level hooks that orchestrate polling and UI state. Test when adding features or fixing bugs.
+
+**What belongs here:** `useExecutionPoll`, any future pagination or filter hooks.
+
+### Tier 3 — UI Components (test if logic exists)
+
+Presentational components that are mostly JSX. Only add tests if the component contains meaningful business logic. Pure layout/display components do not need tests.
+
+## Writing Tests
+
+### File Extension Convention
+
+The Jest config uses file extensions to select the test environment:
+
+| Extension   | Environment             | When to use                                                                |
+| ----------- | ----------------------- | -------------------------------------------------------------------------- |
+| `.test.ts`  | **node** (no DOM)       | Pure logic — utilities, API clients, data transformations                  |
+| `.test.tsx` | **jsdom** (browser DOM) | Anything that renders React — `renderHook` with providers, component tests |
+
+Source files use `.tsx` only when they contain JSX syntax. A hook that has no JSX stays `.ts` even if its test is `.test.tsx` (because the test uses `renderHook` with a JSX wrapper).
+
+### Mocking Patterns
+
+**Mocking axios:**
+
+```typescript
+import axios from 'axios'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+const mockGet = jest.fn()
+mockedAxios.create.mockReturnValue({ get: mockGet, post: jest.fn(), delete: jest.fn(), put: jest.fn() } as any)
+```
+
+**Mocking context hooks:**
+
+```typescript
+jest.mock('@/infrastructure/store', () => ({
+    useObserveApi: () => mockApiClient,
+    useObserveConfig: () => ({ pollInterval: 3000 })
+}))
+```
+
+### Module Mocks
+
+**Axios** (`src/__mocks__/axios.ts`): Prevents network errors by mocking all HTTP methods. Returns empty arrays/objects by default.
+
+**CSS/SVG** (`src/__mocks__/styleMock.js`): Empty object export for CSS and SVG imports.
+
+**Canvas** (`src/__mocks__/canvas.js`): Empty object export — also intercepted at the Node.js level by the custom jsdom environment (see below).
+
+### Custom Jest Environment
+
+`src/__test_utils__/jest-environment-jsdom.js` intercepts `require('canvas')` and returns a mock before jsdom tries to load the native binary. This prevents build failures in environments without native canvas compilation.
+
+## Configuration
+
+-   **Jest config**: `jest.config.js` — two projects: `unit` (node env, `.test.ts`) and `components` (custom jsdom env, `.test.tsx`)
+-   **Import aliases**: `@test-utils` maps to `src/__test_utils__`, `@/` maps to `src/`
+-   **Coverage thresholds**: 80% floor for `branches`, `functions`, `lines`, `statements` — see `coverageThreshold` in `jest.config.js` for per-path entries
+-   **Coverage exclusions**: `src/__test_utils__/**`, `src/__mocks__/**`, `src/**/index.ts`
+-   **Reports**: `coverage/lcov-report/index.html` for detailed HTML report

--- a/packages/observe/examples/.env.example
+++ b/packages/observe/examples/.env.example
@@ -1,0 +1,17 @@
+# Flowise Instance Configuration
+VITE_API_BASE_URL=http://localhost:3000
+
+# API Key (required for authenticated API endpoints)
+# Important: Use an API Key, NOT a user authentication token
+# Get this from: Flowise UI → Settings → API Keys → Create New Key
+VITE_API_TOKEN=
+
+# Agentflow ID (UUID) — scope the executions list to a single agentflow (optional)
+# When set: shows executions for that flow only (canvas-embedded use case)
+# When unset: shows all executions across every agentflow (global view)
+# Get this from: Flowise UI → your agentflow → the UUID in the URL or agentflow settings
+VITE_FLOW_ID=
+
+# Execution ID (UUID) — used for the standalone ExecutionDetail example
+# Get this from: any execution row in the Flowise executions view
+VITE_EXECUTION_ID=

--- a/packages/observe/examples/README.md
+++ b/packages/observe/examples/README.md
@@ -1,0 +1,74 @@
+# @flowiseai/observe — Examples
+
+A Vite + React dev app for exploring and testing `@flowiseai/observe` components against a live Flowise instance.
+
+## Setup
+
+**1. Copy the env file and fill in your values:**
+
+```bash
+cp .env.example .env
+```
+
+| Variable            | Description                                                                                                                                                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VITE_API_BASE_URL` | Base URL of your Flowise instance (default: `http://localhost:3000`)                                                                                                                                              |
+| `VITE_API_TOKEN`    | API key for authentication — get this from **Flowise UI → Settings → API Keys → Create New Key**. This is an API key, not a user session token.                                                                   |
+| `VITE_FLOW_ID`      | _(optional)_ UUID of an agentflow — scopes the Executions Viewer to that flow only. When unset, all executions across every agentflow are shown. Get it from the URL or settings of your agentflow in Flowise UI. |
+| `VITE_EXECUTION_ID` | UUID of a specific execution — used by the Standalone Detail demo. Get it from any execution row in the executions view.                                                                                          |
+
+**2. Install dependencies (from this directory):**
+
+```bash
+pnpm install
+```
+
+**3. Start the dev server:**
+
+```bash
+pnpm dev
+```
+
+The app opens at `http://localhost:5174` (or the next available port).
+
+---
+
+## Demos
+
+### Executions Viewer (`ExecutionsViewerExample`)
+
+Route: `/` (default tab)
+
+Renders `<ExecutionsViewer />` with optional scoping via `VITE_FLOW_ID`. When `VITE_FLOW_ID` is set, the viewer is scoped to that agentflow; when unset, all executions across every agentflow are shown.
+
+Features exercised:
+
+-   Execution list with state and session ID filters
+-   Pagination
+-   Clicking a row opens `ExecutionDetail` in a side drawer
+-   Single-row delete (`allowDelete={true}`)
+-   Auto-poll while a run is INPROGRESS
+-   HITL Approve/Reject buttons (logs to console — no real prediction call)
+
+### Standalone Detail (`StandaloneDetailExample`)
+
+Route: `/detail` (second tab)
+
+Renders `<ExecutionDetail executionId="..." />` given an execution UUID. Useful for testing the step viewer in isolation or deep-linking into a known trace.
+
+The execution ID can be pre-filled via `VITE_EXECUTION_ID` or pasted into the text field at runtime.
+
+Features exercised:
+
+-   Resizable split-pane layout
+-   Node tree sidebar with iteration grouping
+-   `NodeExecutionDetail` — all renderers (markdown, JSON, raw/rendered toggle)
+-   Token / cost / time metrics per node
+-   Auto-poll while INPROGRESS
+
+---
+
+## Notes
+
+-   The examples import `@flowiseai/observe` directly from `packages/observe/src/` via Vite path aliases — no build step required. Source changes are reflected immediately via HMR.
+-   HITL callbacks in these demos log to the browser console instead of making real prediction calls. To test end-to-end HITL, replace the `onHumanInput` handler with a real fetch to your Flowise prediction endpoint.

--- a/packages/observe/examples/README.md
+++ b/packages/observe/examples/README.md
@@ -10,12 +10,12 @@ A Vite + React dev app for exploring and testing `@flowiseai/observe` components
 cp .env.example .env
 ```
 
-| Variable            | Description                                                                                                                                                                                                       |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `VITE_API_BASE_URL` | Base URL of your Flowise instance (default: `http://localhost:3000`)                                                                                                                                              |
-| `VITE_API_TOKEN`    | API key for authentication — get this from **Flowise UI → Settings → API Keys → Create New Key**. This is an API key, not a user session token.                                                                   |
-| `VITE_FLOW_ID`      | _(optional)_ UUID of an agentflow — scopes the Executions Viewer to that flow only. When unset, all executions across every agentflow are shown. Get it from the URL or settings of your agentflow in Flowise UI. |
-| `VITE_EXECUTION_ID` | UUID of a specific execution — used by the Standalone Detail demo. Get it from any execution row in the executions view.                                                                                          |
+| Variable            | Description                                                                                                                                                                                                                                                    |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VITE_API_BASE_URL` | Base URL of your Flowise instance (default: `http://localhost:3000`)                                                                                                                                                                                           |
+| `VITE_API_TOKEN`    | API key for authentication — get this from **Flowise UI → Settings → API Keys → Create New Key**. This is an API key, not a user session token. Ensure the key has the necessary permissions for any features you want to exercise (e.g. deleting executions). |
+| `VITE_FLOW_ID`      | _(optional)_ UUID of an agentflow — scopes the Executions Viewer to that flow only. When unset, all executions across every agentflow are shown. Get it from the URL or settings of your agentflow in Flowise UI.                                              |
+| `VITE_EXECUTION_ID` | UUID of a specific execution — used by the Standalone Detail demo. Get it from any execution row in the executions view.                                                                                                                                       |
 
 **2. Install dependencies (from this directory):**
 

--- a/packages/observe/examples/index.html
+++ b/packages/observe/examples/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>@flowiseai/observe — Examples</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/packages/observe/examples/package-lock.json
+++ b/packages/observe/examples/package-lock.json
@@ -1,0 +1,2365 @@
+{
+    "name": "observe-basic-example",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "observe-basic-example",
+            "version": "0.0.0",
+            "dependencies": {
+                "@emotion/react": "^11.10.0",
+                "@emotion/styled": "^11.10.0",
+                "@mui/icons-material": "^5.15.0",
+                "@mui/material": "^5.15.0",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            },
+            "devDependencies": {
+                "@types/react": "^18.2.0",
+                "@types/react-dom": "^18.2.0",
+                "@vitejs/plugin-react": "^4.0.0",
+                "typescript": "^5.0.0",
+                "vite": "8.0.9"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.29.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/compat-data/-/compat-data-7.29.0.tgz",
+            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.29.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/core/-/core-7.29.0.tgz",
+            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helpers": "^7.28.6",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.29.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/generator/-/generator-7.29.1.tgz",
+            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.28.6",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.28.6",
+                "@babel/helper-validator-option": "^7.27.1",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.28.6",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.28.6",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.28.6",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.28.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.27.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.29.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.0"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-jsx-self": {
+            "version": "7.27.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+            "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-jsx-source": {
+            "version": "7.27.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+            "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.28.6",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/template/-/template-7.28.6.tgz",
+            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.29.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/traverse/-/traverse-7.29.0.tgz",
+            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.9.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emnapi/core/-/core-1.9.2.tgz",
+            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emotion/babel-plugin": {
+            "version": "11.13.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+            "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/runtime": "^7.18.3",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/serialize": "^1.3.3",
+                "babel-plugin-macros": "^3.1.0",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.2.0"
+            }
+        },
+        "node_modules/@emotion/cache": {
+            "version": "11.14.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/cache/-/cache-11.14.0.tgz",
+            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "stylis": "4.2.0"
+            }
+        },
+        "node_modules/@emotion/hash": {
+            "version": "0.9.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.4.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/memoize": "^0.9.0"
+            }
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/react": {
+            "version": "11.14.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/react/-/react-11.14.0.tgz",
+            "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.13.5",
+                "@emotion/cache": "^11.14.0",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "hoist-non-react-statics": "^3.3.1"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/serialize": {
+            "version": "1.3.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@emotion/sheet": {
+            "version": "1.4.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/styled": {
+            "version": "11.14.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/styled/-/styled-11.14.1.tgz",
+            "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.18.3",
+                "@emotion/babel-plugin": "^11.13.5",
+                "@emotion/is-prop-valid": "^1.3.0",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+                "@emotion/utils": "^1.4.2"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.0.0-rc.0",
+                "react": ">=16.8.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+            "version": "1.2.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+            "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@emotion/utils": {
+            "version": "1.4.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/weak-memoize": {
+            "version": "0.4.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@mui/core-downloads-tracker": {
+            "version": "5.18.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
+            "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            }
+        },
+        "node_modules/@mui/icons-material": {
+            "version": "5.18.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@mui/icons-material/-/icons-material-5.18.0.tgz",
+            "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.9"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@mui/material": "^5.0.0",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/material": {
+            "version": "5.18.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@mui/material/-/material-5.18.0.tgz",
+            "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.9",
+                "@mui/core-downloads-tracker": "^5.18.0",
+                "@mui/system": "^5.18.0",
+                "@mui/types": "~7.2.15",
+                "@mui/utils": "^5.17.1",
+                "@popperjs/core": "^2.11.8",
+                "@types/react-transition-group": "^4.4.10",
+                "clsx": "^2.1.0",
+                "csstype": "^3.1.3",
+                "prop-types": "^15.8.1",
+                "react-is": "^19.0.0",
+                "react-transition-group": "^4.4.5"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/private-theming": {
+            "version": "5.17.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@mui/private-theming/-/private-theming-5.17.1.tgz",
+            "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.9",
+                "@mui/utils": "^5.17.1",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/styled-engine": {
+            "version": "5.18.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
+            "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.9",
+                "@emotion/cache": "^11.13.5",
+                "@emotion/serialize": "^1.3.3",
+                "csstype": "^3.1.3",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.4.1",
+                "@emotion/styled": "^11.3.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/system": {
+            "version": "5.18.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@mui/system/-/system-5.18.0.tgz",
+            "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.9",
+                "@mui/private-theming": "^5.17.1",
+                "@mui/styled-engine": "^5.18.0",
+                "@mui/types": "~7.2.15",
+                "@mui/utils": "^5.17.1",
+                "clsx": "^2.1.0",
+                "csstype": "^3.1.3",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.5.0",
+                "@emotion/styled": "^11.3.0",
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/react": {
+                    "optional": true
+                },
+                "@emotion/styled": {
+                    "optional": true
+                },
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/types": {
+            "version": "7.2.24",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@mui/types/-/types-7.2.24.tgz",
+            "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/utils": {
+            "version": "5.17.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@mui/utils/-/utils-5.17.1.tgz",
+            "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.9",
+                "@mui/types": "~7.2.15",
+                "@types/prop-types": "^15.7.12",
+                "clsx": "^2.1.1",
+                "prop-types": "^15.8.1",
+                "react-is": "^19.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.126.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@oxc-project/types/-/types-0.126.0.tgz",
+            "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+            "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+            "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+            "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+            "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+            "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+            "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+            "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+            "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+            "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.9.2",
+                "@emnapi/runtime": "1.9.2",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+            "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+            "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.27",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/babel__core": {
+            "version": "7.20.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.27.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.4",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.28.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.2"
+            }
+        },
+        "node_modules/@types/parse-json": {
+            "version": "4.0.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "18.3.28",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/react/-/react-18.3.28.tgz",
+            "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "18.3.7",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/react-dom/-/react-dom-18.3.7.tgz",
+            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^18.0.0"
+            }
+        },
+        "node_modules/@types/react-transition-group": {
+            "version": "4.4.12",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+            "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*"
+            }
+        },
+        "node_modules/@vitejs/plugin-react": {
+            "version": "4.7.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+            "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.28.0",
+                "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+                "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+                "@rolldown/pluginutils": "1.0.0-beta.27",
+                "@types/babel__core": "^7.20.5",
+                "react-refresh": "^0.17.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+            }
+        },
+        "node_modules/babel-plugin-macros": {
+            "version": "3.1.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            },
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.20",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+            "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.28.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/browserslist/-/browserslist-4.28.2.tgz",
+            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.10.12",
+                "caniuse-lite": "^1.0.30001782",
+                "electron-to-chromium": "^1.5.328",
+                "node-releases": "^2.0.36",
+                "update-browserslist-db": "^1.2.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001788",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+            "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "license": "MIT"
+        },
+        "node_modules/cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cosmiconfig/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "license": "MIT"
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dom-helpers": {
+            "version": "5.2.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/dom-helpers/-/dom-helpers-5.2.1.tgz",
+            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.340",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+            "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "license": "MIT"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "react-is": "^16.7.0"
+            }
+        },
+        "node_modules/hoist-non-react-statics/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "license": "MIT"
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "license": "MIT"
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "license": "MIT"
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.37",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/node-releases/-/node-releases-2.0.37.tgz",
+            "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT"
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.10",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/postcss/-/postcss-8.5.10.tgz",
+            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
+        "node_modules/prop-types/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
+        },
+        "node_modules/react": {
+            "version": "18.3.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "18.3.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.2"
+            },
+            "peerDependencies": {
+                "react": "^18.3.1"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "19.2.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/react-is/-/react-is-19.2.5.tgz",
+            "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+            "license": "MIT"
+        },
+        "node_modules/react-refresh": {
+            "version": "0.17.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/react-refresh/-/react-refresh-0.17.0.tgz",
+            "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-transition-group": {
+            "version": "4.4.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/react-transition-group/-/react-transition-group-4.4.5.tgz",
+            "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "dom-helpers": "^5.0.1",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.6.0",
+                "react-dom": ">=16.6.0"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+            "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.126.0",
+                "@rolldown/pluginutils": "1.0.0-rc.16"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+            }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+            "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stylis": {
+            "version": "4.2.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/stylis/-/stylis-4.2.0.tgz",
+            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+            "license": "MIT"
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.16",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/vite": {
+            "version": "8.0.9",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/vite/-/vite-8.0.9.tgz",
+            "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.10",
+                "rolldown": "1.0.0-rc.16",
+                "tinyglobby": "^0.2.16"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.8.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        }
+    }
+}

--- a/packages/observe/examples/package.json
+++ b/packages/observe/examples/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "observe-basic-example",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview"
+    },
+    "dependencies": {
+        "@emotion/react": "^11.10.0",
+        "@emotion/styled": "^11.10.0",
+        "@mui/icons-material": "^5.15.0",
+        "@mui/material": "^5.15.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    },
+    "devDependencies": {
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "@vitejs/plugin-react": "^4.0.0",
+        "typescript": "^5.0.0",
+        "vite": "8.0.9"
+    }
+}

--- a/packages/observe/examples/src/App.tsx
+++ b/packages/observe/examples/src/App.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+
+import { ObserveProvider } from '@flowiseai/observe'
+import { Box, CssBaseline, Tab, Tabs, Typography } from '@mui/material'
+
+import ExecutionsViewerExample from './demos/ExecutionsViewerExample'
+import StandaloneDetailExample from './demos/StandaloneDetailExample'
+import { apiBaseUrl, token } from './config'
+
+import '@flowiseai/observe/observe.css'
+
+export default function App() {
+    const [tab, setTab] = useState(0)
+
+    return (
+        <ObserveProvider apiBaseUrl={apiBaseUrl} token={token}>
+            <CssBaseline />
+            <Box sx={{ p: 3 }}>
+                <Typography variant='h4' sx={{ mb: 2, fontWeight: 700 }}>
+                    @flowiseai/observe — Examples
+                </Typography>
+                <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}>
+                    <Tab label='Executions Viewer' />
+                    <Tab label='Standalone ExecutionDetail' />
+                </Tabs>
+                {tab === 0 && <ExecutionsViewerExample />}
+                {tab === 1 && <StandaloneDetailExample />}
+            </Box>
+        </ObserveProvider>
+    )
+}

--- a/packages/observe/examples/src/config.ts
+++ b/packages/observe/examples/src/config.ts
@@ -1,0 +1,4 @@
+export const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'
+export const token = import.meta.env.VITE_API_TOKEN || undefined
+export const flowId = import.meta.env.VITE_FLOW_ID || undefined
+export const executionId = import.meta.env.VITE_EXECUTION_ID || undefined

--- a/packages/observe/examples/src/demos/ExecutionsViewerExample.tsx
+++ b/packages/observe/examples/src/demos/ExecutionsViewerExample.tsx
@@ -1,0 +1,35 @@
+import { ExecutionsViewer, HumanInputParams } from '@flowiseai/observe'
+import { Box, Typography } from '@mui/material'
+
+import { flowId } from '../config'
+
+export default function ExecutionsViewerExample() {
+    return (
+        <Box>
+            <Typography variant='body2' color='text.secondary' sx={{ mb: 2 }}>
+                {flowId ? (
+                    <>
+                        Scoped to agentflow: <code>{flowId}</code>
+                    </>
+                ) : (
+                    <>
+                        Showing all executions — set <code>VITE_FLOW_ID</code> to scope to a single agentflow
+                    </>
+                )}
+            </Typography>
+            <Box sx={{ height: 600, border: '1px solid', borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
+                <ExecutionsViewer
+                    agentflowId={flowId}
+                    allowDelete={true}
+                    pollInterval={3000}
+                    onHumanInput={async (agentflowId: string, params: HumanInputParams) => {
+                        console.info('[Example] onHumanInput', agentflowId, params)
+                    }}
+                    onAgentflowClick={(agentflowId: string) => {
+                        console.info('[Example] onAgentflowClick', agentflowId)
+                    }}
+                />
+            </Box>
+        </Box>
+    )
+}

--- a/packages/observe/examples/src/demos/StandaloneDetailExample.tsx
+++ b/packages/observe/examples/src/demos/StandaloneDetailExample.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+
+import { ExecutionDetail } from '@flowiseai/observe'
+import { Box, TextField, Typography } from '@mui/material'
+
+import { executionId as defaultExecutionId } from '../config'
+
+export default function StandaloneDetailExample() {
+    const [executionId, setExecutionId] = useState(defaultExecutionId ?? '')
+
+    return (
+        <Box>
+            <TextField
+                size='small'
+                label='Execution ID'
+                value={executionId}
+                onChange={(e) => setExecutionId(e.target.value)}
+                sx={{ mb: 2, width: 380 }}
+                placeholder='Paste an execution UUID…'
+            />
+            {executionId ? (
+                <Box sx={{ height: 600, border: '1px solid', borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
+                    <ExecutionDetail
+                        executionId={executionId}
+                        pollInterval={3000}
+                        onAgentflowClick={(agentflowId: string) => {
+                            console.info('[Example] onAgentflowClick', agentflowId)
+                        }}
+                    />
+                </Box>
+            ) : (
+                <Typography variant='body2' color='text.secondary'>
+                    Enter an execution ID above to view its trace.
+                </Typography>
+            )}
+        </Box>
+    )
+}

--- a/packages/observe/examples/src/main.tsx
+++ b/packages/observe/examples/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>
+)

--- a/packages/observe/examples/src/vite-env.d.ts
+++ b/packages/observe/examples/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_API_BASE_URL: string
+    readonly VITE_API_TOKEN: string
+    readonly VITE_FLOW_ID: string
+    readonly VITE_EXECUTION_ID: string
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv
+}

--- a/packages/observe/examples/tsconfig.json
+++ b/packages/observe/examples/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "useDefineForClassFields": true,
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx",
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
+        "paths": {
+            "@flowiseai/observe": ["../src/index.ts"],
+            "@flowiseai/observe/*": ["../src/*"]
+        }
+    },
+    "include": ["src", "*.tsx", "*.ts", "../src/**/*.ts", "../src/**/*.tsx"]
+}

--- a/packages/observe/examples/vite.config.ts
+++ b/packages/observe/examples/vite.config.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'path'
+
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+    plugins: [react()],
+    resolve: {
+        alias: {
+            '@flowiseai/observe/observe.css': resolve(__dirname, '../src/observe.css'),
+            '@flowiseai/observe': resolve(__dirname, '../src/index.ts'),
+            '@': resolve(__dirname, '../src')
+        }
+    },
+    root: resolve(__dirname),
+    build: {
+        outDir: resolve(__dirname, 'dist')
+    }
+})

--- a/packages/observe/jest.config.js
+++ b/packages/observe/jest.config.js
@@ -1,0 +1,57 @@
+const baseConfig = {
+    preset: 'ts-jest',
+    roots: ['<rootDir>/src'],
+    transform: {
+        '^.+\\.tsx?$': [
+            'ts-jest',
+            {
+                tsconfig: 'tsconfig.json'
+            }
+        ]
+    },
+    testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+    moduleNameMapper: {
+        '\\.(css|less|scss|sass)$': '<rootDir>/src/__mocks__/styleMock.js',
+        '\\.svg$': '<rootDir>/src/__mocks__/styleMock.js',
+        '^canvas$': '<rootDir>/src/__mocks__/canvas.js',
+        '^@/(.*)$': '<rootDir>/src/$1',
+        '^@test-utils/(.*)$': '<rootDir>/src/__test_utils__/$1'
+    }
+}
+
+module.exports = {
+    verbose: true,
+    collectCoverageFrom: [
+        'src/**/*.{ts,tsx}',
+        '!src/**/*.test.{ts,tsx}',
+        '!src/**/*.d.ts',
+        '!src/**/index.ts',
+        '!src/__mocks__/**',
+        '!src/__test_utils__/**'
+    ],
+    coverageReporters: ['text', 'text-summary', 'lcov'],
+    coverageDirectory: 'coverage',
+    coverageThreshold: {
+        './src/features/executions/hooks/': { branches: 80, functions: 80, lines: 80, statements: 80 },
+        './src/infrastructure/api/executions.ts': { branches: 80, functions: 80, lines: 80, statements: 80 },
+        './src/infrastructure/store/ObserveContext.tsx': { branches: 80, functions: 80, lines: 80, statements: 80 }
+    },
+    projects: [
+        {
+            ...baseConfig,
+            displayName: 'unit',
+            testEnvironment: 'node',
+            testMatch: ['<rootDir>/src/**/*.test.ts']
+        },
+        {
+            ...baseConfig,
+            displayName: 'components',
+            testEnvironment: '<rootDir>/src/__test_utils__/jest-environment-jsdom.js',
+            testEnvironmentOptions: {
+                customExportConditions: ['']
+            },
+            testMatch: ['<rootDir>/src/**/*.test.tsx'],
+            setupFilesAfterEnv: ['@testing-library/jest-dom']
+        }
+    ]
+}

--- a/packages/observe/package.json
+++ b/packages/observe/package.json
@@ -1,0 +1,103 @@
+{
+    "name": "@flowiseai/observe",
+    "version": "0.0.0-dev.1",
+    "description": "Embeddable React components for observing AI agent executions, evaluations, and runtime activity",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/FlowiseAI/Flowise.git",
+        "directory": "packages/observe"
+    },
+    "homepage": "https://github.com/FlowiseAI/Flowise/tree/main/packages/observe#readme",
+    "bugs": {
+        "url": "https://github.com/FlowiseAI/Flowise/issues"
+    },
+    "keywords": [
+        "flowise",
+        "flowiseai",
+        "observe",
+        "executions",
+        "observability",
+        "react",
+        "llm",
+        "ai",
+        "agent"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org"
+    },
+    "main": "./dist/index.umd.js",
+    "module": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/index.js",
+            "require": "./dist/index.umd.js",
+            "types": "./dist/index.d.ts"
+        },
+        "./observe.css": "./dist/observe.css"
+    },
+    "files": [
+        "dist"
+    ],
+    "sideEffects": [
+        "dist/**/*.css"
+    ],
+    "scripts": {
+        "build": "tsc && vite build",
+        "clean": "rimraf dist",
+        "dev": "vite",
+        "dev:example": "vite --config examples/vite.config.ts",
+        "format": "prettier --write \"{src,examples}/**/*.{ts,tsx,js,jsx,json,css,md}\"",
+        "format:check": "prettier --check \"{src,examples}/**/*.{ts,tsx,js,jsx,json,css,md}\"",
+        "lint": "eslint \"{src,examples}/**/*.{js,jsx,ts,tsx,json,md}\" \"*.md\"",
+        "lint:fix": "eslint \"{src,examples}/**/*.{js,jsx,ts,tsx,json,md}\" \"*.md\" --fix",
+        "nuke": "pnpm clean && rimraf node_modules .turbo",
+        "prepublishOnly": "npm run clean && npm run build",
+        "test": "jest",
+        "test:coverage": "jest --coverage",
+        "test:watch": "jest --watch"
+    },
+    "peerDependencies": {
+        "@emotion/react": "^11.10.0",
+        "@emotion/styled": "^11.10.0",
+        "@mui/icons-material": "^5.0.0",
+        "@mui/material": "^5.15.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    },
+    "dependencies": {
+        "@tabler/icons-react": "^3.7.0",
+        "axios": "^1.7.2",
+        "date-fns": "^3.6.0",
+        "flowise-react-json-view": "^1.21.7",
+        "lodash": "^4.17.21",
+        "react-markdown": "^9.0.1",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.0"
+    },
+    "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^14.3.1",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/jest": "^29.5.14",
+        "@types/lodash": "^4.14.195",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "@typescript-eslint/eslint-plugin": "^8.18.2",
+        "@typescript-eslint/parser": "^8.18.2",
+        "@vitejs/plugin-react": "^4.2.0",
+        "eslint-import-resolver-typescript": "4.4.4",
+        "eslint-plugin-import": "^2.29.0",
+        "eslint-plugin-markdown": "^3.0.1",
+        "eslint-plugin-simple-import-sort": "^12.0.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.3.2",
+        "typescript": "^5.4.5",
+        "vite": "^5.0.2",
+        "vite-plugin-dts": "^3.7.0"
+    }
+}

--- a/packages/observe/src/__mocks__/axios.ts
+++ b/packages/observe/src/__mocks__/axios.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAxios: any = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() }
+    },
+    defaults: { headers: { common: {} } }
+}
+mockAxios.create = jest.fn(() => mockAxios)
+
+export default mockAxios

--- a/packages/observe/src/__mocks__/canvas.js
+++ b/packages/observe/src/__mocks__/canvas.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/observe/src/__mocks__/styleMock.js
+++ b/packages/observe/src/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/observe/src/__test_utils__/jest-environment-jsdom.js
+++ b/packages/observe/src/__test_utils__/jest-environment-jsdom.js
@@ -1,0 +1,50 @@
+/**
+ * Custom Jest environment for jsdom tests
+ *
+ * Prevents canvas native module from being loaded during test initialization.
+ * The canvas package requires native compilation which often fails in CI/CD
+ * environments. Since canvas is only optionally used by jsdom and not needed
+ * for our React component tests, we mock it at the module require level.
+ *
+ * Note: This file must be CommonJS (require) because Jest environments
+ * do not support ESM.
+ */
+
+const JSDOMEnvironment = require('jest-environment-jsdom').default
+
+// Mock canvas before jsdom tries to load it.
+// NOTE: This overrides Module.prototype.require globally for the entire test process.
+// Any module requiring 'canvas' (not just jsdom) will receive this mock.
+// This is acceptable because canvas is only an optional jsdom dependency and
+// is not used by any application code under test.
+const Module = require('module')
+
+const originalRequire = Module.prototype.require
+
+Module.prototype.require = function (id) {
+    if (id === 'canvas') {
+        return {
+            createCanvas: () => ({
+                getContext: () => ({}),
+                toBuffer: () => Buffer.from(''),
+                toDataURL: () => ''
+            }),
+            createImageData: () => ({ data: [] }),
+            loadImage: () => Promise.resolve({}),
+            Image: class Image {
+                constructor() {
+                    this.src = ''
+                    this.width = 0
+                    this.height = 0
+                    this.onload = null
+                    this.onerror = null
+                    this.naturalWidth = 0
+                    this.naturalHeight = 0
+                }
+            }
+        }
+    }
+    return originalRequire.apply(this, arguments)
+}
+
+module.exports = JSDOMEnvironment

--- a/packages/observe/src/atoms/MetricsDisplay.tsx
+++ b/packages/observe/src/atoms/MetricsDisplay.tsx
@@ -1,0 +1,49 @@
+import { Stack, Tooltip, Typography } from '@mui/material'
+import { IconClock, IconCoins, IconCpu } from '@tabler/icons-react'
+
+import type { NodeExecutionOutput } from '@/core/types'
+
+interface MetricsDisplayProps {
+    output?: NodeExecutionOutput
+}
+
+/**
+ * Displays time, token, and cost metrics for a node execution.
+ * Renders nothing if no metrics are available.
+ */
+export function MetricsDisplay({ output }: MetricsDisplayProps) {
+    const delta = output?.timeMetadata?.delta
+    const tokens = output?.usageMetadata?.total_tokens
+    const cost = output?.usageMetadata?.total_cost
+
+    if (delta == null && tokens == null && cost == null) return null
+
+    return (
+        <Stack direction='row' spacing={2} alignItems='center' sx={{ mt: 1 }}>
+            {delta != null && (
+                <Tooltip title='Execution time'>
+                    <Stack direction='row' spacing={0.5} alignItems='center'>
+                        <IconClock size={14} />
+                        <Typography variant='caption'>{(delta / 1000).toFixed(2)}s</Typography>
+                    </Stack>
+                </Tooltip>
+            )}
+            {tokens != null && (
+                <Tooltip title='Total tokens'>
+                    <Stack direction='row' spacing={0.5} alignItems='center'>
+                        <IconCpu size={14} />
+                        <Typography variant='caption'>{tokens.toLocaleString()}</Typography>
+                    </Stack>
+                </Tooltip>
+            )}
+            {cost != null && cost > 0 && (
+                <Tooltip title='Estimated cost (USD)'>
+                    <Stack direction='row' spacing={0.5} alignItems='center'>
+                        <IconCoins size={14} />
+                        <Typography variant='caption'>${cost.toFixed(6)}</Typography>
+                    </Stack>
+                </Tooltip>
+            )}
+        </Stack>
+    )
+}

--- a/packages/observe/src/atoms/StatusIndicator.tsx
+++ b/packages/observe/src/atoms/StatusIndicator.tsx
@@ -1,0 +1,34 @@
+import { useTheme } from '@mui/material/styles'
+import { IconAlertCircle, IconCheck, IconLoader2, IconPlayerStop, IconUserQuestion, IconX } from '@tabler/icons-react'
+
+import type { ExecutionState } from '@/core/types'
+
+interface StatusIndicatorProps {
+    state: ExecutionState
+    size?: number
+}
+
+/**
+ * Color-coded icon for an execution or node state.
+ * Used in both the list table and the execution tree view.
+ */
+export function StatusIndicator({ state, size = 16 }: StatusIndicatorProps) {
+    const theme = useTheme()
+
+    switch (state) {
+        case 'FINISHED':
+            return <IconCheck size={size} color={theme.palette.success.main} />
+        case 'ERROR':
+            return <IconAlertCircle size={size} color={theme.palette.error.main} />
+        case 'TERMINATED':
+            return <IconX size={size} color={theme.palette.error.main} />
+        case 'STOPPED':
+            return <IconPlayerStop size={size} color={theme.palette.error.main} />
+        case 'TIMEOUT':
+            return <IconAlertCircle size={size} color={theme.palette.warning.main} />
+        case 'INPROGRESS':
+            return <IconLoader2 size={size} color={theme.palette.warning.dark} style={{ animation: 'spin 1s linear infinite' }} />
+        default:
+            return <IconUserQuestion size={size} color={theme.palette.text.secondary} />
+    }
+}

--- a/packages/observe/src/atoms/index.ts
+++ b/packages/observe/src/atoms/index.ts
@@ -1,0 +1,2 @@
+export { MetricsDisplay } from './MetricsDisplay'
+export { StatusIndicator } from './StatusIndicator'

--- a/packages/observe/src/core/theme/createObserveTheme.ts
+++ b/packages/observe/src/core/theme/createObserveTheme.ts
@@ -1,0 +1,43 @@
+import { createTheme, type Theme } from '@mui/material/styles'
+
+import { tokens } from './tokens'
+
+export function createObserveTheme(isDarkMode: boolean): Theme {
+    const mode = isDarkMode ? 'dark' : 'light'
+
+    return createTheme({
+        palette: {
+            mode,
+            primary: tokens.colors.palette.primary,
+            secondary: tokens.colors.palette.secondary,
+            success: tokens.colors.palette.success,
+            error: tokens.colors.palette.error,
+            warning: tokens.colors.palette.warning,
+            background: {
+                default: tokens.colors.background.canvas[mode],
+                paper: tokens.colors.background.card[mode]
+            },
+            divider: tokens.colors.border.default[mode],
+            text: {
+                primary: tokens.colors.text.primary[mode],
+                secondary: tokens.colors.text.secondary[mode]
+            }
+        },
+        typography: {
+            h4: { fontSize: '1rem', fontWeight: 600 },
+            h5: { fontSize: '0.875rem', fontWeight: 600 },
+            h6: { fontSize: '0.75rem', fontWeight: 500 },
+            subtitle1: { fontSize: '0.875rem', fontWeight: 500 },
+            body1: { fontSize: '0.875rem', fontWeight: 400 },
+            body2: { fontSize: '0.75rem', fontWeight: 400 }
+        },
+        components: {
+            MuiPaper: {
+                defaultProps: { elevation: 0 },
+                styleOverrides: { root: { backgroundImage: 'none' } }
+            }
+        },
+        spacing: 8,
+        shape: { borderRadius: tokens.borderRadius.md }
+    })
+}

--- a/packages/observe/src/core/theme/index.ts
+++ b/packages/observe/src/core/theme/index.ts
@@ -1,0 +1,3 @@
+export { createObserveTheme } from './createObserveTheme'
+export type { Tokens } from './tokens'
+export { tokens } from './tokens'

--- a/packages/observe/src/core/theme/tokens.ts
+++ b/packages/observe/src/core/theme/tokens.ts
@@ -1,0 +1,127 @@
+/**
+ * Design Tokens for @flowiseai/observe
+ * Shared with @flowiseai/agentflow — kept in sync manually until a @flowiseai/core package is introduced.
+ */
+
+const baseColors = {
+    white: '#fff',
+    black: '#000',
+    gray50: '#fafafa',
+    gray75: '#f5f5f5',
+    gray100: '#f8f9fa',
+    gray200: '#e2e2e2',
+    gray300: '#e0e0e0',
+    gray400: '#bdbdbd',
+    gray500: '#9e9e9e',
+    gray600: '#757575',
+    gray700: '#666',
+    gray800: '#333',
+    darkGray100: '#1a1a1a',
+    darkGray200: '#1a1a2e',
+    darkGray300: '#252525',
+    darkGray400: '#2d2d2d',
+    darkGray500: '#404040',
+    darkGray600: '#525252',
+    darkGray700: '#555',
+    darkGray800: '#aaa',
+    success: '#4caf50',
+    error: '#f44336',
+    warning: '#ff9800',
+    warningBg: '#fefcbf',
+    warningText: '#744210',
+    info: '#2196f3',
+    primaryLight: '#e3f2fd',
+    primaryMain: '#2196f3',
+    primaryDark: '#1e88e5',
+    secondaryLight: '#ede7f6',
+    secondaryMain: '#673ab7',
+    secondaryDark: '#5e35b1',
+    successLight: '#cdf5d8',
+    successMain: '#00e676',
+    successDark: '#00c853',
+    errorLight: '#f3d2d2',
+    errorMain: '#f44336',
+    errorDark: '#c62828',
+    warningLight: '#fff8e1',
+    warningMain: '#ffe57f',
+    warningDark: '#ffc107',
+    // Node type colors — used in execution tree status indicators
+    nodeCondition: '#FFB938',
+    nodeStart: '#7EE787',
+    nodeLlm: '#64B5F6',
+    nodeAgent: '#4DD0E1',
+    nodeHumanInput: '#6E6EFD',
+    nodeLoop: '#FFA07A',
+    nodeDirectReply: '#4DDBBB',
+    nodeCustomFunction: '#E4B7FF',
+    nodeTool: '#d4a373',
+    nodeRetriever: '#b8bedd',
+    nodeConditionAgent: '#ff8fab',
+    nodeStickyNote: '#fee440',
+    nodeHttp: '#FF7F7F',
+    nodeIteration: '#9C89B8',
+    nodeExecuteFlow: '#a3b18a'
+} as const
+
+export const tokens = {
+    colors: {
+        nodes: {
+            condition: baseColors.nodeCondition,
+            start: baseColors.nodeStart,
+            llm: baseColors.nodeLlm,
+            agent: baseColors.nodeAgent,
+            humanInput: baseColors.nodeHumanInput,
+            loop: baseColors.nodeLoop,
+            directReply: baseColors.nodeDirectReply,
+            customFunction: baseColors.nodeCustomFunction,
+            tool: baseColors.nodeTool,
+            retriever: baseColors.nodeRetriever,
+            conditionAgent: baseColors.nodeConditionAgent,
+            stickyNote: baseColors.nodeStickyNote,
+            http: baseColors.nodeHttp,
+            iteration: baseColors.nodeIteration,
+            executeFlow: baseColors.nodeExecuteFlow
+        },
+        background: {
+            canvas: { light: baseColors.gray100, dark: baseColors.darkGray100 },
+            card: { light: baseColors.white, dark: baseColors.darkGray400 },
+            cardHover: { light: baseColors.gray75, dark: baseColors.darkGray500 },
+            sidebar: { light: baseColors.gray50, dark: baseColors.darkGray300 }
+        },
+        border: {
+            default: { light: baseColors.gray300, dark: baseColors.darkGray500 },
+            hover: { light: baseColors.gray400, dark: baseColors.darkGray600 }
+        },
+        text: {
+            primary: { light: baseColors.gray800, dark: baseColors.white },
+            secondary: { light: baseColors.gray700, dark: baseColors.gray500 },
+            tertiary: { light: baseColors.gray600, dark: baseColors.gray500 }
+        },
+        palette: {
+            primary: { light: baseColors.primaryLight, main: baseColors.primaryMain, dark: baseColors.primaryDark },
+            secondary: { light: baseColors.secondaryLight, main: baseColors.secondaryMain, dark: baseColors.secondaryDark },
+            success: { light: baseColors.successLight, main: baseColors.successMain, dark: baseColors.successDark },
+            error: { light: baseColors.errorLight, main: baseColors.errorMain, dark: baseColors.errorDark },
+            warning: { light: baseColors.warningLight, main: baseColors.warningMain, dark: baseColors.warningDark }
+        },
+        semantic: {
+            success: baseColors.success,
+            error: baseColors.error,
+            warning: baseColors.warning,
+            warningBg: baseColors.warningBg,
+            warningText: baseColors.warningText,
+            info: baseColors.info
+        }
+    },
+    spacing: { xs: 4, sm: 8, md: 12, lg: 16, xl: 20, xxl: 24 },
+    shadows: {
+        card: '0 2px 8px rgba(0, 0, 0, 0.1)',
+        toolbar: {
+            light: '0 2px 14px 0 rgb(32 40 45 / 8%)',
+            dark: '0 2px 14px 0 rgb(0 0 0 / 20%)'
+        }
+    },
+    borderRadius: { sm: 4, md: 8, lg: 12, round: '50%' }
+} as const
+
+export type Tokens = typeof tokens

--- a/packages/observe/src/core/types/execution.ts
+++ b/packages/observe/src/core/types/execution.ts
@@ -1,0 +1,121 @@
+// ============================================================================
+// Execution Domain Types
+// ============================================================================
+
+export type ExecutionState = 'INPROGRESS' | 'FINISHED' | 'ERROR' | 'TERMINATED' | 'TIMEOUT' | 'STOPPED'
+
+// ============================================================================
+// Execution Record (from API)
+// ============================================================================
+
+export interface AgentflowRef {
+    id: string
+    name: string
+}
+
+export interface Execution {
+    id: string
+    /** JSON-stringified NodeExecutionData[] — parse with JSON.parse before use */
+    executionData: string
+    state: ExecutionState
+    agentflowId: string
+    sessionId: string
+    isPublic: boolean
+    action?: string
+    createdDate: string
+    updatedDate: string
+    stoppedDate?: string
+    /** Populated when the API performs the agentflow join */
+    agentflow?: AgentflowRef
+}
+
+// ============================================================================
+// Node-level Execution Data (parsed from Execution.executionData)
+// ============================================================================
+
+export interface TimeMetadata {
+    delta: number // milliseconds
+}
+
+export interface UsageMetadata {
+    total_tokens: number
+    total_cost: number // USD
+}
+
+export interface NodeExecutionOutput {
+    timeMetadata?: TimeMetadata
+    usageMetadata?: UsageMetadata
+    [key: string]: unknown
+}
+
+export interface NodeExecutionData {
+    nodeLabel: string
+    nodeId: string
+    /** Node output data — shape varies by node type */
+    data: Record<string, unknown>
+    previousNodeIds: string[]
+    status: ExecutionState
+    /** Node type name — used for icon lookup */
+    name?: string
+    /** Index within an iteration group (0-based) */
+    iterationIndex?: number
+    iterationContext?: Record<string, unknown>
+    /** Parent node ID for iteration child nodes */
+    parentNodeId?: string
+    output?: NodeExecutionOutput
+}
+
+// ============================================================================
+// Execution Tree (built client-side from flat NodeExecutionData[])
+// ============================================================================
+
+export interface ExecutionTreeNode {
+    id: string
+    nodeId: string
+    nodeLabel: string
+    status: ExecutionState
+    name?: string
+    /** True for virtual iteration container nodes (not real execution nodes) */
+    isVirtualNode?: boolean
+    iterationIndex?: number
+    children: ExecutionTreeNode[]
+    /** Reference back to the raw execution data for the detail panel */
+    raw?: NodeExecutionData
+}
+
+// ============================================================================
+// API Filter / Pagination
+// ============================================================================
+
+export interface ExecutionFilters {
+    state?: ExecutionState | ''
+    startDate?: Date | null
+    endDate?: Date | null
+    agentflowId?: string
+    agentflowName?: string
+    sessionId?: string
+}
+
+export interface ExecutionListParams extends ExecutionFilters {
+    page: number
+    limit: number
+}
+
+export interface ExecutionListResponse {
+    data: Execution[]
+    total: number
+}
+
+// ============================================================================
+// HITL (Human-in-the-Loop) — passed to onHumanInput callback
+// ============================================================================
+
+export interface HumanInputParams {
+    question: string
+    chatId: string
+    humanInput: {
+        type: 'proceed' | 'reject'
+        startNodeId: string
+        feedback?: string
+    }
+}

--- a/packages/observe/src/core/types/index.ts
+++ b/packages/observe/src/core/types/index.ts
@@ -1,0 +1,22 @@
+export type {
+    // Execution domain
+    AgentflowRef,
+    Execution,
+    ExecutionFilters,
+    ExecutionListParams,
+    ExecutionListResponse,
+    ExecutionState,
+    ExecutionTreeNode,
+    HumanInputParams,
+    NodeExecutionData,
+    NodeExecutionOutput,
+    TimeMetadata,
+    UsageMetadata
+} from './execution'
+export type {
+    // Component props
+    ExecutionDetailProps,
+    ExecutionsViewerProps,
+    ObserveBaseProps,
+    RequestInterceptor
+} from './observe'

--- a/packages/observe/src/core/types/observe.ts
+++ b/packages/observe/src/core/types/observe.ts
@@ -1,0 +1,89 @@
+// ============================================================================
+// Component Props — Public API surface for @flowiseai/observe
+// ============================================================================
+
+import type { InternalAxiosRequestConfig } from 'axios'
+
+import type { ExecutionFilters, HumanInputParams } from './execution'
+
+/**
+ * Callback to customize outgoing Axios requests.
+ * Receives the full request config — modify only what you need and return it.
+ * If the callback throws, the original unmodified config is used.
+ */
+export type RequestInterceptor = (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig
+
+// ============================================================================
+// Shared base props used by all observe components
+// ============================================================================
+
+export interface ObserveBaseProps {
+    /** Flowise API server endpoint (e.g. "https://flowise-url.com") */
+    apiBaseUrl: string
+    /**
+     * API key — injected as `Authorization: Bearer <token>`.
+     * Optional when using requestInterceptor for session-based or proxy auth.
+     */
+    token?: string
+    /**
+     * Customize outgoing API requests (e.g. inject session cookies, proxy headers).
+     * Runs after the Bearer token header is set, so it can override or extend it.
+     * Use this instead of (or alongside) token when the host app owns auth routing.
+     */
+    requestInterceptor?: RequestInterceptor
+    /** Whether to use dark mode (default: false) */
+    isDarkMode?: boolean
+}
+
+// ============================================================================
+// ExecutionsViewer props
+// ============================================================================
+
+export interface ExecutionsViewerProps {
+    /**
+     * When provided, scopes the list to a single agentflow (M1 / DevSite use case).
+     * When omitted, shows the full cross-agent list (M2 / OSS use case).
+     */
+    agentflowId?: string
+    /**
+     * Whether to show a delete icon on each row (default: false).
+     * The SDK handles the DELETE API call internally.
+     */
+    allowDelete?: boolean
+    /**
+     * Polling interval in ms while an execution is INPROGRESS (default: 3000).
+     * Set to 0 to disable auto-poll and use manual refresh only.
+     */
+    pollInterval?: number
+    /**
+     * Pluggable HITL callback. When provided, Approve/Reject buttons are rendered
+     * on INPROGRESS human input nodes. The SDK does NOT make the prediction call —
+     * the consumer owns the routing (direct Flowise or via AgentForge proxy).
+     */
+    onHumanInput?: (agentflowId: string, params: HumanInputParams) => Promise<void>
+    /** Initial filter state */
+    initialFilters?: Partial<ExecutionFilters>
+    /** See ExecutionDetailProps.onAgentflowClick — threaded through to the detail drawer */
+    onAgentflowClick?: (agentflowId: string) => void
+}
+
+// ============================================================================
+// ExecutionDetail props
+// ============================================================================
+
+export interface ExecutionDetailProps {
+    /** Execution ID to fetch and display */
+    executionId: string
+    /** See ExecutionsViewerProps.pollInterval */
+    pollInterval?: number
+    /** See ExecutionsViewerProps.onHumanInput */
+    onHumanInput?: (agentflowId: string, params: HumanInputParams) => Promise<void>
+    /** Called when the drawer/panel is closed (if rendered in a dismissible context) */
+    onClose?: () => void
+    /**
+     * When provided, the agentflow name in the detail header is rendered as a clickable chip.
+     * The SDK does NOT navigate — the consumer owns routing.
+     * When absent, the name is rendered as plain text (or omitted if no name is available).
+     */
+    onAgentflowClick?: (agentflowId: string) => void
+}

--- a/packages/observe/src/features/executions/components/ExecutionDetail.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Box, Chip, CircularProgress, Divider, IconButton, Stack, Tooltip, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
@@ -58,10 +58,19 @@ export function ExecutionDetail({
         document.removeEventListener('mouseup', handleMouseUp)
     }, [handleMouseMove])
 
+    useEffect(() => {
+        return () => {
+            document.removeEventListener('mousemove', handleMouseMove)
+            document.removeEventListener('mouseup', handleMouseUp)
+        }
+    }, [handleMouseMove, handleMouseUp])
+
     const copyId = () => {
-        navigator.clipboard.writeText(executionId)
-        setCopied(true)
-        setTimeout(() => setCopied(false), 2000)
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText(executionId)
+            setCopied(true)
+            setTimeout(() => setCopied(false), 2000)
+        }
     }
 
     if (isLoading) {

--- a/packages/observe/src/features/executions/components/ExecutionDetail.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.tsx
@@ -1,0 +1,246 @@
+import { useCallback, useRef, useState } from 'react'
+
+import { Box, Chip, CircularProgress, Divider, IconButton, Stack, Tooltip, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { IconCopy, IconRefresh } from '@tabler/icons-react'
+
+import { StatusIndicator } from '@/atoms'
+import type { ExecutionDetailProps, ExecutionState, ExecutionTreeNode } from '@/core/types'
+
+import { useExecutionPoll } from '../hooks/useExecutionPoll'
+import { useExecutionTree } from '../hooks/useExecutionTree'
+
+import { NodeExecutionDetail } from './NodeExecutionDetail'
+
+const MIN_SIDEBAR_WIDTH = 240
+const MAX_SIDEBAR_WIDTH = 480
+const DEFAULT_SIDEBAR_WIDTH = 300
+
+/**
+ * Full execution detail view: resizable tree sidebar (left) + node detail panel (right).
+ * Fetches the execution by ID and auto-polls while INPROGRESS.
+ */
+export function ExecutionDetail({
+    executionId,
+    pollInterval = 3000,
+    onHumanInput,
+    onClose: _onClose,
+    onAgentflowClick
+}: ExecutionDetailProps) {
+    const theme = useTheme()
+    const { execution, isLoading, error, refresh } = useExecutionPoll({ executionId, pollInterval })
+    const tree = useExecutionTree(execution?.executionData ?? null)
+    const [selectedNode, setSelectedNode] = useState<ExecutionTreeNode | null>(null)
+    const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH)
+    const [copied, setCopied] = useState(false)
+    const isDragging = useRef(false)
+    const dragStartX = useRef(0)
+    const dragStartWidth = useRef(DEFAULT_SIDEBAR_WIDTH)
+
+    const handleMouseDown = (e: React.MouseEvent) => {
+        isDragging.current = true
+        dragStartX.current = e.clientX
+        dragStartWidth.current = sidebarWidth
+        document.addEventListener('mousemove', handleMouseMove)
+        document.addEventListener('mouseup', handleMouseUp)
+    }
+
+    const handleMouseMove = useCallback((e: MouseEvent) => {
+        if (!isDragging.current) return
+        const delta = e.clientX - dragStartX.current
+        const newWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, dragStartWidth.current + delta))
+        setSidebarWidth(newWidth)
+    }, [])
+
+    const handleMouseUp = useCallback(() => {
+        isDragging.current = false
+        document.removeEventListener('mousemove', handleMouseMove)
+        document.removeEventListener('mouseup', handleMouseUp)
+    }, [handleMouseMove])
+
+    const copyId = () => {
+        navigator.clipboard.writeText(executionId)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+    }
+
+    if (isLoading) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+                <CircularProgress size={32} />
+            </Box>
+        )
+    }
+
+    if (error || !execution) {
+        return (
+            <Box sx={{ p: 3 }}>
+                <Typography color='error'>{error ?? 'Execution not found'}</Typography>
+            </Box>
+        )
+    }
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+            {/* Toolbar */}
+            <Stack
+                direction='row'
+                spacing={1}
+                alignItems='center'
+                sx={{ px: 2, py: 1, borderBottom: `1px solid ${theme.palette.divider}`, flexShrink: 0 }}
+            >
+                <StatusIndicator state={execution.state as ExecutionState} size={16} />
+                <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>
+                    {execution.state}
+                </Typography>
+                <Tooltip title={copied ? 'Copied!' : `ID: ${execution.id}`}>
+                    <IconButton size='small' onClick={copyId}>
+                        <IconCopy size={14} />
+                    </IconButton>
+                </Tooltip>
+                {execution.agentflow &&
+                    (onAgentflowClick ? (
+                        <Chip
+                            label={execution.agentflow.name}
+                            size='small'
+                            clickable
+                            onClick={() => onAgentflowClick(execution.agentflowId)}
+                        />
+                    ) : (
+                        <Typography variant='body2' color='text.secondary'>
+                            {execution.agentflow.name}
+                        </Typography>
+                    ))}
+                <Box sx={{ flex: 1 }} />
+                <Tooltip title='Refresh'>
+                    <IconButton size='small' onClick={refresh}>
+                        <IconRefresh size={14} />
+                    </IconButton>
+                </Tooltip>
+            </Stack>
+
+            {/* Split pane */}
+            <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+                {/* Tree sidebar */}
+                <Box sx={{ width: sidebarWidth, flexShrink: 0, overflow: 'auto', borderRight: `1px solid ${theme.palette.divider}` }}>
+                    {tree.length === 0 ? (
+                        <Box sx={{ p: 2 }}>
+                            <Typography variant='body2' color='text.secondary'>
+                                No execution steps recorded.
+                            </Typography>
+                        </Box>
+                    ) : (
+                        <TreeNodeList nodes={tree} selectedId={selectedNode?.id ?? null} onSelect={setSelectedNode} depth={0} />
+                    )}
+                </Box>
+
+                {/* Drag handle */}
+                <Box
+                    onMouseDown={handleMouseDown}
+                    sx={{
+                        width: 4,
+                        cursor: 'col-resize',
+                        flexShrink: 0,
+                        backgroundColor: 'transparent',
+                        '&:hover': { backgroundColor: theme.palette.primary.main }
+                    }}
+                />
+
+                {/* Node detail panel */}
+                <Box sx={{ flex: 1, overflow: 'hidden' }}>
+                    {selectedNode ? (
+                        <NodeExecutionDetail
+                            node={selectedNode}
+                            agentflowId={execution.agentflowId}
+                            sessionId={execution.sessionId}
+                            onHumanInput={onHumanInput}
+                        />
+                    ) : (
+                        <Box sx={{ p: 3 }}>
+                            <Typography variant='body2' color='text.secondary'>
+                                Select a step to view details.
+                            </Typography>
+                        </Box>
+                    )}
+                </Box>
+            </Box>
+        </Box>
+    )
+}
+
+// ============================================================================
+// Tree rendering — recursive node list
+// ============================================================================
+
+interface TreeNodeListProps {
+    nodes: ExecutionTreeNode[]
+    selectedId: string | null
+    onSelect: (node: ExecutionTreeNode) => void
+    depth: number
+}
+
+function TreeNodeList({ nodes, selectedId, onSelect, depth }: TreeNodeListProps) {
+    return (
+        <>
+            {nodes.map((node) => (
+                <TreeNodeItem key={node.id} node={node} selectedId={selectedId} onSelect={onSelect} depth={depth} />
+            ))}
+        </>
+    )
+}
+
+interface TreeNodeItemProps {
+    node: ExecutionTreeNode
+    selectedId: string | null
+    onSelect: (node: ExecutionTreeNode) => void
+    depth: number
+}
+
+function TreeNodeItem({ node, selectedId, onSelect, depth }: TreeNodeItemProps) {
+    const theme = useTheme()
+    const [expanded, setExpanded] = useState(true)
+    const isSelected = node.id === selectedId
+    const hasChildren = node.children.length > 0
+
+    return (
+        <>
+            <Box
+                onClick={() => {
+                    if (!node.isVirtualNode) onSelect(node)
+                    if (hasChildren) setExpanded((v) => !v)
+                }}
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    pl: 1.5 + depth * 1.5,
+                    pr: 1.5,
+                    py: 0.75,
+                    cursor: node.isVirtualNode ? 'default' : 'pointer',
+                    backgroundColor: isSelected ? theme.palette.action.selected : 'transparent',
+                    '&:hover': { backgroundColor: theme.palette.action.hover },
+                    borderBottom: `1px solid ${theme.palette.divider}`
+                }}
+            >
+                {node.isVirtualNode ? (
+                    <Typography variant='caption' color='text.secondary' sx={{ fontStyle: 'italic' }}>
+                        {node.nodeLabel}
+                    </Typography>
+                ) : (
+                    <>
+                        <StatusIndicator state={node.status as ExecutionState} size={12} />
+                        <Typography variant='body2' sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {node.nodeLabel}
+                        </Typography>
+                    </>
+                )}
+            </Box>
+            {hasChildren && expanded && (
+                <>
+                    <Divider />
+                    <TreeNodeList nodes={node.children} selectedId={selectedId} onSelect={onSelect} depth={depth + 1} />
+                </>
+            )}
+        </>
+    )
+}

--- a/packages/observe/src/features/executions/components/ExecutionsListTable.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionsListTable.tsx
@@ -1,0 +1,129 @@
+import { Box, Checkbox, IconButton, Table, TableBody, TableCell, TableHead, TableRow, Tooltip, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { IconTrash } from '@tabler/icons-react'
+
+import { StatusIndicator } from '@/atoms'
+import type { Execution } from '@/core/types'
+
+interface ExecutionsListTableProps {
+    executions: Execution[]
+    selectedIds: Set<string>
+    onSelectId: (id: string, checked: boolean) => void
+    onSelectAll: (checked: boolean) => void
+    onRowClick: (execution: Execution) => void
+    onDelete?: (execution: Execution) => void
+    allowDelete?: boolean
+    /** When true, hides the Agentflow Name column (scoped view) */
+    scoped?: boolean
+}
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+    })
+}
+
+function truncate(str: string, max = 24): string {
+    return str.length > max ? `${str.slice(0, max)}…` : str
+}
+
+export function ExecutionsListTable({
+    executions,
+    selectedIds,
+    onSelectId,
+    onSelectAll,
+    onRowClick,
+    onDelete,
+    allowDelete = false,
+    scoped = false
+}: ExecutionsListTableProps) {
+    const theme = useTheme()
+    const allSelected = executions.length > 0 && executions.every((e) => selectedIds.has(e.id))
+    const someSelected = executions.some((e) => selectedIds.has(e.id))
+
+    return (
+        <Table size='small' stickyHeader>
+            <TableHead>
+                <TableRow>
+                    <TableCell padding='checkbox'>
+                        <Checkbox
+                            size='small'
+                            checked={allSelected}
+                            indeterminate={someSelected && !allSelected}
+                            onChange={(_, checked) => onSelectAll(checked)}
+                        />
+                    </TableCell>
+                    <TableCell>Status</TableCell>
+                    <TableCell>Last Updated</TableCell>
+                    {!scoped && <TableCell>Agentflow</TableCell>}
+                    <TableCell>Session ID</TableCell>
+                    <TableCell>Created</TableCell>
+                    {allowDelete && <TableCell padding='checkbox' />}
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {executions.map((execution) => (
+                    <TableRow
+                        key={execution.id}
+                        hover
+                        selected={selectedIds.has(execution.id)}
+                        onClick={() => onRowClick(execution)}
+                        sx={{ cursor: 'pointer' }}
+                    >
+                        <TableCell padding='checkbox' onClick={(e) => e.stopPropagation()}>
+                            <Checkbox
+                                size='small'
+                                checked={selectedIds.has(execution.id)}
+                                onChange={(_, checked) => onSelectId(execution.id, checked)}
+                            />
+                        </TableCell>
+                        <TableCell>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                                <StatusIndicator state={execution.state} size={14} />
+                                <Typography variant='caption' color='text.secondary'>
+                                    {execution.state}
+                                </Typography>
+                            </Box>
+                        </TableCell>
+                        <TableCell>
+                            <Typography variant='body2'>{formatDate(execution.updatedDate)}</Typography>
+                        </TableCell>
+                        {!scoped && (
+                            <TableCell>
+                                <Typography variant='body2'>{execution.agentflow?.name ?? '—'}</Typography>
+                            </TableCell>
+                        )}
+                        <TableCell>
+                            <Tooltip title={execution.sessionId}>
+                                <Typography variant='body2' sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                                    {truncate(execution.sessionId)}
+                                </Typography>
+                            </Tooltip>
+                        </TableCell>
+                        <TableCell>
+                            <Typography variant='body2' color='text.secondary'>
+                                {formatDate(execution.createdDate)}
+                            </Typography>
+                        </TableCell>
+                        {allowDelete && (
+                            <TableCell padding='checkbox' onClick={(e) => e.stopPropagation()}>
+                                <Tooltip title='Delete execution'>
+                                    <IconButton
+                                        size='small'
+                                        onClick={() => onDelete?.(execution)}
+                                        sx={{ color: theme.palette.error.main, opacity: 0.6, '&:hover': { opacity: 1 } }}
+                                    >
+                                        <IconTrash size={14} />
+                                    </IconButton>
+                                </Tooltip>
+                            </TableCell>
+                        )}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    )
+}

--- a/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
@@ -1,0 +1,278 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+    Box,
+    Button,
+    Chip,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    Drawer,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
+    Stack,
+    TablePagination,
+    TextField,
+    Typography
+} from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import type { Execution, ExecutionFilters, ExecutionState, ExecutionsViewerProps } from '@/core/types'
+import { useObserveApi } from '@/infrastructure/store'
+
+import { ExecutionDetail } from './ExecutionDetail'
+import { ExecutionsListTable } from './ExecutionsListTable'
+
+const DEFAULT_PAGE_SIZE = 12
+const EXECUTION_STATES: Array<ExecutionState | ''> = ['', 'INPROGRESS', 'FINISHED', 'ERROR', 'TERMINATED', 'TIMEOUT', 'STOPPED']
+
+/**
+ * Top-level executions list + detail drawer.
+ * When agentflowId is provided: scoped view (M1 — hides agentflow name column).
+ * When agentflowId is omitted: full cross-agent list (M2).
+ */
+export function ExecutionsViewer({
+    agentflowId,
+    allowDelete = false,
+    pollInterval = 3000,
+    onHumanInput,
+    onAgentflowClick,
+    initialFilters
+}: ExecutionsViewerProps) {
+    const theme = useTheme()
+    const { executions: api } = useObserveApi()
+
+    // List state
+    const [rows, setRows] = useState<Execution[]>([])
+    const [total, setTotal] = useState(0)
+    const [isLoading, setIsLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+
+    // Pagination
+    const [page, setPage] = useState(0) // MUI TablePagination is 0-based
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
+
+    // Filters
+    const [filters, setFilters] = useState<ExecutionFilters>({
+        state: '',
+        startDate: null,
+        endDate: null,
+        sessionId: '',
+        agentflowName: '',
+        ...initialFilters
+    })
+
+    // Selection
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+    // Detail drawer
+    const [drawerExecution, setDrawerExecution] = useState<Execution | null>(null)
+
+    // Delete confirmation
+    const [deleteTarget, setDeleteTarget] = useState<Execution | null>(null)
+
+    const fetchExecutions = useCallback(async () => {
+        setIsLoading(true)
+        setError(null)
+        try {
+            const result = await api.getAllExecutions({
+                page: page + 1, // API is 1-based
+                limit: pageSize,
+                agentflowId: agentflowId ?? filters.agentflowId,
+                ...filters
+            })
+            setRows(result.data)
+            setTotal(result.total)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to load executions')
+        } finally {
+            setIsLoading(false)
+        }
+    }, [api, page, pageSize, agentflowId, filters])
+
+    useEffect(() => {
+        fetchExecutions()
+    }, [fetchExecutions])
+
+    const handleSelectId = (id: string, checked: boolean) => {
+        setSelectedIds((prev) => {
+            const next = new Set(prev)
+            if (checked) next.add(id)
+            else next.delete(id)
+            return next
+        })
+    }
+
+    const handleSelectAll = (checked: boolean) => {
+        setSelectedIds(checked ? new Set(rows.map((r) => r.id)) : new Set())
+    }
+
+    const handleDelete = async (execution: Execution) => {
+        try {
+            await api.deleteExecutions([execution.id])
+            setDeleteTarget(null)
+            setSelectedIds((prev) => {
+                const next = new Set(prev)
+                next.delete(execution.id)
+                return next
+            })
+            fetchExecutions()
+        } catch (err) {
+            console.error('[Observe] Failed to delete execution', err)
+        }
+    }
+
+    const handleBulkDelete = async () => {
+        try {
+            await api.deleteExecutions(Array.from(selectedIds))
+            setSelectedIds(new Set())
+            fetchExecutions()
+        } catch (err) {
+            console.error('[Observe] Failed to bulk delete executions', err)
+        }
+    }
+
+    const isScoped = !!agentflowId
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+            {/* Filters */}
+            <Stack
+                direction='row'
+                spacing={1.5}
+                flexWrap='wrap'
+                alignItems='center'
+                sx={{ px: 2, py: 1.5, borderBottom: `1px solid ${theme.palette.divider}`, flexShrink: 0 }}
+            >
+                <FormControl size='small' sx={{ minWidth: 140 }}>
+                    <InputLabel>Status</InputLabel>
+                    <Select
+                        label='Status'
+                        value={filters.state ?? ''}
+                        onChange={(e) => setFilters((f) => ({ ...f, state: e.target.value as ExecutionState | '' }))}
+                    >
+                        {EXECUTION_STATES.map((s) => (
+                            <MenuItem key={s} value={s}>
+                                {s || 'All'}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+
+                <TextField
+                    size='small'
+                    label='Session ID'
+                    value={filters.sessionId ?? ''}
+                    onChange={(e) => setFilters((f) => ({ ...f, sessionId: e.target.value }))}
+                    sx={{ width: 200 }}
+                />
+
+                {!isScoped && (
+                    <TextField
+                        size='small'
+                        label='Agentflow Name'
+                        value={filters.agentflowName ?? ''}
+                        onChange={(e) => setFilters((f) => ({ ...f, agentflowName: e.target.value }))}
+                        sx={{ width: 200 }}
+                    />
+                )}
+
+                <Box sx={{ flex: 1 }} />
+
+                {selectedIds.size > 0 && (
+                    <Stack direction='row' spacing={1} alignItems='center'>
+                        <Chip label={`${selectedIds.size} selected`} size='small' />
+                        <Button size='small' color='error' variant='outlined' onClick={handleBulkDelete}>
+                            Delete selected
+                        </Button>
+                    </Stack>
+                )}
+            </Stack>
+
+            {/* Table */}
+            <Box sx={{ flex: 1, overflow: 'auto', position: 'relative' }}>
+                {isLoading && (
+                    <Box
+                        sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1 }}
+                    >
+                        <CircularProgress />
+                    </Box>
+                )}
+                {error && (
+                    <Box sx={{ p: 3 }}>
+                        <Typography color='error'>{error}</Typography>
+                    </Box>
+                )}
+                {!isLoading && !error && rows.length === 0 && (
+                    <Box sx={{ p: 4, textAlign: 'center' }}>
+                        <Typography color='text.secondary'>No executions found.</Typography>
+                    </Box>
+                )}
+                {rows.length > 0 && (
+                    <ExecutionsListTable
+                        executions={rows}
+                        selectedIds={selectedIds}
+                        onSelectId={handleSelectId}
+                        onSelectAll={handleSelectAll}
+                        onRowClick={setDrawerExecution}
+                        onDelete={(e) => setDeleteTarget(e)}
+                        allowDelete={allowDelete}
+                        scoped={isScoped}
+                    />
+                )}
+            </Box>
+
+            {/* Pagination */}
+            <TablePagination
+                component='div'
+                count={total}
+                page={page}
+                rowsPerPage={pageSize}
+                onPageChange={(_, newPage) => setPage(newPage)}
+                onRowsPerPageChange={(e) => {
+                    setPageSize(parseInt(e.target.value, 10))
+                    setPage(0)
+                }}
+                rowsPerPageOptions={[12, 25, 50]}
+                sx={{ borderTop: `1px solid ${theme.palette.divider}`, flexShrink: 0 }}
+            />
+
+            {/* Detail Drawer */}
+            <Drawer
+                anchor='right'
+                open={!!drawerExecution}
+                onClose={() => setDrawerExecution(null)}
+                PaperProps={{ sx: { width: { xs: '100vw', sm: '70vw', md: '60vw' } } }}
+            >
+                {drawerExecution && (
+                    <ExecutionDetail
+                        executionId={drawerExecution.id}
+                        pollInterval={pollInterval}
+                        onHumanInput={onHumanInput}
+                        onAgentflowClick={onAgentflowClick}
+                        onClose={() => setDrawerExecution(null)}
+                    />
+                )}
+            </Drawer>
+
+            {/* Delete confirmation */}
+            <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)} maxWidth='xs' fullWidth>
+                <DialogTitle>Delete Execution</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>This action cannot be undone.</DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+                    <Button color='error' variant='contained' onClick={() => deleteTarget && handleDelete(deleteTarget)}>
+                        Delete
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
+    )
+}

--- a/packages/observe/src/features/executions/components/NodeExecutionDetail.tsx
+++ b/packages/observe/src/features/executions/components/NodeExecutionDetail.tsx
@@ -1,0 +1,231 @@
+import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+
+import {
+    Box,
+    Button,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Divider,
+    Stack,
+    TextField,
+    ToggleButton,
+    ToggleButtonGroup,
+    Tooltip,
+    Typography
+} from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { IconCode, IconEye } from '@tabler/icons-react'
+import ReactJson from 'flowise-react-json-view'
+import remarkGfm from 'remark-gfm'
+
+import { MetricsDisplay, StatusIndicator } from '@/atoms'
+import type { ExecutionState, ExecutionTreeNode, HumanInputParams, NodeExecutionData } from '@/core/types'
+import { useObserveConfig } from '@/infrastructure/store'
+
+type DataView = 'rendered' | 'raw'
+
+interface NodeExecutionDetailProps {
+    node: ExecutionTreeNode
+    agentflowId: string
+    sessionId: string
+    onHumanInput?: (agentflowId: string, params: HumanInputParams) => Promise<void>
+}
+
+function isMarkdown(value: unknown): value is string {
+    return typeof value === 'string' && (value.includes('\n') || value.includes('**') || value.includes('##'))
+}
+
+function renderValue(value: unknown, isDarkMode: boolean) {
+    if (value === null || value === undefined) return null
+    if (typeof value === 'string') {
+        if (isMarkdown(value)) {
+            return <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
+        }
+        return (
+            <Typography variant='body2' sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {value}
+            </Typography>
+        )
+    }
+    if (typeof value === 'object') {
+        return (
+            <ReactJson
+                src={value as object}
+                theme={isDarkMode ? 'monokai' : 'rjv-default'}
+                collapsed={2}
+                displayDataTypes={false}
+                displayObjectSize={false}
+                style={{ fontSize: '0.75rem', background: 'transparent' }}
+            />
+        )
+    }
+    return <Typography variant='body2'>{String(value)}</Typography>
+}
+
+/**
+ * Right-panel detail view for a selected node in the execution tree.
+ * Shows node metadata, metrics, rendered/raw output, and HITL controls when applicable.
+ */
+export function NodeExecutionDetail({ node, agentflowId, sessionId, onHumanInput }: NodeExecutionDetailProps) {
+    const theme = useTheme()
+    const { isDarkMode } = useObserveConfig()
+    const [dataView, setDataView] = useState<DataView>('rendered')
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [feedbackOpen, setFeedbackOpen] = useState(false)
+    const [feedbackText, setFeedbackText] = useState('')
+    const [pendingType, setPendingType] = useState<'proceed' | 'reject' | null>(null)
+
+    const raw = node.raw as NodeExecutionData | undefined
+    const isHumanInputNode = raw?.name === 'humanInputAgentflow'
+    const isInProgress = node.status === 'INPROGRESS'
+    const showHitlControls = isHumanInputNode && isInProgress && !!onHumanInput
+    const enableFeedback = raw?.data?.humanInputEnableFeedback === true
+
+    const submitHumanInput = async (type: 'proceed' | 'reject', feedback = '') => {
+        if (!onHumanInput) return
+        setIsSubmitting(true)
+        try {
+            await onHumanInput(agentflowId, {
+                question: feedback || (type === 'proceed' ? 'Proceed' : 'Reject'),
+                chatId: sessionId,
+                humanInput: { type, startNodeId: node.nodeId, feedback }
+            })
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    const handleProceed = () => {
+        if (enableFeedback) {
+            setPendingType('proceed')
+            setFeedbackOpen(true)
+        } else {
+            submitHumanInput('proceed')
+        }
+    }
+
+    const handleReject = () => {
+        if (enableFeedback) {
+            setPendingType('reject')
+            setFeedbackOpen(true)
+        } else {
+            submitHumanInput('reject')
+        }
+    }
+
+    const handleFeedbackSubmit = () => {
+        if (pendingType) submitHumanInput(pendingType, feedbackText)
+        setFeedbackOpen(false)
+        setFeedbackText('')
+        setPendingType(null)
+    }
+
+    return (
+        <Box sx={{ height: '100%', overflow: 'auto', p: 2 }}>
+            {/* Header */}
+            <Stack direction='row' spacing={1} alignItems='center' sx={{ mb: 1.5 }}>
+                <StatusIndicator state={node.status as ExecutionState} size={18} />
+                <Typography variant='h5'>{node.nodeLabel}</Typography>
+                {node.name && (
+                    <Typography variant='caption' color='text.secondary' sx={{ ml: 'auto' }}>
+                        {node.name}
+                    </Typography>
+                )}
+            </Stack>
+
+            {/* Metrics */}
+            {raw?.output && <MetricsDisplay output={raw.output} />}
+
+            {/* HITL Controls */}
+            {showHitlControls && (
+                <Box sx={{ my: 2, p: 1.5, border: `1px solid ${theme.palette.divider}`, borderRadius: 1 }}>
+                    <Typography variant='subtitle1' sx={{ mb: 1 }}>
+                        {(raw?.data?.question as string) ?? 'Waiting for your response'}
+                    </Typography>
+                    <Stack direction='row' spacing={1}>
+                        <Button variant='contained' color='success' size='small' disabled={isSubmitting} onClick={handleProceed}>
+                            {isSubmitting ? <CircularProgress size={14} /> : 'Approve'}
+                        </Button>
+                        <Button variant='outlined' color='error' size='small' disabled={isSubmitting} onClick={handleReject}>
+                            Reject
+                        </Button>
+                    </Stack>
+                </Box>
+            )}
+
+            <Divider sx={{ my: 1.5 }} />
+
+            {/* Data view toggle */}
+            <Stack direction='row' justifyContent='space-between' alignItems='center' sx={{ mb: 1 }}>
+                <Typography variant='subtitle1'>Output</Typography>
+                <ToggleButtonGroup size='small' value={dataView} exclusive onChange={(_, val) => val && setDataView(val)}>
+                    <ToggleButton value='rendered'>
+                        <Tooltip title='Rendered'>
+                            <IconEye size={14} />
+                        </Tooltip>
+                    </ToggleButton>
+                    <ToggleButton value='raw'>
+                        <Tooltip title='Raw JSON'>
+                            <IconCode size={14} />
+                        </Tooltip>
+                    </ToggleButton>
+                </ToggleButtonGroup>
+            </Stack>
+
+            {/* Data content */}
+            <Box sx={{ fontSize: '0.8125rem', lineHeight: 1.6 }}>
+                {dataView === 'raw' ? (
+                    <ReactJson
+                        src={raw?.data ?? {}}
+                        theme={isDarkMode ? 'monokai' : 'rjv-default'}
+                        collapsed={1}
+                        displayDataTypes={false}
+                        displayObjectSize={false}
+                        style={{ fontSize: '0.75rem', background: 'transparent' }}
+                    />
+                ) : (
+                    Object.entries(raw?.data ?? {}).map(([key, value]) => (
+                        <Box key={key} sx={{ mb: 1.5 }}>
+                            <Typography
+                                variant='caption'
+                                color='text.secondary'
+                                sx={{ textTransform: 'uppercase', letterSpacing: '0.05em' }}
+                            >
+                                {key}
+                            </Typography>
+                            <Box sx={{ mt: 0.5 }}>{renderValue(value, isDarkMode)}</Box>
+                        </Box>
+                    ))
+                )}
+            </Box>
+
+            {/* Feedback dialog */}
+            <Dialog open={feedbackOpen} onClose={() => setFeedbackOpen(false)} maxWidth='sm' fullWidth>
+                <DialogTitle>Provide Feedback</DialogTitle>
+                <DialogContent>
+                    <TextField
+                        autoFocus
+                        multiline
+                        fullWidth
+                        rows={3}
+                        label='Feedback'
+                        variant='outlined'
+                        value={feedbackText}
+                        onChange={(e) => setFeedbackText(e.target.value)}
+                        sx={{ mt: 1 }}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setFeedbackOpen(false)}>Cancel</Button>
+                    <Button onClick={handleFeedbackSubmit} variant='contained' disabled={isSubmitting}>
+                        Submit
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
+    )
+}

--- a/packages/observe/src/features/executions/hooks/useExecutionPoll.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useExecutionPoll.test.tsx
@@ -1,0 +1,155 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useExecutionPoll } from './useExecutionPoll'
+
+const mockGetExecutionById = jest.fn()
+
+jest.mock('@/infrastructure/store', () => ({
+    useObserveApi: () => ({
+        executions: { getExecutionById: mockGetExecutionById }
+    })
+}))
+
+const makeExecution = (state: string) => ({
+    id: 'exec-1',
+    state,
+    agentflowId: 'flow-1',
+    sessionId: 'session-1',
+    createdDate: '2024-01-01T00:00:00Z',
+    nodeExecutions: null
+})
+
+beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+})
+
+afterEach(() => {
+    jest.useRealTimers()
+})
+
+describe('useExecutionPoll', () => {
+    it('fetches execution on mount', async () => {
+        mockGetExecutionById.mockResolvedValueOnce(makeExecution('FINISHED'))
+
+        const { result } = renderHook(() => useExecutionPoll({ executionId: 'exec-1' }))
+
+        expect(result.current.isLoading).toBe(true)
+
+        await act(async () => {})
+
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(1)
+        expect(mockGetExecutionById).toHaveBeenCalledWith('exec-1')
+        expect(result.current.execution).toMatchObject({ id: 'exec-1', state: 'FINISHED' })
+        expect(result.current.isLoading).toBe(false)
+        expect(result.current.error).toBeNull()
+    })
+
+    it('polls repeatedly when pollInterval > 0 and state is non-terminal', async () => {
+        mockGetExecutionById.mockResolvedValue(makeExecution('INPROGRESS'))
+
+        renderHook(() => useExecutionPoll({ executionId: 'exec-1', pollInterval: 1000 }))
+
+        await act(async () => {})
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            jest.advanceTimersByTime(1000)
+        })
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(2)
+
+        await act(async () => {
+            jest.advanceTimersByTime(1000)
+        })
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(3)
+    })
+
+    it.each(['FINISHED', 'ERROR', 'TERMINATED', 'TIMEOUT', 'STOPPED'])(
+        'stops polling when execution reaches terminal state: %s',
+        async (terminalState) => {
+            mockGetExecutionById.mockResolvedValueOnce(makeExecution('INPROGRESS')).mockResolvedValueOnce(makeExecution(terminalState))
+
+            renderHook(() => useExecutionPoll({ executionId: 'exec-1', pollInterval: 1000 }))
+
+            await act(async () => {})
+            expect(mockGetExecutionById).toHaveBeenCalledTimes(1)
+
+            await act(async () => {
+                jest.advanceTimersByTime(1000)
+            })
+            expect(mockGetExecutionById).toHaveBeenCalledTimes(2)
+
+            // interval should be cleared — no more calls
+            await act(async () => {
+                jest.advanceTimersByTime(5000)
+            })
+            expect(mockGetExecutionById).toHaveBeenCalledTimes(2)
+        }
+    )
+
+    it('does not start polling when pollInterval is 0', async () => {
+        mockGetExecutionById.mockResolvedValue(makeExecution('INPROGRESS'))
+
+        renderHook(() => useExecutionPoll({ executionId: 'exec-1', pollInterval: 0 }))
+
+        await act(async () => {})
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            jest.advanceTimersByTime(10000)
+        })
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(1)
+    })
+
+    it('refresh() triggers an additional fetch', async () => {
+        mockGetExecutionById.mockResolvedValue(makeExecution('INPROGRESS'))
+
+        const { result } = renderHook(() => useExecutionPoll({ executionId: 'exec-1', pollInterval: 0 }))
+
+        await act(async () => {})
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            result.current.refresh()
+        })
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(2)
+    })
+
+    it('clears the interval on unmount', async () => {
+        mockGetExecutionById.mockResolvedValue(makeExecution('INPROGRESS'))
+
+        const { unmount } = renderHook(() => useExecutionPoll({ executionId: 'exec-1', pollInterval: 1000 }))
+
+        await act(async () => {})
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(1)
+
+        unmount()
+
+        await act(async () => {
+            jest.advanceTimersByTime(5000)
+        })
+        expect(mockGetExecutionById).toHaveBeenCalledTimes(1)
+    })
+
+    it('sets error state when API throws', async () => {
+        mockGetExecutionById.mockRejectedValueOnce(new Error('Network error'))
+
+        const { result } = renderHook(() => useExecutionPoll({ executionId: 'exec-1', pollInterval: 0 }))
+
+        await act(async () => {})
+
+        expect(result.current.error).toBe('Network error')
+        expect(result.current.execution).toBeNull()
+        expect(result.current.isLoading).toBe(false)
+    })
+
+    it('uses "Failed to load execution" for non-Error rejections', async () => {
+        mockGetExecutionById.mockRejectedValueOnce('something went wrong')
+
+        const { result } = renderHook(() => useExecutionPoll({ executionId: 'exec-1', pollInterval: 0 }))
+
+        await act(async () => {})
+
+        expect(result.current.error).toBe('Failed to load execution')
+    })
+})

--- a/packages/observe/src/features/executions/hooks/useExecutionPoll.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useExecutionPoll.test.tsx
@@ -1,13 +1,13 @@
 import { act, renderHook } from '@testing-library/react'
 
+import { useObserveApi } from '@/infrastructure/store'
+
 import { useExecutionPoll } from './useExecutionPoll'
 
 const mockGetExecutionById = jest.fn()
 
 jest.mock('@/infrastructure/store', () => ({
-    useObserveApi: () => ({
-        executions: { getExecutionById: mockGetExecutionById }
-    })
+    useObserveApi: jest.fn()
 }))
 
 const makeExecution = (state: string) => ({
@@ -22,6 +22,7 @@ const makeExecution = (state: string) => ({
 beforeEach(() => {
     jest.useFakeTimers()
     jest.clearAllMocks()
+    ;(useObserveApi as jest.Mock).mockReturnValue({ executions: { getExecutionById: mockGetExecutionById } })
 })
 
 afterEach(() => {

--- a/packages/observe/src/features/executions/hooks/useExecutionPoll.ts
+++ b/packages/observe/src/features/executions/hooks/useExecutionPoll.ts
@@ -63,8 +63,7 @@ export function useExecutionPoll({ executionId, pollInterval = 3000 }: UseExecut
                 intervalRef.current = null
             }
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [executionId, pollInterval])
+    }, [executionId, pollInterval, fetchExecution])
 
     return { execution, isLoading, error, refresh: fetchExecution }
 }

--- a/packages/observe/src/features/executions/hooks/useExecutionPoll.ts
+++ b/packages/observe/src/features/executions/hooks/useExecutionPoll.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { Execution } from '@/core/types'
+import { useObserveApi } from '@/infrastructure/store'
+
+const TERMINAL_STATES = new Set(['FINISHED', 'ERROR', 'TERMINATED', 'TIMEOUT', 'STOPPED'])
+
+interface UseExecutionPollOptions {
+    executionId: string
+    pollInterval?: number
+}
+
+interface UseExecutionPollResult {
+    execution: Execution | null
+    isLoading: boolean
+    error: string | null
+    refresh: () => void
+}
+
+/**
+ * Fetches a single execution by ID and auto-polls while state is INPROGRESS.
+ * Polling stops automatically when execution reaches a terminal state.
+ *
+ * @param executionId - The execution UUID to fetch
+ * @param pollInterval - Polling interval in ms (default 3000). Set to 0 to disable auto-poll.
+ */
+export function useExecutionPoll({ executionId, pollInterval = 3000 }: UseExecutionPollOptions): UseExecutionPollResult {
+    const { executions: api } = useObserveApi()
+    const [execution, setExecution] = useState<Execution | null>(null)
+    const [isLoading, setIsLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+    const fetchExecution = useCallback(async () => {
+        try {
+            const data = await api.getExecutionById(executionId)
+            setExecution(data)
+            setError(null)
+            // Stop polling once terminal
+            if (TERMINAL_STATES.has(data.state) && intervalRef.current) {
+                clearInterval(intervalRef.current)
+                intervalRef.current = null
+            }
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Failed to load execution'
+            setError(message)
+        } finally {
+            setIsLoading(false)
+        }
+    }, [api, executionId])
+
+    useEffect(() => {
+        setIsLoading(true)
+        fetchExecution()
+
+        if (pollInterval > 0) {
+            intervalRef.current = setInterval(fetchExecution, pollInterval)
+        }
+
+        return () => {
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current)
+                intervalRef.current = null
+            }
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [executionId, pollInterval])
+
+    return { execution, isLoading, error, refresh: fetchExecution }
+}

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
@@ -30,8 +30,11 @@ describe('useExecutionTree', () => {
         })
 
         it('returns [] for invalid JSON', () => {
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
             const { result } = renderHook(() => useExecutionTree('{not valid json'))
             expect(result.current).toEqual([])
+            expect(consoleError).toHaveBeenCalledWith('[Observe] Failed to parse executionData JSON')
+            consoleError.mockRestore()
         })
 
         it('returns [] for non-array JSON', () => {

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
@@ -1,0 +1,163 @@
+import { renderHook } from '@testing-library/react'
+
+import type { NodeExecutionData } from '@/core/types'
+
+import { useExecutionTree } from './useExecutionTree'
+
+function toJson(nodes: Partial<NodeExecutionData>[]): string {
+    return JSON.stringify(nodes)
+}
+
+const baseNode = (overrides: Partial<NodeExecutionData> = {}): NodeExecutionData => ({
+    nodeId: 'node-1',
+    nodeLabel: 'Node 1',
+    status: 'FINISHED',
+    data: {},
+    previousNodeIds: [],
+    ...overrides
+})
+
+describe('useExecutionTree', () => {
+    describe('degenerate inputs', () => {
+        it('returns [] for null', () => {
+            const { result } = renderHook(() => useExecutionTree(null))
+            expect(result.current).toEqual([])
+        })
+
+        it('returns [] for empty string', () => {
+            const { result } = renderHook(() => useExecutionTree(''))
+            expect(result.current).toEqual([])
+        })
+
+        it('returns [] for invalid JSON', () => {
+            const { result } = renderHook(() => useExecutionTree('{not valid json'))
+            expect(result.current).toEqual([])
+        })
+
+        it('returns [] for non-array JSON', () => {
+            const { result } = renderHook(() => useExecutionTree('{"foo":"bar"}'))
+            expect(result.current).toEqual([])
+        })
+
+        it('returns [] for empty array', () => {
+            const { result } = renderHook(() => useExecutionTree('[]'))
+            expect(result.current).toEqual([])
+        })
+    })
+
+    describe('top-level nodes', () => {
+        it('returns a single node with empty children', () => {
+            const node = baseNode({ nodeId: 'n1', nodeLabel: 'Step 1' })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            expect(result.current).toHaveLength(1)
+            expect(result.current[0].nodeId).toBe('n1')
+            expect(result.current[0].nodeLabel).toBe('Step 1')
+            expect(result.current[0].children).toEqual([])
+        })
+
+        it('returns multiple top-level nodes in order', () => {
+            const nodes = [
+                baseNode({ nodeId: 'n1', nodeLabel: 'A' }),
+                baseNode({ nodeId: 'n2', nodeLabel: 'B' }),
+                baseNode({ nodeId: 'n3', nodeLabel: 'C' })
+            ]
+            const { result } = renderHook(() => useExecutionTree(toJson(nodes)))
+            expect(result.current.map((n) => n.nodeId)).toEqual(['n1', 'n2', 'n3'])
+        })
+
+        it('builds node id as nodeId-iterationIndex', () => {
+            const node = baseNode({ nodeId: 'n1', iterationIndex: 0 })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            expect(result.current[0].id).toBe('n1-0')
+        })
+    })
+
+    describe('iteration grouping', () => {
+        it('inserts a virtual container node for iteration children', () => {
+            const parent = baseNode({ nodeId: 'loop', nodeLabel: 'Loop' })
+            const child = baseNode({ nodeId: 'step', nodeLabel: 'Step', parentNodeId: 'loop', iterationIndex: 0 })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, child])))
+
+            expect(result.current).toHaveLength(1)
+            const parentNode = result.current[0]
+            expect(parentNode.children).toHaveLength(1)
+
+            const virtualNode = parentNode.children[0]
+            expect(virtualNode.isVirtualNode).toBe(true)
+            expect(virtualNode.nodeLabel).toBe('Iteration #1')
+            expect(virtualNode.id).toBe('loop-iteration-0')
+            expect(virtualNode.iterationIndex).toBe(0)
+        })
+
+        it('groups children by iterationIndex into separate virtual nodes', () => {
+            const parent = baseNode({ nodeId: 'loop', nodeLabel: 'Loop' })
+            const iter0a = baseNode({ nodeId: 'step-a', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter0b = baseNode({ nodeId: 'step-b', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter1a = baseNode({ nodeId: 'step-c', parentNodeId: 'loop', iterationIndex: 1 })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, iter0a, iter0b, iter1a])))
+
+            const children = result.current[0].children
+            expect(children).toHaveLength(2)
+            expect(children[0].iterationIndex).toBe(0)
+            expect(children[0].children).toHaveLength(2)
+            expect(children[1].iterationIndex).toBe(1)
+            expect(children[1].children).toHaveLength(1)
+        })
+
+        it('sorts virtual nodes by iterationIndex ascending', () => {
+            const parent = baseNode({ nodeId: 'loop' })
+            const iter2 = baseNode({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 2 })
+            const iter0 = baseNode({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter1 = baseNode({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 1 })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, iter2, iter0, iter1])))
+
+            const indices = result.current[0].children.map((c) => c.iterationIndex)
+            expect(indices).toEqual([0, 1, 2])
+        })
+
+        it('virtual node status matches last child in the iteration group', () => {
+            const parent = baseNode({ nodeId: 'loop' })
+            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'INPROGRESS' })
+            const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'ERROR' })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
+
+            expect(result.current[0].children[0].status).toBe('ERROR')
+        })
+
+        it('defaults iterationIndex to 0 when absent', () => {
+            const parent = baseNode({ nodeId: 'loop' })
+            const child = baseNode({ nodeId: 'c1', parentNodeId: 'loop' })
+            // no iterationIndex set
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, child])))
+
+            expect(result.current[0].children).toHaveLength(1)
+            expect(result.current[0].children[0].iterationIndex).toBe(0)
+        })
+
+        it('does not include iteration children as top-level nodes', () => {
+            const parent = baseNode({ nodeId: 'loop' })
+            const child = baseNode({ nodeId: 'child', parentNodeId: 'loop', iterationIndex: 0 })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, child])))
+
+            expect(result.current).toHaveLength(1)
+            expect(result.current[0].nodeId).toBe('loop')
+        })
+    })
+
+    describe('raw node reference', () => {
+        it('attaches the original NodeExecutionData as raw on leaf nodes', () => {
+            const node = baseNode({ nodeId: 'n1', nodeLabel: 'Step' })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            expect(result.current[0].raw).toMatchObject({ nodeId: 'n1', nodeLabel: 'Step' })
+        })
+
+        it('does not set raw on virtual iteration container nodes', () => {
+            const parent = baseNode({ nodeId: 'loop' })
+            const child = baseNode({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 0 })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, child])))
+
+            const virtualNode = result.current[0].children[0]
+            expect(virtualNode.raw).toBeUndefined()
+        })
+    })
+})

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.ts
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.ts
@@ -1,0 +1,85 @@
+import { useMemo } from 'react'
+
+import type { ExecutionTreeNode, NodeExecutionData } from '@/core/types'
+
+/**
+ * Builds a hierarchical ExecutionTreeNode[] from the flat NodeExecutionData[] stored in
+ * execution.executionData (JSON string). Handles:
+ *
+ * - Top-level nodes (no parentNodeId)
+ * - Iteration child nodes (parentNodeId set, grouped by iterationIndex)
+ * - Virtual iteration container nodes (synthesized to group iteration children)
+ *
+ * Mirrors the tree-building logic in OSS ExecutionDetails.jsx.
+ */
+export function useExecutionTree(executionDataJson: string | null): ExecutionTreeNode[] {
+    return useMemo(() => {
+        if (!executionDataJson) return []
+
+        let nodes: NodeExecutionData[]
+        try {
+            nodes = JSON.parse(executionDataJson) as NodeExecutionData[]
+        } catch {
+            console.error('[Observe] Failed to parse executionData JSON')
+            return []
+        }
+
+        if (!Array.isArray(nodes) || nodes.length === 0) return []
+
+        // Separate top-level nodes from iteration children
+        const topLevel = nodes.filter((n) => !n.parentNodeId)
+        const iterationChildren = nodes.filter((n) => !!n.parentNodeId)
+
+        // Group iteration children by parentNodeId, then by iterationIndex
+        const childrenByParent = new Map<string, Map<number, NodeExecutionData[]>>()
+        for (const child of iterationChildren) {
+            const parentId = child.parentNodeId!
+            const iterIdx = child.iterationIndex ?? 0
+
+            if (!childrenByParent.has(parentId)) {
+                childrenByParent.set(parentId, new Map())
+            }
+            const byIndex = childrenByParent.get(parentId)!
+            if (!byIndex.has(iterIdx)) {
+                byIndex.set(iterIdx, [])
+            }
+            byIndex.get(iterIdx)!.push(child)
+        }
+
+        function buildNode(n: NodeExecutionData): ExecutionTreeNode {
+            const treeNode: ExecutionTreeNode = {
+                id: `${n.nodeId}-${n.iterationIndex ?? 0}`,
+                nodeId: n.nodeId,
+                nodeLabel: n.nodeLabel,
+                status: n.status,
+                name: n.name,
+                iterationIndex: n.iterationIndex,
+                children: [],
+                raw: n
+            }
+
+            const childGroups = childrenByParent.get(n.nodeId)
+            if (childGroups && childGroups.size > 0) {
+                // Build a virtual container per iteration group
+                const sortedIterations = Array.from(childGroups.keys()).sort((a, b) => a - b)
+                treeNode.children = sortedIterations.map((iterIdx) => {
+                    const groupChildren = childGroups.get(iterIdx)!
+                    const virtualNode: ExecutionTreeNode = {
+                        id: `${n.nodeId}-iteration-${iterIdx}`,
+                        nodeId: `${n.nodeId}-iteration-${iterIdx}`,
+                        nodeLabel: `Iteration #${iterIdx + 1}`,
+                        status: groupChildren[groupChildren.length - 1]?.status ?? 'FINISHED',
+                        isVirtualNode: true,
+                        iterationIndex: iterIdx,
+                        children: groupChildren.map(buildNode)
+                    }
+                    return virtualNode
+                })
+            }
+
+            return treeNode
+        }
+
+        return topLevel.map(buildNode)
+    }, [executionDataJson])
+}

--- a/packages/observe/src/features/executions/index.ts
+++ b/packages/observe/src/features/executions/index.ts
@@ -1,0 +1,6 @@
+export { ExecutionDetail } from './components/ExecutionDetail'
+export { ExecutionsListTable } from './components/ExecutionsListTable'
+export { ExecutionsViewer } from './components/ExecutionsViewer'
+export { NodeExecutionDetail } from './components/NodeExecutionDetail'
+export { useExecutionPoll } from './hooks/useExecutionPoll'
+export { useExecutionTree } from './hooks/useExecutionTree'

--- a/packages/observe/src/index.ts
+++ b/packages/observe/src/index.ts
@@ -1,0 +1,40 @@
+// ===========================================
+// @flowiseai/observe — Public API
+// ===========================================
+
+// Root provider (required — wrap your app or page with this)
+export { ObserveProvider } from './infrastructure/store'
+
+// Executions feature
+export { ExecutionDetail, ExecutionsViewer } from './features/executions'
+
+// Advanced usage — individual sub-components
+export { ExecutionsListTable, NodeExecutionDetail } from './features/executions'
+
+// Hooks (for consumers building custom UIs on top of observe infrastructure)
+export { useExecutionPoll, useExecutionTree } from './features/executions'
+
+// Context hooks
+export { useObserveApi, useObserveConfig } from './infrastructure/store'
+
+// Types
+/* eslint-disable simple-import-sort/exports */
+export type {
+    // Execution domain
+    AgentflowRef,
+    Execution,
+    ExecutionDetailProps,
+    ExecutionFilters,
+    ExecutionListParams,
+    ExecutionListResponse,
+    ExecutionsViewerProps,
+    ExecutionState,
+    ExecutionTreeNode,
+    HumanInputParams,
+    NodeExecutionData,
+    NodeExecutionOutput,
+    ObserveBaseProps,
+    TimeMetadata,
+    UsageMetadata
+} from './core/types'
+/* eslint-enable simple-import-sort/exports */

--- a/packages/observe/src/infrastructure/api/client.ts
+++ b/packages/observe/src/infrastructure/api/client.ts
@@ -1,0 +1,59 @@
+import axios, { type AxiosInstance } from 'axios'
+
+import type { RequestInterceptor } from '@/core/types'
+
+/**
+ * Creates a configured axios instance for @flowiseai/observe API calls.
+ * All internal SDK calls (executions list, get by id, delete) use this client.
+ * The HITL prediction call is intentionally NOT made here — it is delegated to
+ * the consumer via the onHumanInput prop so routing can differ between OSS and DevSite.
+ *
+ * @param apiBaseUrl - Base URL of the Flowise server
+ * @param token - Optional API key — sets Authorization: Bearer header when provided
+ * @param requestInterceptor - Optional callback to customize outgoing requests.
+ *   Runs after the Bearer header is set, so it can extend or override auth headers.
+ */
+export function bindApiClient(apiBaseUrl: string, token?: string, requestInterceptor?: RequestInterceptor): AxiosInstance {
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json'
+    }
+
+    if (token) {
+        headers['Authorization'] = `Bearer ${token}`
+    }
+
+    const client = axios.create({
+        baseURL: `${apiBaseUrl}/api/v1`,
+        headers
+    })
+
+    client.interceptors.request.use(
+        (config) => {
+            if (!requestInterceptor) return config
+            try {
+                return requestInterceptor(config)
+            } catch (error) {
+                console.error('[Observe] requestInterceptor threw:', error)
+                return config
+            }
+        },
+        (error) => Promise.reject(error)
+    )
+
+    client.interceptors.response.use(
+        (response) => response,
+        (error) => {
+            if (error.response?.status === 401) {
+                console.error('[Observe] 401 Authentication error:', {
+                    url: error.config?.url,
+                    message: error.response?.data?.message || error.message,
+                    hasToken: !!token,
+                    hasInterceptor: !!requestInterceptor
+                })
+            }
+            return Promise.reject(error)
+        }
+    )
+
+    return client
+}

--- a/packages/observe/src/infrastructure/api/executions.test.ts
+++ b/packages/observe/src/infrastructure/api/executions.test.ts
@@ -1,0 +1,123 @@
+import type { AxiosInstance } from 'axios'
+
+import { createExecutionsApi } from './executions'
+
+const mockGet = jest.fn()
+const mockDelete = jest.fn()
+const mockPut = jest.fn()
+
+const mockClient = {
+    get: mockGet,
+    delete: mockDelete,
+    put: mockPut
+} as unknown as AxiosInstance
+
+describe('createExecutionsApi', () => {
+    let api: ReturnType<typeof createExecutionsApi>
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        api = createExecutionsApi(mockClient)
+    })
+
+    describe('getAllExecutions', () => {
+        it('always sends page and limit', async () => {
+            mockGet.mockResolvedValueOnce({ data: { data: [], total: 0 } })
+            await api.getAllExecutions({ page: 1, limit: 10 })
+            expect(mockGet).toHaveBeenCalledWith('/executions', { params: { page: 1, limit: 10 } })
+        })
+
+        it('includes optional params when provided', async () => {
+            mockGet.mockResolvedValueOnce({ data: { data: [], total: 0 } })
+            await api.getAllExecutions({
+                page: 2,
+                limit: 25,
+                state: 'FINISHED',
+                agentflowId: 'af-123',
+                agentflowName: 'My Flow',
+                sessionId: 'sess-abc'
+            })
+            expect(mockGet).toHaveBeenCalledWith('/executions', {
+                params: expect.objectContaining({
+                    state: 'FINISHED',
+                    agentflowId: 'af-123',
+                    agentflowName: 'My Flow',
+                    sessionId: 'sess-abc'
+                })
+            })
+        })
+
+        it('omits undefined optional params', async () => {
+            mockGet.mockResolvedValueOnce({ data: { data: [], total: 0 } })
+            await api.getAllExecutions({ page: 1, limit: 10 })
+            const { params } = mockGet.mock.calls[0][1]
+            expect(params).not.toHaveProperty('state')
+            expect(params).not.toHaveProperty('agentflowId')
+            expect(params).not.toHaveProperty('agentflowName')
+            expect(params).not.toHaveProperty('sessionId')
+            expect(params).not.toHaveProperty('startDate')
+            expect(params).not.toHaveProperty('endDate')
+        })
+
+        it('serialises startDate and endDate to ISO strings', async () => {
+            mockGet.mockResolvedValueOnce({ data: { data: [], total: 0 } })
+            const startDate = new Date('2024-01-01T00:00:00.000Z')
+            const endDate = new Date('2024-01-31T23:59:59.000Z')
+            await api.getAllExecutions({ page: 1, limit: 10, startDate, endDate })
+            const { params } = mockGet.mock.calls[0][1]
+            expect(params.startDate).toBe('2024-01-01T00:00:00.000Z')
+            expect(params.endDate).toBe('2024-01-31T23:59:59.000Z')
+        })
+
+        it('returns response.data', async () => {
+            const expected = { data: [{ id: 'exec-1' }], total: 1 }
+            mockGet.mockResolvedValueOnce({ data: expected })
+            const result = await api.getAllExecutions({ page: 1, limit: 10 })
+            expect(result).toBe(expected)
+        })
+    })
+
+    describe('getExecutionById', () => {
+        it('calls GET /executions/:id', async () => {
+            mockGet.mockResolvedValueOnce({ data: { id: 'exec-1' } })
+            await api.getExecutionById('exec-1')
+            expect(mockGet).toHaveBeenCalledWith('/executions/exec-1')
+        })
+
+        it('returns response.data', async () => {
+            const expected = { id: 'exec-1', state: 'FINISHED' }
+            mockGet.mockResolvedValueOnce({ data: expected })
+            const result = await api.getExecutionById('exec-1')
+            expect(result).toBe(expected)
+        })
+    })
+
+    describe('deleteExecutions', () => {
+        it('calls DELETE /executions with executionIds in request body', async () => {
+            mockDelete.mockResolvedValueOnce({})
+            await api.deleteExecutions(['id-1', 'id-2'])
+            expect(mockDelete).toHaveBeenCalledWith('/executions', { data: { executionIds: ['id-1', 'id-2'] } })
+        })
+
+        it('works with a single id', async () => {
+            mockDelete.mockResolvedValueOnce({})
+            await api.deleteExecutions(['id-1'])
+            expect(mockDelete).toHaveBeenCalledWith('/executions', { data: { executionIds: ['id-1'] } })
+        })
+    })
+
+    describe('updateExecution', () => {
+        it('calls PUT /executions/:id with payload', async () => {
+            mockPut.mockResolvedValueOnce({ data: { id: 'exec-1', isPublic: true } })
+            await api.updateExecution('exec-1', { isPublic: true })
+            expect(mockPut).toHaveBeenCalledWith('/executions/exec-1', { isPublic: true })
+        })
+
+        it('returns response.data', async () => {
+            const expected = { id: 'exec-1', isPublic: false }
+            mockPut.mockResolvedValueOnce({ data: expected })
+            const result = await api.updateExecution('exec-1', { isPublic: false })
+            expect(result).toBe(expected)
+        })
+    })
+})

--- a/packages/observe/src/infrastructure/api/executions.ts
+++ b/packages/observe/src/infrastructure/api/executions.ts
@@ -1,0 +1,44 @@
+import type { AxiosInstance } from 'axios'
+
+import type { Execution, ExecutionListParams, ExecutionListResponse } from '@/core/types'
+
+export function createExecutionsApi(client: AxiosInstance) {
+    return {
+        /**
+         * List executions with optional filters and pagination.
+         * When agentflowId is provided this returns a scoped view (M1).
+         * Without agentflowId it returns the full cross-agent list (M2).
+         */
+        getAllExecutions: async (params: ExecutionListParams): Promise<ExecutionListResponse> => {
+            const query: Record<string, unknown> = {
+                page: params.page,
+                limit: params.limit
+            }
+            if (params.state) query.state = params.state
+            if (params.agentflowId) query.agentflowId = params.agentflowId
+            if (params.agentflowName) query.agentflowName = params.agentflowName
+            if (params.sessionId) query.sessionId = params.sessionId
+            if (params.startDate) query.startDate = params.startDate.toISOString()
+            if (params.endDate) query.endDate = params.endDate.toISOString()
+
+            const response = await client.get<ExecutionListResponse>('/executions', { params: query })
+            return response.data
+        },
+
+        getExecutionById: async (executionId: string): Promise<Execution> => {
+            const response = await client.get<Execution>(`/executions/${executionId}`)
+            return response.data
+        },
+
+        deleteExecutions: async (executionIds: string[]): Promise<void> => {
+            await client.delete('/executions', { data: { executionIds } })
+        },
+
+        updateExecution: async (executionId: string, payload: { isPublic: boolean }): Promise<Execution> => {
+            const response = await client.put<Execution>(`/executions/${executionId}`, payload)
+            return response.data
+        }
+    }
+}
+
+export type ExecutionsApi = ReturnType<typeof createExecutionsApi>

--- a/packages/observe/src/infrastructure/api/index.ts
+++ b/packages/observe/src/infrastructure/api/index.ts
@@ -1,0 +1,3 @@
+export { bindApiClient } from './client'
+export type { ExecutionsApi } from './executions'
+export { createExecutionsApi } from './executions'

--- a/packages/observe/src/infrastructure/store/ObserveContext.test.tsx
+++ b/packages/observe/src/infrastructure/store/ObserveContext.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import { renderHook } from '@testing-library/react'
+
+import { ObserveProvider, useObserveApi, useObserveConfig } from './ObserveContext'
+
+jest.mock('axios')
+
+const wrapper = (isDarkMode?: boolean) => {
+    function Wrapper({ children }: { children: React.ReactNode }) {
+        return (
+            <ObserveProvider apiBaseUrl='http://localhost:3000' token='test-token' isDarkMode={isDarkMode}>
+                {children}
+            </ObserveProvider>
+        )
+    }
+    return Wrapper
+}
+
+describe('useObserveApi', () => {
+    it('provides an executions API with all four methods', () => {
+        const { result } = renderHook(() => useObserveApi(), { wrapper: wrapper() })
+        const { executions } = result.current
+        expect(typeof executions.getAllExecutions).toBe('function')
+        expect(typeof executions.getExecutionById).toBe('function')
+        expect(typeof executions.deleteExecutions).toBe('function')
+        expect(typeof executions.updateExecution).toBe('function')
+    })
+
+    it('throws when called outside ObserveProvider', () => {
+        expect(() => renderHook(() => useObserveApi())).toThrow('useObserveApi must be used inside ObserveProvider')
+    })
+})
+
+describe('useObserveConfig', () => {
+    it('returns isDarkMode: false by default', () => {
+        const { result } = renderHook(() => useObserveConfig(), { wrapper: wrapper() })
+        expect(result.current.isDarkMode).toBe(false)
+    })
+
+    it('returns isDarkMode: true when prop is true', () => {
+        const { result } = renderHook(() => useObserveConfig(), { wrapper: wrapper(true) })
+        expect(result.current.isDarkMode).toBe(true)
+    })
+})

--- a/packages/observe/src/infrastructure/store/ObserveContext.test.tsx
+++ b/packages/observe/src/infrastructure/store/ObserveContext.test.tsx
@@ -17,29 +17,33 @@ const wrapper = (isDarkMode?: boolean) => {
     return Wrapper
 }
 
-describe('useObserveApi', () => {
-    it('provides an executions API with all four methods', () => {
-        const { result } = renderHook(() => useObserveApi(), { wrapper: wrapper() })
-        const { executions } = result.current
-        expect(typeof executions.getAllExecutions).toBe('function')
-        expect(typeof executions.getExecutionById).toBe('function')
-        expect(typeof executions.deleteExecutions).toBe('function')
-        expect(typeof executions.updateExecution).toBe('function')
+describe('ObserveContext', () => {
+    describe('useObserveApi', () => {
+        it('provides an executions API with all four methods', () => {
+            const { result } = renderHook(() => useObserveApi(), { wrapper: wrapper() })
+            const { executions } = result.current
+            expect(typeof executions.getAllExecutions).toBe('function')
+            expect(typeof executions.getExecutionById).toBe('function')
+            expect(typeof executions.deleteExecutions).toBe('function')
+            expect(typeof executions.updateExecution).toBe('function')
+        })
+
+        it('throws when called outside ObserveProvider', () => {
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+            expect(() => renderHook(() => useObserveApi())).toThrow('useObserveApi must be used inside ObserveProvider')
+            consoleError.mockRestore()
+        })
     })
 
-    it('throws when called outside ObserveProvider', () => {
-        expect(() => renderHook(() => useObserveApi())).toThrow('useObserveApi must be used inside ObserveProvider')
-    })
-})
+    describe('useObserveConfig', () => {
+        it('returns isDarkMode: false by default', () => {
+            const { result } = renderHook(() => useObserveConfig(), { wrapper: wrapper() })
+            expect(result.current.isDarkMode).toBe(false)
+        })
 
-describe('useObserveConfig', () => {
-    it('returns isDarkMode: false by default', () => {
-        const { result } = renderHook(() => useObserveConfig(), { wrapper: wrapper() })
-        expect(result.current.isDarkMode).toBe(false)
-    })
-
-    it('returns isDarkMode: true when prop is true', () => {
-        const { result } = renderHook(() => useObserveConfig(), { wrapper: wrapper(true) })
-        expect(result.current.isDarkMode).toBe(true)
+        it('returns isDarkMode: true when prop is true', () => {
+            const { result } = renderHook(() => useObserveConfig(), { wrapper: wrapper(true) })
+            expect(result.current.isDarkMode).toBe(true)
+        })
     })
 })

--- a/packages/observe/src/infrastructure/store/ObserveContext.tsx
+++ b/packages/observe/src/infrastructure/store/ObserveContext.tsx
@@ -1,0 +1,68 @@
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+
+import { createObserveTheme } from '@/core/theme'
+import type { RequestInterceptor } from '@/core/types'
+import { bindApiClient, createExecutionsApi, type ExecutionsApi } from '@/infrastructure/api'
+
+// ============================================================================
+// API Context — provides initialized API modules to all observe components
+// ============================================================================
+
+interface ObserveApiContextValue {
+    executions: ExecutionsApi
+}
+
+const ObserveApiContext = createContext<ObserveApiContextValue | null>(null)
+
+export function useObserveApi(): ObserveApiContextValue {
+    const ctx = useContext(ObserveApiContext)
+    if (!ctx) throw new Error('useObserveApi must be used inside ObserveProvider')
+    return ctx
+}
+
+// ============================================================================
+// Config Context — provides shared config (dark mode, etc.)
+// ============================================================================
+
+interface ObserveConfigContextValue {
+    isDarkMode: boolean
+}
+
+const ObserveConfigContext = createContext<ObserveConfigContextValue>({ isDarkMode: false })
+
+export function useObserveConfig(): ObserveConfigContextValue {
+    return useContext(ObserveConfigContext)
+}
+
+// ============================================================================
+// ObserveProvider — root provider for all observe components
+// ============================================================================
+
+interface ObserveProviderProps {
+    apiBaseUrl: string
+    token?: string
+    requestInterceptor?: RequestInterceptor
+    isDarkMode?: boolean
+    children: ReactNode
+}
+
+export function ObserveProvider({ apiBaseUrl, token, requestInterceptor, isDarkMode = false, children }: ObserveProviderProps) {
+    const theme = useMemo(() => createObserveTheme(isDarkMode), [isDarkMode])
+
+    const api = useMemo(() => {
+        const client = bindApiClient(apiBaseUrl, token, requestInterceptor)
+        return { executions: createExecutionsApi(client) }
+    }, [apiBaseUrl, token, requestInterceptor])
+
+    const config = useMemo(() => ({ isDarkMode }), [isDarkMode])
+
+    return (
+        <ThemeProvider theme={theme}>
+            <ObserveApiContext.Provider value={api}>
+                <ObserveConfigContext.Provider value={config}>{children}</ObserveConfigContext.Provider>
+            </ObserveApiContext.Provider>
+        </ThemeProvider>
+    )
+}

--- a/packages/observe/src/infrastructure/store/index.ts
+++ b/packages/observe/src/infrastructure/store/index.ts
@@ -1,0 +1,1 @@
+export { ObserveProvider, useObserveApi, useObserveConfig } from './ObserveContext'

--- a/packages/observe/tsconfig.json
+++ b/packages/observe/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "noEmit": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "declaration": true,
+        "declarationMap": true,
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./src/*"],
+            "@test-utils/*": ["./src/__test_utils__/*"]
+        }
+    },
+    "include": ["src"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/observe/vite.config.ts
+++ b/packages/observe/vite.config.ts
@@ -1,0 +1,63 @@
+import { resolve } from 'path'
+
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig(({ mode }) => {
+    const isDev = mode === 'development'
+
+    return {
+        plugins: [
+            react(),
+            dts({
+                insertTypesEntry: true,
+                include: ['src/**/*'],
+                exclude: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/__*__/**']
+            })
+        ],
+        resolve: {
+            alias: {
+                '@': resolve(__dirname, 'src')
+            }
+        },
+        build: {
+            lib: {
+                entry: resolve(__dirname, 'src/index.ts'),
+                name: 'FlowiseObserve',
+                formats: ['es', 'umd'],
+                fileName: (format) => `index.${format === 'es' ? 'js' : 'umd.js'}`
+            },
+            rollupOptions: {
+                external: [
+                    'react',
+                    'react-dom',
+                    'react/jsx-runtime',
+                    '@mui/material',
+                    '@mui/material/styles',
+                    '@mui/icons-material',
+                    '@emotion/react',
+                    '@emotion/styled'
+                ],
+                output: {
+                    globals: {
+                        react: 'React',
+                        'react-dom': 'ReactDOM',
+                        'react/jsx-runtime': 'jsxRuntime',
+                        '@mui/material': 'MaterialUI',
+                        '@mui/material/styles': 'MaterialUIStyles',
+                        '@mui/icons-material': 'MaterialUIIcons',
+                        '@emotion/react': 'emotionReact',
+                        '@emotion/styled': 'emotionStyled'
+                    },
+                    assetFileNames: (assetInfo) => {
+                        if (assetInfo.name === 'style.css') return 'observe.css'
+                        return assetInfo.name || 'asset'
+                    }
+                }
+            },
+            cssCodeSplit: false,
+            sourcemap: isDev ? true : false
+        }
+    }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,6 +805,115 @@ importers:
         specifier: ^5.4.5
         version: 5.5.2
 
+  packages/observe:
+    dependencies:
+      '@emotion/react':
+        specifier: ^11.10.0
+        version: 11.11.4(@types/react@18.2.65)(react@18.2.0)
+      '@emotion/styled':
+        specifier: ^11.10.0
+        version: 11.11.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react@18.2.0)
+      '@mui/icons-material':
+        specifier: ^5.0.0
+        version: 5.0.3(@mui/material@5.15.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.65)(react@18.2.0)
+      '@mui/material':
+        specifier: ^5.15.0
+        version: 5.15.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tabler/icons-react':
+        specifier: ^3.7.0
+        version: 3.31.0(react@18.2.0)
+      axios:
+        specifier: 1.12.0
+        version: 1.12.0(debug@4.3.4)
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
+      flowise-react-json-view:
+        specifier: ^1.21.7
+        version: 1.21.7(@types/react@18.2.65)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+      react-markdown:
+        specifier: ^9.0.1
+        version: 9.1.0(@types/react@18.2.65)(react@18.2.0)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.1
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@9.3.4)
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/lodash':
+        specifier: ^4.14.195
+        version: 4.17.20
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.2.65
+      '@types/react-dom':
+        specifier: ^18.2.0
+        version: 18.2.21
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.18.2
+        version: 8.55.0(@typescript-eslint/parser@8.55.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.18.2
+        version: 8.55.0(eslint@8.57.0)(typescript@5.5.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.2.1(vite@5.1.6(@types/node@22.16.3)(sass@1.71.1)(terser@5.29.1))
+      eslint-import-resolver-typescript:
+        specifier: 4.4.4
+        version: 4.4.4(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import:
+        specifier: ^2.29.0
+        version: 2.29.1(@typescript-eslint/parser@8.55.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.0)
+      eslint-plugin-markdown:
+        specifier: ^3.0.1
+        version: 3.0.1(eslint@8.57.0)
+      eslint-plugin-simple-import-sort:
+        specifier: ^12.0.0
+        version: 12.1.1(eslint@8.57.0)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.16.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2))
+      jest-environment-jsdom:
+        specifier: ^29.7.0
+        version: 29.7.0(bufferutil@4.0.8)(canvas@2.11.2(encoding@0.1.13))(utf-8-validate@6.0.4)
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.5
+      ts-jest:
+        specifier: ^29.3.2
+        version: 29.3.2(@babel/core@7.24.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.0))(jest@29.7.0(@types/node@22.16.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2)))(typescript@5.5.2)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.5.2
+      vite:
+        specifier: ^5.0.2
+        version: 5.1.6(@types/node@22.16.3)(sass@1.71.1)(terser@5.29.1)
+      vite-plugin-dts:
+        specifier: ^3.7.0
+        version: 3.9.1(@types/node@22.16.3)(rollup@4.45.0)(typescript@5.5.2)(vite@5.1.6(@types/node@22.16.3)(sass@1.71.1)(terser@5.29.1))
+
   packages/server:
     dependencies:
       '@aws-sdk/client-secrets-manager':
@@ -1278,10 +1387,10 @@ importers:
         version: 16.4.5
       flowise-embed:
         specifier: latest
-        version: 3.1.2
+        version: 3.1.5
       flowise-embed-react:
         specifier: latest
-        version: 3.1.2(@types/node@22.16.3)(flowise-embed@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
+        version: 3.1.5(@types/node@22.16.3)(flowise-embed@3.1.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
       flowise-react-json-view:
         specifier: '*'
         version: 1.21.7(@types/react@18.2.65)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -4429,79 +4538,67 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -6307,35 +6404,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.73':
     resolution: {integrity: sha512-lX0z2bNmnk1PGZ+0a9OZwI2lPPvWjRYzPqvEitXX7lspyLFrOzh2kcQiLL7bhyODN23QvfriqwYqp5GreSzVvA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.73':
     resolution: {integrity: sha512-QDQgMElwxAoADsSR3UYvdTTQk5XOyD9J5kq15Z8XpGwpZOZsSE0zZ/X1JaOtS2x+HEZL6z1S6MF/1uhZFZb5ig==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.73':
     resolution: {integrity: sha512-wbzLJrTalQrpyrU1YRrO6w6pdr5vcebbJa+Aut5QfTaW9eEmMb1WFG6l1V+cCa5LdHmRr8bsvl0nJDU/IYDsmw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.73':
     resolution: {integrity: sha512-xbfhYrUufoTAKvsEx2ZUN4jvACabIF0h1F5Ik1Rk4e/kQq6c+Dwa5QF0bGrfLhceLpzHT0pCMGMDeQKQrcUIyA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-x64-msvc@0.1.73':
     resolution: {integrity: sha512-YQmHXBufFBdWqhx+ympeTPkMfs3RNxaOgWm59vyjpsub7Us07BwCcmu1N5kildhO8Fm0syoI2kHnzGkJBLSvsg==}
@@ -7200,67 +7292,56 @@ packages:
     resolution: {integrity: sha512-hLrmRl53prCcD+YXTfNvXd776HTxNh8wPAMllusQ+amcQmtgo3V5i/nkhPN6FakW+QVLoUUr2AsbtIRPFU3xIA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.0':
     resolution: {integrity: sha512-XBKGSYcrkdiRRjl+8XvrUR3AosXU0NvF7VuqMsm7s5nRy+nt58ZMB19Jdp1RdqewLcaYnpk8zeVs/4MlLZEJxw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.0':
     resolution: {integrity: sha512-fRvZZPUiBz7NztBE/2QnCS5AtqLVhXmUOPj9IHlfGEXkapgImf4W9+FSkL8cWqoAjozyUzqFmSc4zh2ooaeF6g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.0':
     resolution: {integrity: sha512-Btv2WRZOcUGi8XU80XwIvzTg4U6+l6D0V6sZTrZx214nrwxw5nAi8hysaXj/mctyClWgesyuxbeLylCBNauimg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.0':
     resolution: {integrity: sha512-Li0emNnwtUZdLwHjQPBxn4VWztcrw/h7mgLyHiEI5Z0MhpeFGlzaiBHpSNVOMB/xucjXTTcO+dhv469Djr16KA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.0':
     resolution: {integrity: sha512-sB8+pfkYx2kvpDCfd63d5ScYT0Fz1LO6jIb2zLZvmK9ob2D8DeVqrmBDE0iDK8KlBVmsTNzrjr3G1xV4eUZhSw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.0':
     resolution: {integrity: sha512-5GQ6PFhh7E6jQm70p1aW05G2cap5zMOvO0se5JMecHeAdj5ZhWEHbJ4hiKpfi1nnnEdTauDXxPgXae/mqjow9w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.0':
     resolution: {integrity: sha512-N/euLsBd1rekWcuduakTo/dJw6U6sBP3eUq+RXM9RNfPuWTvG2w/WObDkIvJ2KChy6oxZmOSC08Ak2OJA0UiAA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.0':
     resolution: {integrity: sha512-2l9sA7d7QdikL0xQwNMO3xURBUNEWyHVHfAsHsUdq+E/pgLTUcCE+gih5PCdmyHmfTDeXUWVhqL0WZzg0nua3g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.0':
     resolution: {integrity: sha512-XZdD3fEEQcwG2KrJDdEQu7NrHonPxxaV0/w2HpvINBdcqebz1aL+0vM2WFJq4DeiAVT6F5SUQas65HY5JDqoPw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.0':
     resolution: {integrity: sha512-7ayfgvtmmWgKWBkCGg5+xTQ0r5V1owVm67zTrsEY1008L5ro7mCyGYORomARt/OquB9KY7LpxVBZes+oSniAAQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.0':
     resolution: {integrity: sha512-B+IJgcBnE2bm93jEW5kHisqvPITs4ddLOROAcOc/diBgrEiQJJ6Qcjby75rFSmH5eMGrqJryUgJDhrfj942apQ==}
@@ -8244,28 +8325,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.4.6':
     resolution: {integrity: sha512-LGQsKJ8MA9zZ8xHCkbGkcPSmpkZL2O7drvwsGKynyCttHhpwVjj9lguhD4DWU3+FWIsjvho5Vu0Ggei8OYi/Lw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.4.6':
     resolution: {integrity: sha512-10JL2nLIreMQDKvq2TECnQe5fCuoqBHu1yW8aChqgHUyg9d7gfZX/kppUsuimqcgRBnS0AjTDAA+JF6UsG/2Yg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.4.6':
     resolution: {integrity: sha512-EGyjFVzVY6Do89x8sfah7I3cuP4MwtwzmA6OlfD/KASqfCFf5eIaEBMbajgR41bVfMV7lK72lwAIea5xEyq1AQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.4.6':
     resolution: {integrity: sha512-gfW9AuXvwSyK07Vb8Y8E9m2oJZk21WqcD+X4BZhkbKB0TCZK0zk1j/HpS2UFlr1JB2zPKPpSWLU3ll0GEHRG2A==}
@@ -8736,6 +8813,9 @@ packages:
 
   '@types/eslint@8.56.5':
     resolution: {integrity: sha512-u5/YPJHo1tvkSF2CE0USEkxon82Z5DBy2xR+qfyYNszpX9qcs4sT6uq2kBbj4BXY1+DBGDPnrhMZV3pKWGNukw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@0.0.39':
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
@@ -9356,49 +9436,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -10520,8 +10592,14 @@ packages:
     resolution: {integrity: sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==}
     engines: {node: '>=12.20'}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
   character-entities-legacy@1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   character-entities@1.2.4:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
@@ -10531,6 +10609,9 @@ packages:
 
   character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
@@ -10578,14 +10659,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   chromadb-js-bindings-linux-x64-gnu@1.1.1:
     resolution: {integrity: sha512-RcvBcECbUcFXlFM2httdGc+3wmkI76tD9iGS0H9npEhz4LyLvdXKBK8CZtw67hsHCH09KklKw4ITkSS85pHVbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   chromadb-js-bindings-win32-x64-msvc@1.1.1:
     resolution: {integrity: sha512-296SxWNwsmvP+1Ggkl72norTFLOivoXhGu0t5mXNIbd7yd2UodntvAvG2cheTHDCL/ILbox4u+6KHNvRxHgm6A==}
@@ -11385,6 +11464,9 @@ packages:
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
+
+  date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
@@ -12233,6 +12315,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
 
@@ -12627,14 +12712,14 @@ packages:
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
-  flowise-embed-react@3.1.2:
-    resolution: {integrity: sha512-ugzG31lKAw1hX5oAQ3R8MLff+jFpAYtL55yCUEz4VVN4hgI0c4qsatCWl4WM21xvTJ7SONxxFBzxUawwaG1VoQ==}
+  flowise-embed-react@3.1.5:
+    resolution: {integrity: sha512-rOjUy5iZdlhyd2/7U3wYdFOQKSFWq+wPJdVTrP5XeFjlGFdpCzM+uzaID3Uw+hHWIqlFYUIT5DeP/6eIvPeBmg==}
     peerDependencies:
       flowise-embed: '*'
       react: 18.x
 
-  flowise-embed@3.1.2:
-    resolution: {integrity: sha512-Uo7cqTHUy5Oz93LPy10kiTWpmKL39aJVe6NNKiKSfjajaql2tpS6GBiKv0dTCsOyssbPziCRUCuagOmt4kwYWg==}
+  flowise-embed@3.1.5:
+    resolution: {integrity: sha512-A7VJMLhsLVLl4eyRJlQn2Oqm5hQz8DmY+iSPuK5u/MiQ7Jip9W60gFO6NMTTJ8Xm9JbVx0QkajGOCQDW88hpWw==}
 
   flowise-nim-container-manager@1.0.11:
     resolution: {integrity: sha512-Er/leiIzJZ691kWqXkjCWv29g0G5qWA4juBOcGZ1P5kBLnkKFxbWc5x8JsSPcHuJQIiGNX/dYEzp2ZrOV3YYMg==}
@@ -13242,6 +13327,9 @@ packages:
   hast-util-raw@9.0.2:
     resolution: {integrity: sha512-PldBy71wO9Uq1kyaMch9AHIghtQvIwxBUkv823pKmkTM3oV1JxtsTNYdevMxvUHqcnOAuO65JKU2+0NOxc2ksA==}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
   hast-util-to-parse5@8.0.0:
     resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
 
@@ -13250,6 +13338,9 @@ packages:
 
   hast-util-whitespace@2.0.1:
     resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   hastscript@6.0.0:
     resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
@@ -13341,6 +13432,9 @@ packages:
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -13618,8 +13712,14 @@ packages:
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
   is-alphanumerical@1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-arguments@1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
@@ -13706,6 +13806,9 @@ packages:
   is-decimal@1.0.4:
     resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-descriptor@0.1.7:
     resolution: {integrity: sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==}
     engines: {node: '>= 0.4'}
@@ -13765,6 +13868,9 @@ packages:
 
   is-hexadecimal@1.0.4:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-installed-globally@0.4.0:
     resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
@@ -15099,35 +15205,71 @@ packages:
   mdast-util-find-and-replace@2.2.2:
     resolution: {integrity: sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
 
   mdast-util-from-markdown@1.3.1:
     resolution: {integrity: sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
   mdast-util-gfm-autolink-literal@1.0.3:
     resolution: {integrity: sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
 
   mdast-util-gfm-footnote@1.0.2:
     resolution: {integrity: sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==}
 
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
   mdast-util-gfm-strikethrough@1.0.3:
     resolution: {integrity: sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
 
   mdast-util-gfm-table@1.0.7:
     resolution: {integrity: sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==}
 
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
   mdast-util-gfm-task-list-item@1.0.2:
     resolution: {integrity: sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
 
   mdast-util-gfm@2.0.2:
     resolution: {integrity: sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==}
 
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
   mdast-util-math@2.0.2:
     resolution: {integrity: sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==}
 
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
   mdast-util-phrasing@3.0.1:
     resolution: {integrity: sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
   mdast-util-to-hast@12.3.0:
     resolution: {integrity: sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==}
@@ -15138,11 +15280,17 @@ packages:
   mdast-util-to-markdown@1.5.0:
     resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
 
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
   mdast-util-to-string@2.0.0:
     resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
 
   mdast-util-to-string@3.2.0:
     resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -15227,26 +15375,50 @@ packages:
   micromark-core-commonmark@1.1.0:
     resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
 
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
   micromark-extension-gfm-autolink-literal@1.0.5:
     resolution: {integrity: sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
 
   micromark-extension-gfm-footnote@1.1.2:
     resolution: {integrity: sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==}
 
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
   micromark-extension-gfm-strikethrough@1.0.7:
     resolution: {integrity: sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
 
   micromark-extension-gfm-table@1.0.7:
     resolution: {integrity: sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==}
 
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
   micromark-extension-gfm-tagfilter@1.0.2:
     resolution: {integrity: sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
 
   micromark-extension-gfm-task-list-item@1.0.5:
     resolution: {integrity: sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==}
 
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
   micromark-extension-gfm@2.0.3:
     resolution: {integrity: sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-extension-math@2.1.2:
     resolution: {integrity: sha512-es0CcOV89VNS9wFmyn+wyFTKweXGW4CEvdaAca6SWRWPyYCbBisnjaHLjWO4Nszuiud84jCpkHsqAJoa768Pvg==}
@@ -15254,17 +15426,32 @@ packages:
   micromark-factory-destination@1.1.0:
     resolution: {integrity: sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==}
 
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
   micromark-factory-label@1.1.0:
     resolution: {integrity: sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
 
   micromark-factory-space@1.1.0:
     resolution: {integrity: sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==}
 
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
   micromark-factory-title@1.1.0:
     resolution: {integrity: sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==}
 
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
   micromark-factory-whitespace@1.1.0:
     resolution: {integrity: sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
 
   micromark-util-character@1.2.0:
     resolution: {integrity: sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==}
@@ -15275,17 +15462,32 @@ packages:
   micromark-util-chunked@1.1.0:
     resolution: {integrity: sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==}
 
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
   micromark-util-classify-character@1.1.0:
     resolution: {integrity: sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
 
   micromark-util-combine-extensions@1.1.0:
     resolution: {integrity: sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==}
 
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
   micromark-util-decode-numeric-character-reference@1.1.0:
     resolution: {integrity: sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==}
 
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
   micromark-util-decode-string@1.1.0:
     resolution: {integrity: sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@1.1.0:
     resolution: {integrity: sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==}
@@ -15296,11 +15498,20 @@ packages:
   micromark-util-html-tag-name@1.2.0:
     resolution: {integrity: sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==}
 
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
   micromark-util-normalize-identifier@1.1.0:
     resolution: {integrity: sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==}
 
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
   micromark-util-resolve-all@1.1.0:
     resolution: {integrity: sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
 
   micromark-util-sanitize-uri@1.2.0:
     resolution: {integrity: sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==}
@@ -15310,6 +15521,9 @@ packages:
 
   micromark-util-subtokenize@1.1.0:
     resolution: {integrity: sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
 
   micromark-util-symbol@1.1.0:
     resolution: {integrity: sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==}
@@ -15328,6 +15542,9 @@ packages:
 
   micromark@3.2.0:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@3.1.10:
     resolution: {integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==}
@@ -15414,10 +15631,6 @@ packages:
   minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
-
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.4:
     resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
@@ -15947,6 +16160,9 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  object-inspect@1.13.1:
+    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -16216,6 +16432,9 @@ packages:
 
   parse-entities@2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse-filepath@1.0.2:
     resolution: {integrity: sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==}
@@ -16516,10 +16735,6 @@ packages:
   picomatch@3.0.1:
     resolution: {integrity: sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==}
     engines: {node: '>=10'}
-
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
@@ -17021,10 +17236,6 @@ packages:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.4.39:
-    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -17187,6 +17398,9 @@ packages:
 
   property-information@6.4.1:
     resolution: {integrity: sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   prosemirror-changeset@2.3.0:
     resolution: {integrity: sha512-8wRKhlEwEJ4I13Ju54q2NZR1pVKGTgJ/8XsQ8L5A5uUsQ/YQScQJuEAuh8Bn8i6IwAMjjLRABd9lVli+DlIiVw==}
@@ -17518,6 +17732,12 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  react-markdown@9.1.0:
+    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-onclickoutside@6.13.0:
     resolution: {integrity: sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==}
     peerDependencies:
@@ -17794,14 +18014,26 @@ packages:
   remark-gfm@3.0.1:
     resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-math@5.1.1:
     resolution: {integrity: sha512-cE5T2R/xLVtfFI4cCePtiRn+e6jKMtFDR3P8V3qpv8wpKjwvHoBA4eJzvX+nVrnlNy0911bdGmuspCSwetfYHw==}
 
   remark-parse@10.0.2:
     resolution: {integrity: sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==}
 
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
   remark-rehype@10.1.0:
     resolution: {integrity: sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   remove-bom-buffer@3.0.0:
     resolution: {integrity: sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==}
@@ -18312,6 +18544,10 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
+  side-channel@1.0.6:
+    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
+    engines: {node: '>= 0.4'}
+
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
@@ -18594,10 +18830,6 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
-  stop-iteration-iterator@1.0.0:
-    resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
-    engines: {node: '>= 0.4'}
-
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -18708,6 +18940,9 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   stringify-object@3.3.0:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
@@ -19577,6 +19812,9 @@ packages:
 
   unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
   union-value@1.0.1:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
@@ -23621,7 +23859,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.7.1
@@ -24567,7 +24805,7 @@ snapshots:
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.24.0)':
     dependencies:
       '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.24.0)':
     dependencies:
@@ -28966,7 +29204,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.45.0
 
@@ -30618,7 +30856,7 @@ snapshots:
   '@testing-library/jest-dom@6.9.1':
     dependencies:
       '@adobe/css-tools': 4.4.4
-      aria-query: 5.3.0
+      aria-query: 5.3.2
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
@@ -31089,6 +31327,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@0.0.39': {}
 
@@ -31571,7 +31813,7 @@ snapshots:
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
-      '@eslint-community/regexpp': 4.10.0
+      '@eslint-community/regexpp': 4.12.2
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.5.2)
@@ -31735,7 +31977,7 @@ snapshots:
 
   '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
@@ -32482,9 +32724,9 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       es-array-method-boxes-properly: 1.0.0
-      is-string: 1.0.7
+      is-string: 1.1.1
 
   array.prototype.findlast@1.2.4:
     dependencies:
@@ -32496,33 +32738,33 @@ snapshots:
 
   array.prototype.findlastindex@1.2.4:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       es-shim-unscopables: 1.0.2
 
   array.prototype.flat@1.3.2:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       es-shim-unscopables: 1.0.2
 
   array.prototype.flatmap@1.3.2:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       es-shim-unscopables: 1.0.2
 
   array.prototype.reduce@1.0.6:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       es-array-method-boxes-properly: 1.0.0
-      is-string: 1.0.7
+      is-string: 1.1.1
 
   array.prototype.toreversed@1.1.2:
     dependencies:
@@ -32544,7 +32786,7 @@ snapshots:
       array-buffer-byte-length: 1.0.1
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.4
@@ -33276,13 +33518,19 @@ snapshots:
 
   char-regex@2.0.1: {}
 
+  character-entities-html4@2.1.0: {}
+
   character-entities-legacy@1.1.4: {}
+
+  character-entities-legacy@3.0.0: {}
 
   character-entities@1.2.4: {}
 
   character-entities@2.0.2: {}
 
   character-reference-invalid@1.1.4: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@0.7.0: {}
 
@@ -33953,9 +34201,9 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-declaration-sorter@6.4.1(postcss@8.4.39):
+  css-declaration-sorter@6.4.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
   css-has-pseudo@3.0.4(postcss@8.4.35):
     dependencies:
@@ -33964,12 +34212,12 @@ snapshots:
 
   css-loader@6.10.0(webpack@5.90.3(@swc/core@1.4.6)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.39)
-      postcss-modules-local-by-default: 4.0.4(postcss@8.4.39)
-      postcss-modules-scope: 3.1.1(postcss@8.4.39)
-      postcss-modules-values: 4.0.0(postcss@8.4.39)
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-modules-extract-imports: 3.0.0(postcss@8.4.49)
+      postcss-modules-local-by-default: 4.0.4(postcss@8.4.49)
+      postcss-modules-scope: 3.1.1(postcss@8.4.49)
+      postcss-modules-values: 4.0.0(postcss@8.4.49)
       postcss-value-parser: 4.2.0
       semver: 7.7.1
     optionalDependencies:
@@ -33977,9 +34225,9 @@ snapshots:
 
   css-minimizer-webpack-plugin@3.4.1(webpack@5.90.3(@swc/core@1.4.6)):
     dependencies:
-      cssnano: 5.1.15(postcss@8.4.39)
+      cssnano: 5.1.15(postcss@8.4.49)
       jest-worker: 27.5.1
-      postcss: 8.4.39
+      postcss: 8.4.49
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
       source-map: 0.6.1
@@ -34045,48 +34293,48 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@5.2.14(postcss@8.4.39):
+  cssnano-preset-default@5.2.14(postcss@8.4.49):
     dependencies:
-      css-declaration-sorter: 6.4.1(postcss@8.4.39)
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-calc: 8.2.4(postcss@8.4.39)
-      postcss-colormin: 5.3.1(postcss@8.4.39)
-      postcss-convert-values: 5.1.3(postcss@8.4.39)
-      postcss-discard-comments: 5.1.2(postcss@8.4.39)
-      postcss-discard-duplicates: 5.1.0(postcss@8.4.39)
-      postcss-discard-empty: 5.1.1(postcss@8.4.39)
-      postcss-discard-overridden: 5.1.0(postcss@8.4.39)
-      postcss-merge-longhand: 5.1.7(postcss@8.4.39)
-      postcss-merge-rules: 5.1.4(postcss@8.4.39)
-      postcss-minify-font-values: 5.1.0(postcss@8.4.39)
-      postcss-minify-gradients: 5.1.1(postcss@8.4.39)
-      postcss-minify-params: 5.1.4(postcss@8.4.39)
-      postcss-minify-selectors: 5.2.1(postcss@8.4.39)
-      postcss-normalize-charset: 5.1.0(postcss@8.4.39)
-      postcss-normalize-display-values: 5.1.0(postcss@8.4.39)
-      postcss-normalize-positions: 5.1.1(postcss@8.4.39)
-      postcss-normalize-repeat-style: 5.1.1(postcss@8.4.39)
-      postcss-normalize-string: 5.1.0(postcss@8.4.39)
-      postcss-normalize-timing-functions: 5.1.0(postcss@8.4.39)
-      postcss-normalize-unicode: 5.1.1(postcss@8.4.39)
-      postcss-normalize-url: 5.1.0(postcss@8.4.39)
-      postcss-normalize-whitespace: 5.1.1(postcss@8.4.39)
-      postcss-ordered-values: 5.1.3(postcss@8.4.39)
-      postcss-reduce-initial: 5.1.2(postcss@8.4.39)
-      postcss-reduce-transforms: 5.1.0(postcss@8.4.39)
-      postcss-svgo: 5.1.0(postcss@8.4.39)
-      postcss-unique-selectors: 5.1.1(postcss@8.4.39)
+      css-declaration-sorter: 6.4.1(postcss@8.4.49)
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
+      postcss-calc: 8.2.4(postcss@8.4.49)
+      postcss-colormin: 5.3.1(postcss@8.4.49)
+      postcss-convert-values: 5.1.3(postcss@8.4.49)
+      postcss-discard-comments: 5.1.2(postcss@8.4.49)
+      postcss-discard-duplicates: 5.1.0(postcss@8.4.49)
+      postcss-discard-empty: 5.1.1(postcss@8.4.49)
+      postcss-discard-overridden: 5.1.0(postcss@8.4.49)
+      postcss-merge-longhand: 5.1.7(postcss@8.4.49)
+      postcss-merge-rules: 5.1.4(postcss@8.4.49)
+      postcss-minify-font-values: 5.1.0(postcss@8.4.49)
+      postcss-minify-gradients: 5.1.1(postcss@8.4.49)
+      postcss-minify-params: 5.1.4(postcss@8.4.49)
+      postcss-minify-selectors: 5.2.1(postcss@8.4.49)
+      postcss-normalize-charset: 5.1.0(postcss@8.4.49)
+      postcss-normalize-display-values: 5.1.0(postcss@8.4.49)
+      postcss-normalize-positions: 5.1.1(postcss@8.4.49)
+      postcss-normalize-repeat-style: 5.1.1(postcss@8.4.49)
+      postcss-normalize-string: 5.1.0(postcss@8.4.49)
+      postcss-normalize-timing-functions: 5.1.0(postcss@8.4.49)
+      postcss-normalize-unicode: 5.1.1(postcss@8.4.49)
+      postcss-normalize-url: 5.1.0(postcss@8.4.49)
+      postcss-normalize-whitespace: 5.1.1(postcss@8.4.49)
+      postcss-ordered-values: 5.1.3(postcss@8.4.49)
+      postcss-reduce-initial: 5.1.2(postcss@8.4.49)
+      postcss-reduce-transforms: 5.1.0(postcss@8.4.49)
+      postcss-svgo: 5.1.0(postcss@8.4.49)
+      postcss-unique-selectors: 5.1.1(postcss@8.4.49)
 
-  cssnano-utils@3.1.0(postcss@8.4.39):
+  cssnano-utils@3.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
-  cssnano@5.1.15(postcss@8.4.39):
+  cssnano@5.1.15(postcss@8.4.49):
     dependencies:
-      cssnano-preset-default: 5.2.14(postcss@8.4.39)
+      cssnano-preset-default: 5.2.14(postcss@8.4.49)
       lilconfig: 2.1.0
-      postcss: 8.4.39
+      postcss: 8.4.49
       yaml: 1.10.2
 
   csso@4.2.0:
@@ -34283,6 +34531,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.10
 
+  date-fns@3.6.0: {}
+
   dayjs@1.11.10: {}
 
   de-indent@1.0.2: {}
@@ -34372,22 +34622,22 @@ snapshots:
 
   deep-equal@2.2.3:
     dependencies:
-      array-buffer-byte-length: 1.0.1
+      array-buffer-byte-length: 1.0.2
       call-bind: 1.0.8
       es-get-iterator: 1.1.3
       get-intrinsic: 1.3.0
       is-arguments: 1.1.1
-      is-array-buffer: 3.0.4
-      is-date-object: 1.0.5
-      is-regex: 1.1.4
-      is-shared-array-buffer: 1.0.3
+      is-array-buffer: 3.0.5
+      is-date-object: 1.1.0
+      is-regex: 1.2.1
+      is-shared-array-buffer: 1.0.4
       isarray: 2.0.5
       object-is: 1.1.6
       object-keys: 1.1.1
-      object.assign: 4.1.5
-      regexp.prototype.flags: 1.5.2
+      object.assign: 4.1.7
+      regexp.prototype.flags: 1.5.4
       side-channel: 1.1.0
-      which-boxed-primitive: 1.0.2
+      which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
       which-typed-array: 1.1.20
 
@@ -34797,7 +35047,7 @@ snapshots:
       is-negative-zero: 2.0.3
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.3
-      is-string: 1.0.7
+      is-string: 1.1.1
       is-typed-array: 1.1.13
       is-weakref: 1.0.2
       object-inspect: 1.13.4
@@ -34887,9 +35137,9 @@ snapshots:
       is-arguments: 1.1.1
       is-map: 2.0.3
       is-set: 2.0.3
-      is-string: 1.0.7
+      is-string: 1.1.1
       isarray: 2.0.5
-      stop-iteration-iterator: 1.0.0
+      stop-iteration-iterator: 1.1.0
 
   es-iterator-helpers@1.3.1:
     dependencies:
@@ -34937,8 +35187,8 @@ snapshots:
   es-to-primitive@1.3.0:
     dependencies:
       is-callable: 1.2.7
-      is-date-object: 1.0.5
-      is-symbol: 1.0.4
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   es5-ext@0.10.64:
     dependencies:
@@ -35139,7 +35389,7 @@ snapshots:
 
   eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0):
     dependencies:
-      array-includes: 3.1.7
+      array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.4
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
@@ -35152,7 +35402,7 @@ snapshots:
       is-core-module: 2.13.1
       is-glob: 4.0.3
       minimatch: 3.1.2
-      object.fromentries: 2.0.7
+      object.fromentries: 2.0.8
       object.groupby: 1.0.2
       object.values: 1.1.7
       semver: 7.7.1
@@ -35166,7 +35416,7 @@ snapshots:
 
   eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.55.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.0):
     dependencies:
-      array-includes: 3.1.7
+      array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.4
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
@@ -35179,7 +35429,7 @@ snapshots:
       is-core-module: 2.13.1
       is-glob: 4.0.3
       minimatch: 3.1.2
-      object.fromentries: 2.0.7
+      object.fromentries: 2.0.8
       object.groupby: 1.0.2
       object.values: 1.1.7
       semver: 7.7.1
@@ -35382,6 +35632,8 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@1.0.1: {}
 
@@ -36015,10 +36267,10 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  flowise-embed-react@3.1.2(@types/node@22.16.3)(flowise-embed@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2):
+  flowise-embed-react@3.1.5(@types/node@22.16.3)(flowise-embed@3.1.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2):
     dependencies:
       '@ladle/react': 2.5.1(@types/node@22.16.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.71.1)(terser@5.29.1)(typescript@5.5.2)
-      flowise-embed: 3.1.2
+      flowise-embed: 3.1.5
       react: 18.2.0
     transitivePeerDependencies:
       - '@types/node'
@@ -36032,7 +36284,7 @@ snapshots:
       - terser
       - typescript
 
-  flowise-embed@3.1.2:
+  flowise-embed@3.1.5:
     dependencies:
       '@babel/core': 7.24.0
       '@microsoft/fetch-event-source': 2.0.1
@@ -36291,7 +36543,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       functions-have-names: 1.2.3
 
   function.prototype.name@1.1.8:
@@ -36498,7 +36750,7 @@ snapshots:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 2.3.6
-      minimatch: 9.0.3
+      minimatch: 9.0.5
       minipass: 7.0.4
       path-scurry: 1.10.1
 
@@ -36689,7 +36941,7 @@ snapshots:
 
   groq-sdk@0.19.0(encoding@0.1.13):
     dependencies:
-      '@types/node': 18.19.23
+      '@types/node': 18.19.130
       '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -36887,6 +37139,26 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.2
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.3
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   hast-util-to-parse5@8.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -36905,6 +37177,10 @@ snapshots:
       unist-util-find-after: 4.0.1
 
   hast-util-whitespace@2.0.1: {}
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hastscript@6.0.0:
     dependencies:
@@ -37018,6 +37294,8 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -37198,9 +37476,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.4.39):
+  icss-utils@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
   idb@7.1.1: {}
 
@@ -37359,10 +37637,17 @@ snapshots:
 
   is-alphabetical@1.0.4: {}
 
+  is-alphabetical@2.0.1: {}
+
   is-alphanumerical@1.0.4:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-arguments@1.1.1:
     dependencies:
@@ -37453,6 +37738,8 @@ snapshots:
 
   is-decimal@1.0.4: {}
 
+  is-decimal@2.0.1: {}
+
   is-descriptor@0.1.7:
     dependencies:
       is-accessor-descriptor: 1.0.1
@@ -37500,6 +37787,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@1.0.4: {}
+
+  is-hexadecimal@2.0.1: {}
 
   is-installed-globally@0.4.0:
     dependencies:
@@ -39478,6 +39767,13 @@ snapshots:
       unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.3
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.3
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
   mdast-util-from-markdown@0.8.5:
     dependencies:
       '@types/mdast': 3.0.15
@@ -39505,6 +39801,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.3
+      '@types/unist': 3.0.2
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-autolink-literal@1.0.3:
     dependencies:
       '@types/mdast': 3.0.15
@@ -39512,16 +39825,42 @@ snapshots:
       mdast-util-find-and-replace: 2.2.2
       micromark-util-character: 1.2.0
 
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.0
+
   mdast-util-gfm-footnote@1.0.2:
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-markdown: 1.5.0
       micromark-util-normalize-identifier: 1.1.0
 
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.3
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-strikethrough@1.0.3:
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-markdown: 1.5.0
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.3
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   mdast-util-gfm-table@1.0.7:
     dependencies:
@@ -39532,10 +39871,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.3
+      devlop: 1.1.0
+      markdown-table: 3.0.3
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-task-list-item@1.0.2:
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-markdown: 1.5.0
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.3
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   mdast-util-gfm@2.0.2:
     dependencies:
@@ -39549,16 +39907,72 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-math@2.0.2:
     dependencies:
       '@types/mdast': 3.0.15
       longest-streak: 3.1.0
       mdast-util-to-markdown: 1.5.0
 
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.3
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.3
+      '@types/unist': 3.0.2
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.3
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-phrasing@3.0.1:
     dependencies:
       '@types/mdast': 3.0.15
       unist-util-is: 5.2.1
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.3
+      unist-util-is: 6.0.0
 
   mdast-util-to-hast@12.3.0:
     dependencies:
@@ -39594,11 +40008,27 @@ snapshots:
       unist-util-visit: 4.1.2
       zwitch: 2.0.4
 
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.3
+      '@types/unist': 3.0.2
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
   mdast-util-to-string@2.0.0: {}
 
   mdast-util-to-string@3.2.0:
     dependencies:
       '@types/mdast': 3.0.15
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.3
 
   mdn-data@2.0.14: {}
 
@@ -39692,12 +40122,38 @@ snapshots:
       micromark-util-types: 1.1.0
       uvu: 0.5.6
 
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
   micromark-extension-gfm-autolink-literal@1.0.5:
     dependencies:
       micromark-util-character: 1.2.0
       micromark-util-sanitize-uri: 1.2.0
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-sanitize-uri: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
 
   micromark-extension-gfm-footnote@1.1.2:
     dependencies:
@@ -39710,6 +40166,17 @@ snapshots:
       micromark-util-types: 1.1.0
       uvu: 0.5.6
 
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.0
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
   micromark-extension-gfm-strikethrough@1.0.7:
     dependencies:
       micromark-util-chunked: 1.1.0
@@ -39719,6 +40186,15 @@ snapshots:
       micromark-util-types: 1.1.0
       uvu: 0.5.6
 
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
   micromark-extension-gfm-table@1.0.7:
     dependencies:
       micromark-factory-space: 1.1.0
@@ -39727,9 +40203,21 @@ snapshots:
       micromark-util-types: 1.1.0
       uvu: 0.5.6
 
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
   micromark-extension-gfm-tagfilter@1.0.2:
     dependencies:
       micromark-util-types: 1.1.0
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.0
 
   micromark-extension-gfm-task-list-item@1.0.5:
     dependencies:
@@ -39738,6 +40226,14 @@ snapshots:
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
       uvu: 0.5.6
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
 
   micromark-extension-gfm@2.0.3:
     dependencies:
@@ -39749,6 +40245,17 @@ snapshots:
       micromark-extension-gfm-task-list-item: 1.0.5
       micromark-util-combine-extensions: 1.1.0
       micromark-util-types: 1.1.0
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.0
 
   micromark-extension-math@2.1.2:
     dependencies:
@@ -39766,6 +40273,12 @@ snapshots:
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
 
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
   micromark-factory-label@1.1.0:
     dependencies:
       micromark-util-character: 1.2.0
@@ -39773,10 +40286,22 @@ snapshots:
       micromark-util-types: 1.1.0
       uvu: 0.5.6
 
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
   micromark-factory-space@1.1.0:
     dependencies:
       micromark-util-character: 1.2.0
       micromark-util-types: 1.1.0
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-types: 2.0.0
 
   micromark-factory-title@1.1.0:
     dependencies:
@@ -39785,12 +40310,26 @@ snapshots:
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
 
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
   micromark-factory-whitespace@1.1.0:
     dependencies:
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
 
   micromark-util-character@1.2.0:
     dependencies:
@@ -39806,20 +40345,39 @@ snapshots:
     dependencies:
       micromark-util-symbol: 1.1.0
 
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.0
+
   micromark-util-classify-character@1.1.0:
     dependencies:
       micromark-util-character: 1.2.0
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
 
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
   micromark-util-combine-extensions@1.1.0:
     dependencies:
       micromark-util-chunked: 1.1.0
       micromark-util-types: 1.1.0
 
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.0
+
   micromark-util-decode-numeric-character-reference@1.1.0:
     dependencies:
       micromark-util-symbol: 1.1.0
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.0
 
   micromark-util-decode-string@1.1.0:
     dependencies:
@@ -39828,19 +40386,36 @@ snapshots:
       micromark-util-decode-numeric-character-reference: 1.1.0
       micromark-util-symbol: 1.1.0
 
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-util-character: 2.1.0
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.0
+
   micromark-util-encode@1.1.0: {}
 
   micromark-util-encode@2.0.0: {}
 
   micromark-util-html-tag-name@1.2.0: {}
 
+  micromark-util-html-tag-name@2.0.1: {}
+
   micromark-util-normalize-identifier@1.1.0:
     dependencies:
       micromark-util-symbol: 1.1.0
 
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.0
+
   micromark-util-resolve-all@1.1.0:
     dependencies:
       micromark-util-types: 1.1.0
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.0
 
   micromark-util-sanitize-uri@1.2.0:
     dependencies:
@@ -39860,6 +40435,13 @@ snapshots:
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
       uvu: 0.5.6
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
 
   micromark-util-symbol@1.1.0: {}
 
@@ -39895,6 +40477,28 @@ snapshots:
       micromark-util-symbol: 1.1.0
       micromark-util-types: 1.1.0
       uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3(supports-color@8.1.1)
+      decode-named-character-reference: 1.0.2
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.0
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.0
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -39974,10 +40578,6 @@ snapshots:
       brace-expansion: 1.1.11
 
   minimatch@5.1.6:
-    dependencies:
-      brace-expansion: 2.0.1
-
-  minimatch@9.0.3:
     dependencies:
       brace-expansion: 2.0.1
 
@@ -40500,6 +41100,8 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  object-inspect@1.13.1: {}
+
   object-inspect@1.13.4: {}
 
   object-is@1.1.6:
@@ -40560,15 +41162,15 @@ snapshots:
       array.prototype.reduce: 1.0.6
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
-      safe-array-concat: 1.1.2
+      es-abstract: 1.24.1
+      safe-array-concat: 1.1.3
 
   object.groupby@1.0.2:
     dependencies:
       array.prototype.filter: 1.0.3
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       es-errors: 1.3.0
 
   object.hasown@1.1.3:
@@ -40592,9 +41194,9 @@ snapshots:
 
   object.values@1.1.7:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
 
   obliterator@1.6.1: {}
 
@@ -40857,6 +41459,16 @@ snapshots:
       is-alphanumerical: 1.0.4
       is-decimal: 1.0.4
       is-hexadecimal: 1.0.4
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.10
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.0.2
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse-filepath@1.0.2:
     dependencies:
@@ -41159,8 +41771,6 @@ snapshots:
 
   picomatch@3.0.1: {}
 
-  picomatch@4.0.2: {}
-
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
@@ -41228,9 +41838,9 @@ snapshots:
       browserslist: 4.23.0
       postcss: 8.4.35
 
-  postcss-calc@8.2.4(postcss@8.4.39):
+  postcss-calc@8.2.4(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-selector-parser: 6.0.15
       postcss-value-parser: 4.2.0
 
@@ -41254,18 +41864,18 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@5.3.1(postcss@8.4.39):
+  postcss-colormin@5.3.1(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@5.1.3(postcss@8.4.39):
+  postcss-convert-values@5.1.3(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-custom-media@8.0.2(postcss@8.4.35):
@@ -41288,21 +41898,21 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.15
 
-  postcss-discard-comments@5.1.2(postcss@8.4.39):
+  postcss-discard-comments@5.1.2(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
-  postcss-discard-duplicates@5.1.0(postcss@8.4.39):
+  postcss-discard-duplicates@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
-  postcss-discard-empty@5.1.1(postcss@8.4.39):
+  postcss-discard-empty@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
-  postcss-discard-overridden@5.1.0(postcss@8.4.39):
+  postcss-discard-overridden@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
   postcss-double-position-gradients@3.1.2(postcss@8.4.35):
     dependencies:
@@ -41342,9 +41952,9 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-import@15.1.0(postcss@8.4.39):
+  postcss-import@15.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.8
@@ -41353,10 +41963,10 @@ snapshots:
     dependencies:
       postcss: 8.4.35
 
-  postcss-js@4.0.1(postcss@8.4.39):
+  postcss-js@4.0.1(postcss@8.4.49):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.39
+      postcss: 8.4.49
 
   postcss-lab-function@4.2.1(postcss@8.4.35):
     dependencies:
@@ -41364,12 +41974,12 @@ snapshots:
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
 
-  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.4.1
     optionalDependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       ts-node: 10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2)
 
   postcss-loader@6.2.1(postcss@8.4.35)(webpack@5.90.3(@swc/core@1.4.6)):
@@ -41388,68 +41998,68 @@ snapshots:
     dependencies:
       postcss: 8.4.35
 
-  postcss-merge-longhand@5.1.7(postcss@8.4.39):
+  postcss-merge-longhand@5.1.7(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
-      stylehacks: 5.1.1(postcss@8.4.39)
+      stylehacks: 5.1.1(postcss@8.4.49)
 
-  postcss-merge-rules@5.1.4(postcss@8.4.39):
+  postcss-merge-rules@5.1.4(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
       caniuse-api: 3.0.0
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-selector-parser: 6.0.15
 
-  postcss-minify-font-values@5.1.0(postcss@8.4.39):
+  postcss-minify-font-values@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@5.1.1(postcss@8.4.39):
+  postcss-minify-gradients@5.1.1(postcss@8.4.49):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@5.1.4(postcss@8.4.39):
+  postcss-minify-params@5.1.4(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@5.2.1(postcss@8.4.39):
+  postcss-minify-selectors@5.2.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-selector-parser: 6.0.15
 
-  postcss-modules-extract-imports@3.0.0(postcss@8.4.39):
+  postcss-modules-extract-imports@3.0.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
-  postcss-modules-local-by-default@4.0.4(postcss@8.4.39):
+  postcss-modules-local-by-default@4.0.4(postcss@8.4.49):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-selector-parser: 6.0.15
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.1.1(postcss@8.4.39):
+  postcss-modules-scope@3.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-selector-parser: 6.0.15
 
-  postcss-modules-values@4.0.0(postcss@8.4.39):
+  postcss-modules-values@4.0.0(postcss@8.4.49):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
 
-  postcss-nested@6.0.1(postcss@8.4.39):
+  postcss-nested@6.0.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-selector-parser: 6.0.15
 
   postcss-nesting@10.2.0(postcss@8.4.35):
@@ -41458,50 +42068,50 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.15
 
-  postcss-normalize-charset@5.1.0(postcss@8.4.39):
+  postcss-normalize-charset@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
 
-  postcss-normalize-display-values@5.1.0(postcss@8.4.39):
+  postcss-normalize-display-values@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@5.1.1(postcss@8.4.39):
+  postcss-normalize-positions@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@5.1.1(postcss@8.4.39):
+  postcss-normalize-repeat-style@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@5.1.0(postcss@8.4.39):
+  postcss-normalize-string@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@5.1.0(postcss@8.4.39):
+  postcss-normalize-timing-functions@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@5.1.1(postcss@8.4.39):
+  postcss-normalize-unicode@5.1.1(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@5.1.0(postcss@8.4.39):
+  postcss-normalize-url@5.1.0(postcss@8.4.49):
     dependencies:
       normalize-url: 6.1.0
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@5.1.1(postcss@8.4.39):
+  postcss-normalize-whitespace@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-normalize@10.0.1(browserslist@4.23.0)(postcss@8.4.35):
@@ -41516,10 +42126,10 @@ snapshots:
     dependencies:
       postcss: 8.4.35
 
-  postcss-ordered-values@5.1.3(postcss@8.4.39):
+  postcss-ordered-values@5.1.3(postcss@8.4.49):
     dependencies:
-      cssnano-utils: 3.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 3.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-overflow-shorthand@3.0.4(postcss@8.4.35):
@@ -41594,15 +42204,15 @@ snapshots:
       postcss: 8.4.35
       postcss-selector-parser: 6.0.15
 
-  postcss-reduce-initial@5.1.2(postcss@8.4.39):
+  postcss-reduce-initial@5.1.2(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
       caniuse-api: 3.0.0
-      postcss: 8.4.39
+      postcss: 8.4.49
 
-  postcss-reduce-transforms@5.1.0(postcss@8.4.39):
+  postcss-reduce-transforms@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
   postcss-replace-overflow-wrap@4.0.0(postcss@8.4.35):
@@ -41619,15 +42229,15 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@5.1.0(postcss@8.4.39):
+  postcss-svgo@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
       svgo: 2.8.0
 
-  postcss-unique-selectors@5.1.1(postcss@8.4.39):
+  postcss-unique-selectors@5.1.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-selector-parser: 6.0.15
 
   postcss-value-parser@4.2.0: {}
@@ -41642,12 +42252,6 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.1.1
       source-map-js: 1.2.0
-
-  postcss@8.4.39:
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.4.49:
     dependencies:
@@ -41817,6 +42421,8 @@ snapshots:
       xtend: 4.0.2
 
   property-information@6.4.1: {}
+
+  property-information@7.1.0: {}
 
   prosemirror-changeset@2.3.0:
     dependencies:
@@ -42056,15 +42662,15 @@ snapshots:
 
   qs@6.11.0:
     dependencies:
-      side-channel: 1.1.0
+      side-channel: 1.0.6
 
   qs@6.11.2:
     dependencies:
-      side-channel: 1.1.0
+      side-channel: 1.0.6
 
   qs@6.12.1:
     dependencies:
-      side-channel: 1.1.0
+      side-channel: 1.0.6
 
   qs@6.13.0:
     dependencies:
@@ -42279,6 +42885,24 @@ snapshots:
       unified: 10.1.2
       unist-util-visit: 4.1.2
       vfile: 5.3.7
+    transitivePeerDependencies:
+      - supports-color
+
+  react-markdown@9.1.0(@types/react@18.2.65)(react@18.2.0):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.3
+      '@types/react': 18.2.65
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.1.0
+      react: 18.2.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -42724,6 +43348,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.3
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-math@5.1.1:
     dependencies:
       '@types/mdast': 3.0.15
@@ -42739,12 +43374,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.3
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-rehype@10.1.0:
     dependencies:
       '@types/hast': 2.3.10
       '@types/mdast': 3.0.15
       mdast-util-to-hast: 12.3.0
       unified: 10.1.2
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.3
+      mdast-util-to-hast: 13.1.0
+      unified: 11.0.5
+      vfile: 6.0.1
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.3
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   remove-bom-buffer@3.0.0:
     dependencies:
@@ -43401,6 +44059,13 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
+  side-channel@1.0.6:
+    dependencies:
+      call-bind: 1.0.8
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.1
+
   side-channel@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -43736,10 +44401,6 @@ snapshots:
 
   statuses@2.0.1: {}
 
-  stop-iteration-iterator@1.0.0:
-    dependencies:
-      internal-slot: 1.0.7
-
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -43848,7 +44509,7 @@ snapshots:
       internal-slot: 1.0.7
       regexp.prototype.flags: 1.5.2
       set-function-name: 2.0.2
-      side-channel: 1.1.0
+      side-channel: 1.0.6
 
   string.prototype.trim@1.2.10:
     dependencies:
@@ -43864,13 +44525,13 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
 
   string.prototype.trimend@1.0.7:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
 
   string.prototype.trimend@1.0.9:
     dependencies:
@@ -43883,7 +44544,7 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
 
   string.prototype.trimstart@1.0.8:
     dependencies:
@@ -43898,6 +44559,11 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   stringify-object@3.3.0:
     dependencies:
@@ -44001,10 +44667,10 @@ snapshots:
       stylis: 4.3.2
       tslib: 2.6.2
 
-  stylehacks@5.1.1(postcss@8.4.39):
+  stylehacks@5.1.1(postcss@8.4.49):
     dependencies:
       browserslist: 4.23.0
-      postcss: 8.4.39
+      postcss: 8.4.49
       postcss-selector-parser: 6.0.15
 
   stylis@4.2.0: {}
@@ -44179,11 +44845,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.4.39
-      postcss-import: 15.1.0(postcss@8.4.39)
-      postcss-js: 4.0.1(postcss@8.4.39)
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2))
-      postcss-nested: 6.0.1(postcss@8.4.39)
+      postcss: 8.4.49
+      postcss-import: 15.1.0(postcss@8.4.49)
+      postcss-js: 4.0.1(postcss@8.4.49)
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2))
+      postcss-nested: 6.0.1(postcss@8.4.49)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
       sucrase: 3.35.0
@@ -44845,6 +45511,16 @@ snapshots:
       trough: 2.2.0
       vfile: 5.3.7
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.2
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.1
+
   union-value@1.0.1:
     dependencies:
       arr-union: 3.1.0
@@ -45048,7 +45724,7 @@ snapshots:
   util.promisify@1.0.1:
     dependencies:
       define-properties: 1.2.1
-      es-abstract: 1.22.5
+      es-abstract: 1.24.1
       has-symbols: 1.1.0
       object.getownpropertydescriptors: 2.1.7
 
@@ -45201,7 +45877,7 @@ snapshots:
       '@microsoft/api-extractor': 7.43.0(@types/node@22.16.3)
       '@rollup/pluginutils': 5.1.3(rollup@4.45.0)
       '@vue/language-core': 1.8.27(typescript@5.5.2)
-      debug: 4.4.1
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       magic-string: 0.30.10
       typescript: 5.5.2
@@ -45256,7 +45932,7 @@ snapshots:
   vite@5.1.6(@types/node@22.16.3)(sass@1.71.1)(terser@5.29.1):
     dependencies:
       esbuild: 0.19.12
-      postcss: 8.4.35
+      postcss: 8.4.49
       rollup: 4.45.0
     optionalDependencies:
       '@types/node': 22.16.3
@@ -45524,7 +46200,7 @@ snapshots:
       is-bigint: 1.0.4
       is-boolean-object: 1.1.2
       is-number-object: 1.0.7
-      is-string: 1.0.7
+      is-string: 1.1.1
       is-symbol: 1.0.4
 
   which-boxed-primitive@1.1.1:
@@ -45990,7 +46666,7 @@ snapshots:
   yargs-parser@5.0.1:
     dependencies:
       camelcase: 3.0.0
-      object.assign: 4.1.5
+      object.assign: 4.1.7
 
   yargs@16.2.0:
     dependencies:


### PR DESCRIPTION
- Introduced the @flowiseai/observe package with a modular architecture for observing AI agent executions and evaluations.
- Added essential files including ESLint and Prettier configurations, Jest setup, and TypeScript configuration.
- Created foundational components and documentation for usage, testing, and architecture.
- Updated pnpm-lock.yaml with new dependencies for the observe package.

This commit sets the groundwork for further development of the observability features.

FLOWISE-574

demo: 

https://github.com/user-attachments/assets/87409827-0fd6-441e-b7ab-8b2ed9f6dabf