### PR TITLE
Chore update Node.js version to 20.20.2 in CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 platform: [ubuntu-latest]
-                node-version: [18.15.0]
+                node-version: [20.20.2]
         runs-on: ${{ matrix.platform }}
         env:
             PUPPETEER_SKIP_DOWNLOAD: true

--- a/.github/workflows/publish-agentflow.yml
+++ b/.github/workflows/publish-agentflow.yml
@@ -42,7 +42,7 @@ jobs:
 
             - uses: actions/setup-node@v6
               with:
-                  node-version: '18.15.0'
+                  node-version: '20.20.2'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Validate custom version
@@ -107,7 +107,7 @@ jobs:
 
             - uses: actions/setup-node@v6
               with:
-                  node-version: '18.15.0'
+                  node-version: '20.20.2'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Install dependencies


### PR DESCRIPTION
Updates Node.js version from 18.15.0 to 20.20.2 in GitHub Actions workflows to fix CI pipeline failures.