### PR TITLE
bugfix:308 | remove ungated overrideConfig spread

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -1099,8 +1099,7 @@ const executeNode = async ({
             apiMessageId,
             chatHistory,
             runtimeChatHistoryLength: Math.max(0, runtimeChatHistory.length - 1),
-            state: updatedState,
-            ...overrideConfig
+            state: updatedState
         }
         if (
             iterationContext &&

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -562,8 +562,7 @@ export const executeFlow = async ({
         chatId,
         sessionId,
         chatHistory,
-        apiMessageId,
-        ...incomingInput.overrideConfig
+        apiMessageId
     }
 
     logger.debug(`[server]: [${orgId}]: Start building flow ${chatflowid}`)

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -566,9 +566,11 @@ export const buildFlow = async ({
 
     const flowData: ICommonObject = {
         chatflowid,
+        chatflowId: chatflowid,
         chatId,
         sessionId,
-        chatHistory
+        chatHistory,
+        apiMessageId
     }
     while (nodeQueue.length) {
         const { nodeId, depth } = nodeQueue.shift() as INodeQueue

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -568,8 +568,7 @@ export const buildFlow = async ({
         chatflowid,
         chatId,
         sessionId,
-        chatHistory,
-        ...overrideConfig
+        chatHistory
     }
     while (nodeQueue.length) {
         const { nodeId, depth } = nodeQueue.shift() as INodeQueue


### PR DESCRIPTION
## Changes
- Remove `...overrideConfig` spread from `flowConfig/flowData` objects in `buildChatflow.ts, buildAgentflow.ts, and util.index.ts`
- This spread allowed API callers to inject arbitrary keys into the `$flow.*` template variable namespace without any authorization check, bypassing the per-parameter gating that `replaceInputsWithConfig()` enforces
- Internal `$flow.*` variables (chatId, sessionId, chatHistory, etc.) continue to resolve because they are explicit fields on the config objects

Fixes: [Flowise 308](https://jira2.workday.com/browse/FLOWISE-308)

## Video Demos
<details>
<summary>Test Videos Demo</summary>

<b>Chatflow-Before-injected.mp4</b>
<video src="https://github.com/user-attachments/assets/500b5ee8-4854-47a6-af56-5e9df45cbb16" controls width="100%"></video>

<b>Chatflow-After-not-injected.mp4</b>
<video src="https://github.com/user-attachments/assets/4357cdcf-70c0-4160-9cdf-15823f78317c" controls width="100%"></video>

<b>Agentflow-BEFORE-ap...still-can-override.mp4</b>
<video src="https://github.com/user-attachments/assets/a7006a53-138f-4311-bd56-f98e9f6920c6" controls width="100%"></video>

<b>Agentflow-AFTER-Nee...Override-To-Work.mp4</b>
<video src="https://github.com/user-attachments/assets/c4293ca8-2ce5-49b3-b640-b063e0aabf6a" controls width="100%"></video>

</details>
