### PR TITLE
feat: add GPT-5.5 and GPT-5.5 Pro to OpenAI chat models

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1563,6 +1563,18 @@
             "name": "chatOpenAI_LlamaIndex",
             "models": [
                 {
+                    "label": "gpt-5.5",
+                    "name": "gpt-5.5",
+                    "input_cost": 0.000005,
+                    "output_cost": 0.00003
+                },
+                {
+                    "label": "gpt-5.5-pro",
+                    "name": "gpt-5.5-pro",
+                    "input_cost": 0.00003,
+                    "output_cost": 0.00018
+                },
+                {
                     "label": "gpt-4o",
                     "name": "gpt-4o",
                     "input_cost": 2.5e-6,

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -1276,6 +1276,18 @@
             "name": "chatOpenAI",
             "models": [
                 {
+                    "label": "gpt-5.5",
+                    "name": "gpt-5.5",
+                    "input_cost": 0.000005,
+                    "output_cost": 0.00003
+                },
+                {
+                    "label": "gpt-5.5-pro",
+                    "name": "gpt-5.5-pro",
+                    "input_cost": 0.00003,
+                    "output_cost": 0.00018
+                },
+                {
                     "label": "gpt-5.4",
                     "name": "gpt-5.4",
                     "input_cost": 0.0000025,


### PR DESCRIPTION
Adds the newly released GPT-5.5 and GPT-5.5 Pro models to the OpenAI chat model list in `models.json`.

  OpenAI announced GPT-5.5 on **April 23, 2026**, with API access described as "coming very soon." This PR adds both variants ahead of full API availability so users can select them as soon as they become accessible.

  ## Changes

  - `packages/components/models.json` - added `gpt-5.5` and `gpt-5.5-pro` at the top of the `chatOpenAI` models array

  ## Pricing

  | Model | Input / 1M tokens | Output / 1M tokens |
  |---|---|---|
  | gpt-5.5 | $5.00 | $30.00 |
  | gpt-5.5-pro | $30.00 | $180.00 |

  ## References

  - [Introducing GPT-5.5 | OpenAI](https://openai.com/index/introducing-gpt-5-5/)
  - [OpenAI Developer Community announcement](https://community.openai.com/t/gpt-5-5-is-here-available-in-codex-and-chatgpt-today/1379630)