### PR TITLE
feat: add FuturMix as chat model provider

### DIFF
--- a/packages/components/credentials/FuturMixApi.credential.ts
+++ b/packages/components/credentials/FuturMixApi.credential.ts
@@ -1,0 +1,25 @@
+import { INodeParams, INodeCredential } from '../src/Interface'
+
+class FuturMixAPIAuth implements INodeCredential {
+    label: string
+    name: string
+    version: number
+    description: string
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'FuturMix API Key'
+        this.name = 'futurmixApi'
+        this.version = 1.0
+        this.inputs = [
+            {
+                label: 'FuturMix API Key',
+                name: 'futurmixApiKey',
+                type: 'password',
+                description: 'API Key from https://futurmix.ai'
+            }
+        ]
+    }
+}
+
+module.exports = { credClass: FuturMixAPIAuth }

--- a/packages/components/nodes/chatmodels/ChatFuturMix/ChatFuturMix.ts
+++ b/packages/components/nodes/chatmodels/ChatFuturMix/ChatFuturMix.ts
@@ -148,13 +148,13 @@ class ChatFuturMix_ChatModels implements INode {
         const futurmixApiKey = getCredentialParam('futurmixApiKey', credentialData, nodeData)
 
         const obj: ChatOpenAIFields = {
-            temperature: parseFloat(temperature),
             modelName,
             openAIApiKey: futurmixApiKey,
             apiKey: futurmixApiKey,
             streaming: streaming ?? true
         }
 
+        if (temperature) obj.temperature = parseFloat(temperature)
         if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
         if (topP) obj.topP = parseFloat(topP)
         if (frequencyPenalty) obj.frequencyPenalty = parseFloat(frequencyPenalty)

--- a/packages/components/nodes/chatmodels/ChatFuturMix/ChatFuturMix.ts
+++ b/packages/components/nodes/chatmodels/ChatFuturMix/ChatFuturMix.ts
@@ -1,0 +1,194 @@
+import { ChatOpenAI as LangchainChatOpenAI, ChatOpenAIFields } from '@langchain/openai'
+import { BaseCache } from '@langchain/core/caches'
+import { ICommonObject, IMultiModalOption, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { ChatFuturMix } from './FlowiseChatFuturMix'
+
+class ChatFuturMix_ChatModels implements INode {
+    label: string
+    name: string
+    version: number
+    type: string
+    icon: string
+    category: string
+    description: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'FuturMix'
+        this.name = 'chatFuturMix'
+        this.version = 1.0
+        this.type = 'ChatFuturMix'
+        this.icon = 'futurmix.svg'
+        this.category = 'Chat Models'
+        this.description = 'Wrapper around FuturMix AI Gateway - Access 22+ models with a single API key'
+        this.baseClasses = [this.type, ...getBaseClasses(LangchainChatOpenAI)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['futurmixApi'],
+            optional: true
+        }
+        this.inputs = [
+            {
+                label: 'Cache',
+                name: 'cache',
+                type: 'BaseCache',
+                optional: true
+            },
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'string',
+                placeholder: 'claude-sonnet-4-20250514'
+            },
+            {
+                label: 'Temperature',
+                name: 'temperature',
+                type: 'number',
+                step: 0.1,
+                default: 0.9,
+                optional: true
+            },
+            {
+                label: 'Streaming',
+                name: 'streaming',
+                type: 'boolean',
+                default: true,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Allow Image Uploads',
+                name: 'allowImageUploads',
+                type: 'boolean',
+                description:
+                    'Allow image input. Refer to the <a href="https://docs.flowiseai.com/using-flowise/uploads#image" target="_blank">docs</a> for more details.',
+                default: false,
+                optional: true
+            },
+            {
+                label: 'Max Tokens',
+                name: 'maxTokens',
+                type: 'number',
+                step: 1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Top Probability',
+                name: 'topP',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Frequency Penalty',
+                name: 'frequencyPenalty',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Presence Penalty',
+                name: 'presencePenalty',
+                type: 'number',
+                step: 0.1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Timeout',
+                name: 'timeout',
+                type: 'number',
+                step: 1,
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Base Path',
+                name: 'basepath',
+                type: 'string',
+                optional: true,
+                default: 'https://futurmix.ai/v1',
+                description: 'Override the default base URL for the API.',
+                additionalParams: true
+            },
+            {
+                label: 'Base Options',
+                name: 'baseOptions',
+                type: 'json',
+                optional: true,
+                description: 'Default headers to include with every request to the API.',
+                additionalParams: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const temperature = nodeData.inputs?.temperature as string
+        const modelName = nodeData.inputs?.modelName as string
+        const maxTokens = nodeData.inputs?.maxTokens as string
+        const topP = nodeData.inputs?.topP as string
+        const frequencyPenalty = nodeData.inputs?.frequencyPenalty as string
+        const presencePenalty = nodeData.inputs?.presencePenalty as string
+        const timeout = nodeData.inputs?.timeout as string
+        const streaming = nodeData.inputs?.streaming as boolean
+        const basePath = (nodeData.inputs?.basepath as string) || 'https://futurmix.ai/v1'
+        const baseOptions = nodeData.inputs?.baseOptions
+        const cache = nodeData.inputs?.cache as BaseCache
+        const allowImageUploads = nodeData.inputs?.allowImageUploads as boolean
+
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const futurmixApiKey = getCredentialParam('futurmixApiKey', credentialData, nodeData)
+
+        const obj: ChatOpenAIFields = {
+            temperature: parseFloat(temperature),
+            modelName,
+            openAIApiKey: futurmixApiKey,
+            apiKey: futurmixApiKey,
+            streaming: streaming ?? true
+        }
+
+        if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
+        if (topP) obj.topP = parseFloat(topP)
+        if (frequencyPenalty) obj.frequencyPenalty = parseFloat(frequencyPenalty)
+        if (presencePenalty) obj.presencePenalty = parseFloat(presencePenalty)
+        if (timeout) obj.timeout = parseInt(timeout, 10)
+        if (cache) obj.cache = cache
+
+        let parsedBaseOptions: any | undefined = undefined
+
+        if (baseOptions) {
+            try {
+                parsedBaseOptions = typeof baseOptions === 'object' ? baseOptions : JSON.parse(baseOptions)
+            } catch (exception) {
+                throw new Error("Invalid JSON in the ChatFuturMix's BaseOptions: " + exception)
+            }
+        }
+
+        if (basePath || parsedBaseOptions) {
+            obj.configuration = {
+                baseURL: basePath,
+                defaultHeaders: parsedBaseOptions
+            }
+        }
+
+        const multiModalOption: IMultiModalOption = {
+            image: {
+                allowImageUploads: allowImageUploads ?? false
+            }
+        }
+
+        const model = new ChatFuturMix(nodeData.id, obj)
+        model.setMultiModalOption(multiModalOption)
+        return model
+    }
+}
+
+module.exports = { nodeClass: ChatFuturMix_ChatModels }

--- a/packages/components/nodes/chatmodels/ChatFuturMix/FlowiseChatFuturMix.ts
+++ b/packages/components/nodes/chatmodels/ChatFuturMix/FlowiseChatFuturMix.ts
@@ -1,0 +1,20 @@
+import { ChatOpenAI as LangchainChatOpenAI, ChatOpenAIFields } from '@langchain/openai'
+import { IMultiModalOption, IVisionChatModal } from '../../../src'
+
+export class ChatFuturMix extends LangchainChatOpenAI implements IVisionChatModal {
+    configuredModel: string
+    configuredMaxToken?: number
+    multiModalOption: IMultiModalOption
+    id: string
+
+    constructor(id: string, fields?: ChatOpenAIFields) {
+        super(fields)
+        this.id = id
+        this.configuredModel = fields?.modelName ?? ''
+        this.configuredMaxToken = fields?.maxTokens
+    }
+
+    setMultiModalOption(multiModalOption: IMultiModalOption): void {
+        this.multiModalOption = multiModalOption
+    }
+}

--- a/packages/components/nodes/chatmodels/ChatFuturMix/futurmix.svg
+++ b/packages/components/nodes/chatmodels/ChatFuturMix/futurmix.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8b5cf6;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" rx="20" fill="url(#grad)"/>
+  <text x="50" y="62" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="36" fill="white">FM</text>
+</svg>


### PR DESCRIPTION
## Summary

Add FuturMix.ai as a new chat model provider, following the same pattern as ChatOpenRouter.

**Files added:**
- `packages/components/credentials/FuturMixApi.credential.ts` — API key credential
- `packages/components/nodes/chatmodels/ChatFuturMix/ChatFuturMix.ts` — Chat model component
- `packages/components/nodes/chatmodels/ChatFuturMix/FlowiseChatFuturMix.ts` — Multi-modal wrapper
- `packages/components/nodes/chatmodels/ChatFuturMix/futurmix.svg` — Provider icon

**What is FuturMix?**

[FuturMix.ai](https://futurmix.ai) is an enterprise AI agent platform providing access to 22+ models (Claude, GPT, Gemini) through a single OpenAI-compatible API with 99.99% SLA. 

**Implementation:**
- Extends LangChain `ChatOpenAI` with custom `baseURL` (same pattern as ChatOpenRouter)
- Implements `IVisionChatModal` for multi-modal image upload support
- Supports streaming, temperature, max tokens, top-p, frequency/presence penalty
- Default base path: (see [futurmix.ai](https://futurmix.ai)) (configurable)