### PR TITLE
feat: add object/array body param types and per-option show/hide on d…

### DIFF
--- a/packages/agentflow/src/core/types/node.ts
+++ b/packages/agentflow/src/core/types/node.ts
@@ -84,7 +84,17 @@ export interface InputParam {
     type: string
     default?: unknown
     optional?: boolean
-    options?: Array<{ label: string; name: string; description?: string; client?: Array<ClientType> } | string>
+    options?: Array<
+        | {
+              label: string
+              name: string
+              description?: string
+              client?: Array<ClientType>
+              show?: Record<string, unknown>
+              hide?: Record<string, unknown>
+          }
+        | string
+    >
     placeholder?: string
     rows?: number
     description?: string

--- a/packages/agentflow/src/core/utils/fieldVisibility.test.ts
+++ b/packages/agentflow/src/core/utils/fieldVisibility.test.ts
@@ -194,6 +194,104 @@ describe('evaluateFieldVisibility', () => {
         expect(params[0].display).toBeUndefined()
         expect(params[1].display).toBeUndefined()
     })
+
+    describe('option-level show/hide filtering', () => {
+        it('removes options whose hide condition matches', () => {
+            const param = makeParam({
+                type: 'options',
+                options: [
+                    { label: 'String', name: 'string' },
+                    { label: 'Object', name: 'object', hide: { contentType: 'application/x-www-form-urlencoded' } }
+                ] as any
+            })
+
+            const result = evaluateFieldVisibility([param], { contentType: 'application/x-www-form-urlencoded' })
+            expect(result[0].options).toHaveLength(1)
+            expect(result[0].options![0]).toMatchObject({ name: 'string' })
+        })
+
+        it('keeps options whose hide condition does not match', () => {
+            const param = makeParam({
+                type: 'options',
+                options: [
+                    { label: 'String', name: 'string' },
+                    { label: 'Object', name: 'object', hide: { contentType: 'application/x-www-form-urlencoded' } }
+                ] as any
+            })
+
+            const result = evaluateFieldVisibility([param], { contentType: 'application/json' })
+            expect(result[0].options).toHaveLength(2)
+        })
+
+        it('removes options whose show condition does not match', () => {
+            const param = makeParam({
+                type: 'options',
+                options: [
+                    { label: 'Basic', name: 'basic' },
+                    { label: 'Advanced', name: 'advanced', show: { mode: 'expert' } }
+                ] as any
+            })
+
+            const result = evaluateFieldVisibility([param], { mode: 'beginner' })
+            expect(result[0].options).toHaveLength(1)
+            expect(result[0].options![0]).toMatchObject({ name: 'basic' })
+        })
+
+        it('keeps options whose show condition matches', () => {
+            const param = makeParam({
+                type: 'options',
+                options: [
+                    { label: 'Basic', name: 'basic' },
+                    { label: 'Advanced', name: 'advanced', show: { mode: 'expert' } }
+                ] as any
+            })
+
+            const result = evaluateFieldVisibility([param], { mode: 'expert' })
+            expect(result[0].options).toHaveLength(2)
+        })
+
+        it('passes through string options unchanged', () => {
+            const param = makeParam({
+                type: 'options',
+                options: ['one', 'two', 'three'] as any
+            })
+
+            const result = evaluateFieldVisibility([param], {})
+            expect(result[0].options).toHaveLength(3)
+        })
+
+        it('passes through options with no show/hide unchanged', () => {
+            const param = makeParam({
+                type: 'options',
+                options: [
+                    { label: 'A', name: 'a' },
+                    { label: 'B', name: 'b' }
+                ] as any
+            })
+
+            const result = evaluateFieldVisibility([param], {})
+            expect(result[0].options).toHaveLength(2)
+        })
+
+        it('does not mutate the original options array', () => {
+            const options = [
+                { label: 'String', name: 'string' },
+                { label: 'Object', name: 'object', hide: { contentType: 'application/x-www-form-urlencoded' } }
+            ] as any
+            const param = makeParam({ type: 'options', options })
+
+            evaluateFieldVisibility([param], { contentType: 'application/x-www-form-urlencoded' })
+
+            // Original options array is untouched
+            expect(options).toHaveLength(2)
+        })
+
+        it('does not affect non-options params', () => {
+            const param = makeParam({ type: 'string' })
+            const result = evaluateFieldVisibility([param], {})
+            expect(result[0].options).toBeUndefined()
+        })
+    })
 })
 
 describe('evaluateFieldVisibility – nested array $index pattern (Start node formInputTypes)', () => {

--- a/packages/agentflow/src/core/utils/fieldVisibility.ts
+++ b/packages/agentflow/src/core/utils/fieldVisibility.ts
@@ -129,13 +129,27 @@ export function evaluateParamVisibility(param: InputParam, inputValues: Record<s
 
 /**
  * Evaluate visibility for all params, returning new param objects with computed `display`.
+ * Also filters individual options within `type: 'options'` params based on their own show/hide conditions.
  * Does not mutate the originals.
  */
 export function evaluateFieldVisibility(params: InputParam[], inputValues: Record<string, unknown>, arrayIndex?: number): InputParam[] {
-    return params.map((param) => ({
-        ...param,
-        display: evaluateParamVisibility(param, inputValues, arrayIndex)
-    }))
+    return params.map((param) => {
+        const withDisplay = { ...param, display: evaluateParamVisibility(param, inputValues, arrayIndex) }
+
+        if (withDisplay.type === 'options' && withDisplay.options) {
+            const filteredOptions = withDisplay.options.filter((opt) => {
+                if (typeof opt === 'string' || (!opt.show && !opt.hide)) return true
+                return evaluateParamVisibility(
+                    { id: '', name: '', label: '', type: '', show: opt.show, hide: opt.hide },
+                    inputValues,
+                    arrayIndex
+                )
+            })
+            return filteredOptions.length === withDisplay.options.length ? withDisplay : { ...withDisplay, options: filteredOptions }
+        }
+
+        return withDisplay
+    })
 }
 
 /**

--- a/packages/components/nodes/agentflow/Start/Start.ts
+++ b/packages/components/nodes/agentflow/Start/Start.ts
@@ -291,6 +291,31 @@ class Start_Agentflow implements INode {
                             {
                                 label: 'Boolean',
                                 name: 'boolean'
+                            },
+                            {
+                                label: 'Object',
+                                name: 'object',
+                                hide: { webhookContentType: 'application/x-www-form-urlencoded' }
+                            },
+                            {
+                                label: 'Array[String]',
+                                name: 'array[string]',
+                                hide: { webhookContentType: 'application/x-www-form-urlencoded' }
+                            },
+                            {
+                                label: 'Array[Number]',
+                                name: 'array[number]',
+                                hide: { webhookContentType: 'application/x-www-form-urlencoded' }
+                            },
+                            {
+                                label: 'Array[Boolean]',
+                                name: 'array[boolean]',
+                                hide: { webhookContentType: 'application/x-www-form-urlencoded' }
+                            },
+                            {
+                                label: 'Array[Object]',
+                                name: 'array[object]',
+                                hide: { webhookContentType: 'application/x-www-form-urlencoded' }
                             }
                         ],
                         default: 'string'

--- a/packages/components/src/Interface.ts
+++ b/packages/components/src/Interface.ts
@@ -64,6 +64,8 @@ export interface INodeOptionsValue {
     description?: string
     imageSrc?: string
     client?: Array<ClientType>
+    show?: INodeDisplay
+    hide?: INodeDisplay
 }
 
 export interface INodeOutputsValue {

--- a/packages/server/src/services/webhook/index.test.ts
+++ b/packages/server/src/services/webhook/index.test.ts
@@ -365,4 +365,72 @@ describe('validateWebhookChatflow', () => {
             webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY, { skipFieldValidation: true })
         ).rejects.toMatchObject({ statusCode: 401 })
     })
+
+    // --- HMAC signature verification ---
+
+    const SECRET = 'test-secret-abc123'
+    const RAW_BODY = Buffer.from('{"event":"push"}')
+
+    function sign(secret: string, body: Buffer): string {
+        const { createHmac } = require('crypto')
+        return createHmac('sha256', secret).update(body).digest('hex')
+    }
+
+    it('resolves without signature check when no webhookSecret is configured', async () => {
+        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger'))
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY)).resolves.toBeUndefined()
+    })
+
+    it('resolves when secret is set and signature is valid', async () => {
+        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
+        mockGetWebhookSecret.mockResolvedValue(SECRET)
+        const headers = { 'x-webhook-signature': sign(SECRET, RAW_BODY) }
+
+        await expect(
+            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, RAW_BODY)
+        ).resolves.toBeUndefined()
+    })
+
+    it('throws 401 when secret is set but X-Webhook-Signature header is missing', async () => {
+        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
+        mockGetWebhookSecret.mockResolvedValue(SECRET)
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY)).rejects.toMatchObject({
+            statusCode: 401
+        })
+    })
+
+    it('throws 401 when secret is set but signature is wrong', async () => {
+        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
+        mockGetWebhookSecret.mockResolvedValue(SECRET)
+        const headers = { 'x-webhook-signature': 'deadbeef' }
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, RAW_BODY)).rejects.toMatchObject(
+            {
+                statusCode: 401
+            }
+        )
+    })
+
+    it('throws 401 when payload is tampered (signature computed against original body)', async () => {
+        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
+        mockGetWebhookSecret.mockResolvedValue(SECRET)
+        const tamperedBody = Buffer.from('{"event":"delete"}')
+        const headers = { 'x-webhook-signature': sign(SECRET, RAW_BODY) }
+
+        await expect(
+            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, tamperedBody)
+        ).rejects.toMatchObject({ statusCode: 401 })
+    })
+
+    it('throws 401 when secret is set but rawBody is undefined', async () => {
+        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
+        mockGetWebhookSecret.mockResolvedValue(SECRET)
+        const headers = { 'x-webhook-signature': sign(SECRET, RAW_BODY) }
+
+        await expect(
+            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, undefined)
+        ).rejects.toMatchObject({ statusCode: 401 })
+    })
 })

--- a/packages/server/src/services/webhook/index.test.ts
+++ b/packages/server/src/services/webhook/index.test.ts
@@ -265,7 +265,7 @@ describe('validateWebhookChatflow', () => {
             makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'count', type: 'number', required: false }] })
         )
 
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { count: '42' })).resolves.toBeUndefined()
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { count: '42' })).resolves.toMatchObject({})
     })
 
     it('throws 400 when number param is an empty string (form-encoded)', async () => {
@@ -284,7 +284,7 @@ describe('validateWebhookChatflow', () => {
             makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
         )
 
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: true })).resolves.toBeUndefined()
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: true })).resolves.toMatchObject({})
     })
 
     it('resolves when boolean param is the string "true" (form-encoded)', async () => {
@@ -292,7 +292,7 @@ describe('validateWebhookChatflow', () => {
             makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
         )
 
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'true' })).resolves.toBeUndefined()
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'true' })).resolves.toMatchObject({})
     })
 
     it('resolves when boolean param is the string "false" (form-encoded)', async () => {
@@ -300,7 +300,7 @@ describe('validateWebhookChatflow', () => {
             makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
         )
 
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'false' })).resolves.toBeUndefined()
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'false' })).resolves.toMatchObject({})
     })
 
     it('throws 400 when boolean param is an invalid string like "yes" (form-encoded)', async () => {
@@ -433,7 +433,7 @@ describe('validateWebhookChatflow', () => {
     it('resolves without signature check when no webhookSecret is configured', async () => {
         mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger'))
 
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY)).resolves.toBeUndefined()
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY)).resolves.toMatchObject({})
     })
 
     it('resolves when secret is set and signature is valid', async () => {
@@ -443,7 +443,7 @@ describe('validateWebhookChatflow', () => {
 
         await expect(
             webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, RAW_BODY)
-        ).resolves.toBeUndefined()
+        ).resolves.toMatchObject({})
     })
 
     it('throws 401 when secret is set but X-Webhook-Signature header is missing', async () => {
@@ -496,7 +496,7 @@ describe('validateWebhookChatflow', () => {
         // Missing required body param 'action' — would normally throw 400, but not on resume
         await expect(
             webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, undefined, { skipFieldValidation: true })
-        ).resolves.toBeUndefined()
+        ).resolves.toMatchObject({})
     })
 
     it('still runs signature check when skipFieldValidation is true', async () => {

--- a/packages/server/src/services/webhook/index.test.ts
+++ b/packages/server/src/services/webhook/index.test.ts
@@ -260,6 +260,60 @@ describe('validateWebhookChatflow', () => {
         })
     })
 
+    it('resolves when number param is sent as a numeric string (form-encoded)', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'count', type: 'number', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { count: '42' })).resolves.toBeUndefined()
+    })
+
+    it('throws 400 when number param is an empty string (form-encoded)', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'count', type: 'number', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { count: '' })).rejects.toMatchObject({
+            statusCode: StatusCodes.BAD_REQUEST,
+            message: expect.stringContaining('count')
+        })
+    })
+
+    it('resolves when boolean param is a native boolean (JSON)', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: true })).resolves.toBeUndefined()
+    })
+
+    it('resolves when boolean param is the string "true" (form-encoded)', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'true' })).resolves.toBeUndefined()
+    })
+
+    it('resolves when boolean param is the string "false" (form-encoded)', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'false' })).resolves.toBeUndefined()
+    })
+
+    it('throws 400 when boolean param is an invalid string like "yes" (form-encoded)', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'yes' })).rejects.toMatchObject({
+            statusCode: StatusCodes.BAD_REQUEST,
+            message: expect.stringContaining('active')
+        })
+    })
+
     // --- Query param validation ---
 
     it('throws 400 when a required query param is missing', async () => {

--- a/packages/server/src/services/webhook/index.test.ts
+++ b/packages/server/src/services/webhook/index.test.ts
@@ -487,4 +487,25 @@ describe('validateWebhookChatflow', () => {
             webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, undefined)
         ).rejects.toMatchObject({ statusCode: 401 })
     })
+
+    // --- skipFieldValidation option (resume calls) ---
+
+    it('skips field validation when skipFieldValidation is true', async () => {
+        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'action', required: true }] }))
+
+        // Missing required body param 'action' — would normally throw 400, but not on resume
+        await expect(
+            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, undefined, { skipFieldValidation: true })
+        ).resolves.toBeUndefined()
+    })
+
+    it('still runs signature check when skipFieldValidation is true', async () => {
+        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
+        mockGetWebhookSecret.mockResolvedValue(SECRET)
+
+        // No signature header — should still 401 even with skipFieldValidation
+        await expect(
+            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY, { skipFieldValidation: true })
+        ).rejects.toMatchObject({ statusCode: 401 })
+    })
 })

--- a/packages/server/src/services/webhook/index.test.ts
+++ b/packages/server/src/services/webhook/index.test.ts
@@ -260,57 +260,143 @@ describe('validateWebhookChatflow', () => {
         })
     })
 
-    it('resolves when number param is sent as a numeric string (form-encoded)', async () => {
+    // --- object type ---
+
+    it('resolves when object param is a plain object', async () => {
         mockGetChatflowById.mockResolvedValue(
-            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'count', type: 'number', required: false }] })
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'meta', type: 'object', required: false }] })
         )
 
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { count: '42' })).resolves.toMatchObject({})
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { meta: { key: 'val' } })).resolves.toMatchObject({})
     })
 
-    it('throws 400 when number param is an empty string (form-encoded)', async () => {
+    it('throws 400 when object param is a string', async () => {
         mockGetChatflowById.mockResolvedValue(
-            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'count', type: 'number', required: false }] })
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'meta', type: 'object', required: false }] })
         )
 
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { count: '' })).rejects.toMatchObject({
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { meta: 'hello' })).rejects.toMatchObject({
             statusCode: StatusCodes.BAD_REQUEST,
-            message: expect.stringContaining('count')
+            message: expect.stringContaining('meta')
         })
     })
 
-    it('resolves when boolean param is a native boolean (JSON)', async () => {
+    it('throws 400 when object param is an array', async () => {
         mockGetChatflowById.mockResolvedValue(
-            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'meta', type: 'object', required: false }] })
         )
 
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: true })).resolves.toMatchObject({})
-    })
-
-    it('resolves when boolean param is the string "true" (form-encoded)', async () => {
-        mockGetChatflowById.mockResolvedValue(
-            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
-        )
-
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'true' })).resolves.toMatchObject({})
-    })
-
-    it('resolves when boolean param is the string "false" (form-encoded)', async () => {
-        mockGetChatflowById.mockResolvedValue(
-            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
-        )
-
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'false' })).resolves.toMatchObject({})
-    })
-
-    it('throws 400 when boolean param is an invalid string like "yes" (form-encoded)', async () => {
-        mockGetChatflowById.mockResolvedValue(
-            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'active', type: 'boolean', required: false }] })
-        )
-
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { active: 'yes' })).rejects.toMatchObject({
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { meta: [1, 2] })).rejects.toMatchObject({
             statusCode: StatusCodes.BAD_REQUEST,
-            message: expect.stringContaining('active')
+            message: expect.stringContaining('meta')
+        })
+    })
+
+    // --- array[string] type ---
+
+    it('resolves when array[string] param is an array of strings', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'tags', type: 'array[string]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { tags: ['a', 'b'] })).resolves.toMatchObject({})
+    })
+
+    it('throws 400 when array[string] param contains non-strings', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'tags', type: 'array[string]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { tags: [1, 2] })).rejects.toMatchObject({
+            statusCode: StatusCodes.BAD_REQUEST,
+            message: expect.stringContaining('tags')
+        })
+    })
+
+    it('throws 400 when array[string] param is not an array', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'tags', type: 'array[string]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { tags: 'hello' })).rejects.toMatchObject({
+            statusCode: StatusCodes.BAD_REQUEST,
+            message: expect.stringContaining('tags')
+        })
+    })
+
+    // --- array[number] type ---
+
+    it('resolves when array[number] param is an array of numbers', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'scores', type: 'array[number]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { scores: [1, 2, 3] })).resolves.toMatchObject({})
+    })
+
+    it('throws 400 when array[number] param contains non-numbers', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'scores', type: 'array[number]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { scores: ['a', 'b'] })).rejects.toMatchObject({
+            statusCode: StatusCodes.BAD_REQUEST,
+            message: expect.stringContaining('scores')
+        })
+    })
+
+    // --- array[boolean] type ---
+
+    it('resolves when array[boolean] param is an array of booleans', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'flags', type: 'array[boolean]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { flags: [true, false] })).resolves.toMatchObject({})
+    })
+
+    it('throws 400 when array[boolean] param contains boolean strings (no coercion for array elements)', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'flags', type: 'array[boolean]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { flags: ['true', 'false'] })).rejects.toMatchObject({
+            statusCode: StatusCodes.BAD_REQUEST,
+            message: expect.stringContaining('flags')
+        })
+    })
+
+    // --- array[object] type ---
+
+    it('resolves when array[object] param is an array of plain objects', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'items', type: 'array[object]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { items: [{ a: 1 }, { b: 2 }] })).resolves.toMatchObject(
+            {}
+        )
+    })
+
+    it('throws 400 when array[object] param contains non-objects', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'items', type: 'array[object]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { items: ['a', 'b'] })).rejects.toMatchObject({
+            statusCode: StatusCodes.BAD_REQUEST,
+            message: expect.stringContaining('items')
+        })
+    })
+
+    it('throws 400 when array[object] param contains nested arrays', async () => {
+        mockGetChatflowById.mockResolvedValue(
+            makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'items', type: 'array[object]', required: false }] })
+        )
+
+        await expect(webhookService.validateWebhookChatflow('some-id', undefined, { items: [[1, 2]] })).rejects.toMatchObject({
+            statusCode: StatusCodes.BAD_REQUEST,
+            message: expect.stringContaining('items')
         })
     })
 
@@ -329,95 +415,6 @@ describe('validateWebhookChatflow', () => {
         mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', { webhookQueryParams: [{ name: 'page', required: true }] }))
 
         await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, { page: '2' })).resolves.toMatchObject({})
-    })
-
-    // --- HMAC signature verification ---
-
-    const SECRET = 'test-secret-abc123'
-    const RAW_BODY = Buffer.from('{"event":"push"}')
-
-    function sign(secret: string, body: Buffer): string {
-        const { createHmac } = require('crypto')
-        return createHmac('sha256', secret).update(body).digest('hex')
-    }
-
-    it('resolves without signature check when no webhookSecret is configured', async () => {
-        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger'))
-
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY)).resolves.toMatchObject({})
-    })
-
-    it('resolves when secret is set and signature is valid', async () => {
-        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
-        mockGetWebhookSecret.mockResolvedValue(SECRET)
-        const headers = { 'x-webhook-signature': sign(SECRET, RAW_BODY) }
-
-        await expect(
-            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, RAW_BODY)
-        ).resolves.toMatchObject({})
-    })
-
-    it('throws 401 when secret is set but X-Webhook-Signature header is missing', async () => {
-        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
-        mockGetWebhookSecret.mockResolvedValue(SECRET)
-
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY)).rejects.toMatchObject({
-            statusCode: 401
-        })
-    })
-
-    it('throws 401 when secret is set but signature is wrong', async () => {
-        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
-        mockGetWebhookSecret.mockResolvedValue(SECRET)
-        const headers = { 'x-webhook-signature': 'deadbeef' }
-
-        await expect(webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, RAW_BODY)).rejects.toMatchObject(
-            {
-                statusCode: 401
-            }
-        )
-    })
-
-    it('throws 401 when payload is tampered (signature computed against original body)', async () => {
-        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
-        mockGetWebhookSecret.mockResolvedValue(SECRET)
-        const tamperedBody = Buffer.from('{"event":"delete"}')
-        const headers = { 'x-webhook-signature': sign(SECRET, RAW_BODY) }
-
-        await expect(
-            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, tamperedBody)
-        ).rejects.toMatchObject({ statusCode: 401 })
-    })
-
-    it('throws 401 when secret is set but rawBody is undefined', async () => {
-        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
-        mockGetWebhookSecret.mockResolvedValue(SECRET)
-        const headers = { 'x-webhook-signature': sign(SECRET, RAW_BODY) }
-
-        await expect(
-            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', headers, {}, undefined)
-        ).rejects.toMatchObject({ statusCode: 401 })
-    })
-
-    // --- skipFieldValidation option (resume calls) ---
-
-    it('skips field validation when skipFieldValidation is true', async () => {
-        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', { webhookBodyParams: [{ name: 'action', required: true }] }))
-
-        // Missing required body param 'action' — would normally throw 400, but not on resume
-        await expect(
-            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, undefined, { skipFieldValidation: true })
-        ).resolves.toMatchObject({})
-    })
-
-    it('still runs signature check when skipFieldValidation is true', async () => {
-        mockGetChatflowById.mockResolvedValue(makeChatflow('webhookTrigger', {}, { webhookSecretConfigured: true }))
-        mockGetWebhookSecret.mockResolvedValue(SECRET)
-
-        // No signature header — should still 401 even with skipFieldValidation
-        await expect(
-            webhookService.validateWebhookChatflow('some-id', undefined, {}, 'POST', {}, {}, RAW_BODY, { skipFieldValidation: true })
-        ).rejects.toMatchObject({ statusCode: 401 })
     })
 
     // --- HMAC signature verification ---

--- a/packages/server/src/services/webhook/index.ts
+++ b/packages/server/src/services/webhook/index.ts
@@ -96,6 +96,14 @@ const validateWebhookChatflow = async (
                 const val = body[p.name]
                 if (p.type === 'number') return val === '' || isNaN(Number(val))
                 if (p.type === 'boolean') return typeof val !== 'boolean' && val !== 'true' && val !== 'false'
+                if (p.type === 'object') return typeof val !== 'object' || val === null || Array.isArray(val)
+                if (p.type === 'array[string]') return !Array.isArray(val) || (val as unknown[]).some((el) => typeof el !== 'string')
+                if (p.type === 'array[number]') return !Array.isArray(val) || (val as unknown[]).some((el) => typeof el !== 'number')
+                if (p.type === 'array[boolean]') return !Array.isArray(val) || (val as unknown[]).some((el) => typeof el !== 'boolean')
+                if (p.type === 'array[object]')
+                    return (
+                        !Array.isArray(val) || (val as unknown[]).some((el) => typeof el !== 'object' || el === null || Array.isArray(el))
+                    )
                 return typeof val !== p.type
             })
             .map((p) => p.name)

--- a/packages/ui/src/utils/genericHelper.js
+++ b/packages/ui/src/utils/genericHelper.js
@@ -1292,6 +1292,17 @@ export const showHideInputs = (nodeData, inputType, overrideParams, arrayIndex) 
         if (inputParam.hide) {
             _showHideOperation(nodeData, inputParam, 'hide', arrayIndex)
         }
+
+        // Filter individual options within dropdowns based on their own show/hide conditions
+        if (inputParam.type === 'options' && inputParam.options) {
+            inputParam.options = inputParam.options.filter((opt) => {
+                if (typeof opt === 'string' || (!opt.show && !opt.hide)) return true
+                const synthetic = { show: opt.show, hide: opt.hide, display: true }
+                if (opt.show) _showHideOperation(nodeData, synthetic, 'show', arrayIndex)
+                if (opt.hide) _showHideOperation(nodeData, synthetic, 'hide', arrayIndex)
+                return synthetic.display !== false
+            })
+        }
     }
 
     return params


### PR DESCRIPTION
## Changes
- Add object, array[string/number/boolean/object] as webhook expected body param types, available when content type is `application/json`, should not show for `application/x-form-urlencoded`
- There was no easy way to `show/hide` specific options based on a selection from another node, so added the ability to `show/hide` options as well in inputs.
- Extend options fields with show/hide conditions so individual dropdown choices can be hidden based on other param values

## Videos 
<details>
  <summary>Test Videos Demo</summary>
  <b>expected-params-OBJECT</b>
  <video src="https://github.com/user-attachments/assets/889828bf-8129-46f8-9651-e0310ddd8511" controls width="100%"></video>

  <b>expected-param-ARRAY</b>
  <video src="https://github.com/user-attachments/assets/dcedf16b-29db-47f2-907f-d89b0c354c3a" controls width="100%"></video>

  <b>canvas-dropdowns</b>
  <video src="https://github.com/user-attachments/assets/d8f9b491-ce34-4f40-823b-d0d8a29686b3" controls width="100%"></video>
  
    <b>package-agentflow-dropdowns but is currently hidden, just showing this that it works</b>
  <video src="https://github.com/user-attachments/assets/98f31939-50ea-47b7-aca9-9a09824481a4" controls width="100%"></video>

</details>

## Screenshots
<img width="573" height="556" alt="Screenshot 2026-04-22 at 2 50 52 PM" src="https://github.com/user-attachments/assets/9ccfc493-93e7-40ea-9457-48f1dda6bedd" />
