### PR TITLE
feat(components): add newer Voyage AI embedding and reranker models

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -2626,5 +2626,47 @@
                 }
             ]
         }
+    ],
+    "reranker": [
+        {
+            "name": "voyageAIRerankRetriever",
+            "models": [
+                {
+                    "label": "rerank-2.5",
+                    "name": "rerank-2.5",
+                    "description": "Latest general-purpose reranker with top relevance quality."
+                },
+                {
+                    "label": "rerank-2.5-lite",
+                    "name": "rerank-2.5-lite",
+                    "description": "Lightweight version of rerank-2.5, optimized for latency and cost."
+                },
+                {
+                    "label": "rerank-2",
+                    "name": "rerank-2",
+                    "description": "General-purpose reranker model."
+                },
+                {
+                    "label": "rerank-2-lite",
+                    "name": "rerank-2-lite",
+                    "description": "Lightweight version of rerank-2, optimized for latency and cost."
+                },
+                {
+                    "label": "rerank-1",
+                    "name": "rerank-1",
+                    "description": "Legacy general-purpose reranker. Kept for backward compatibility."
+                },
+                {
+                    "label": "rerank-lite-2",
+                    "name": "rerank-lite-2",
+                    "description": "Legacy lightweight reranker. Kept for backward compatibility."
+                },
+                {
+                    "label": "rerank-lite-1",
+                    "name": "rerank-lite-1",
+                    "description": "Legacy lightweight reranker. Kept for backward compatibility."
+                }
+            ]
+        }
     ]
 }

--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -2259,6 +2259,26 @@
             "name": "voyageAIEmbeddings",
             "models": [
                 {
+                    "label": "voyage-3.5",
+                    "name": "voyage-3.5",
+                    "description": "Latest general-purpose embedding model with top retrieval quality."
+                },
+                {
+                    "label": "voyage-3.5-lite",
+                    "name": "voyage-3.5-lite",
+                    "description": "Lightweight version of voyage-3.5, optimized for latency and cost."
+                },
+                {
+                    "label": "voyage-multimodal-3.5",
+                    "name": "voyage-multimodal-3.5",
+                    "description": "Multimodal embedding model for text and image retrieval."
+                },
+                {
+                    "label": "voyage-multimodal-3",
+                    "name": "voyage-multimodal-3",
+                    "description": "Multimodal embedding model for text and image retrieval."
+                },
+                {
                     "label": "voyage-3",
                     "name": "voyage-3",
                     "description": "High-performance embedding model with excellent retrieval quality, 32K token context, and 1024 dimension size."
@@ -2267,6 +2287,16 @@
                     "label": "voyage-3-lite",
                     "name": "voyage-3-lite",
                     "description": "Lightweight embedding model optimized for low latency and cost, 32K token context, and 512 dimension size."
+                },
+                {
+                    "label": "voyage-3-large",
+                    "name": "voyage-3-large",
+                    "description": "Large embedding model with higher dimension size for improved retrieval quality."
+                },
+                {
+                    "label": "voyage-code-3",
+                    "name": "voyage-code-3",
+                    "description": "Optimized for code retrieval and understanding."
                 },
                 {
                     "label": "voyage-2",

--- a/packages/components/nodes/retrievers/VoyageAIRetriever/VoyageAIRerankRetriever.ts
+++ b/packages/components/nodes/retrievers/VoyageAIRetriever/VoyageAIRerankRetriever.ts
@@ -3,7 +3,8 @@ import { VectorStoreRetriever } from '@langchain/core/vectorstores'
 import { ContextualCompressionRetriever } from '@langchain/classic/retrievers/contextual_compression'
 import { VoyageAIRerank } from './VoyageAIRerank'
 import { getCredentialData, getCredentialParam, handleEscapeCharacters } from '../../../src'
-import { ICommonObject, INode, INodeData, INodeOutputsValue, INodeParams } from '../../../src/Interface'
+import { ICommonObject, INode, INodeData, INodeOptionsValue, INodeOutputsValue, INodeParams } from '../../../src/Interface'
+import { MODEL_TYPE, getModels } from '../../../src/modelLoader'
 
 class VoyageAIRerankRetriever_Retrievers implements INode {
     label: string
@@ -43,37 +44,8 @@ class VoyageAIRerankRetriever_Retrievers implements INode {
             {
                 label: 'Model Name',
                 name: 'model',
-                type: 'options',
-                options: [
-                    {
-                        label: 'rerank-2.5',
-                        name: 'rerank-2.5'
-                    },
-                    {
-                        label: 'rerank-2.5-lite',
-                        name: 'rerank-2.5-lite'
-                    },
-                    {
-                        label: 'rerank-2',
-                        name: 'rerank-2'
-                    },
-                    {
-                        label: 'rerank-2-lite',
-                        name: 'rerank-2-lite'
-                    },
-                    {
-                        label: 'rerank-1',
-                        name: 'rerank-1'
-                    },
-                    {
-                        label: 'rerank-lite-2',
-                        name: 'rerank-lite-2'
-                    },
-                    {
-                        label: 'rerank-lite-1',
-                        name: 'rerank-lite-1'
-                    }
-                ],
+                type: 'asyncOptions',
+                loadMethod: 'listModels',
                 default: 'rerank-2.5',
                 optional: true
             },
@@ -114,6 +86,13 @@ class VoyageAIRerankRetriever_Retrievers implements INode {
                 baseClasses: ['string', 'json']
             }
         ]
+    }
+
+    //@ts-ignore
+    loadMethods = {
+        async listModels(): Promise<INodeOptionsValue[]> {
+            return await getModels(MODEL_TYPE.RERANKER, 'voyageAIRerankRetriever')
+        }
     }
 
     async init(nodeData: INodeData, input: string, options: ICommonObject): Promise<any> {

--- a/packages/components/nodes/retrievers/VoyageAIRetriever/VoyageAIRerankRetriever.ts
+++ b/packages/components/nodes/retrievers/VoyageAIRetriever/VoyageAIRerankRetriever.ts
@@ -46,23 +46,31 @@ class VoyageAIRerankRetriever_Retrievers implements INode {
                 type: 'options',
                 options: [
                     {
-                        label: 'rerank-lite-1',
-                        name: 'rerank-lite-1'
+                        label: 'rerank-2.5',
+                        name: 'rerank-2.5'
                     },
                     {
-                        label: 'rerank-lite-2',
-                        name: 'rerank-lite-2'
+                        label: 'rerank-2.5-lite',
+                        name: 'rerank-2.5-lite'
+                    },
+                    {
+                        label: 'rerank-2',
+                        name: 'rerank-2'
+                    },
+                    {
+                        label: 'rerank-2-lite',
+                        name: 'rerank-2-lite'
                     },
                     {
                         label: 'rerank-1',
                         name: 'rerank-1'
                     },
                     {
-                        label: 'rerank-2',
-                        name: 'rerank-2'
+                        label: 'rerank-lite-1',
+                        name: 'rerank-lite-1'
                     }
                 ],
-                default: 'rerank-lite-1',
+                default: 'rerank-2.5',
                 optional: true
             },
             {

--- a/packages/components/nodes/retrievers/VoyageAIRetriever/VoyageAIRerankRetriever.ts
+++ b/packages/components/nodes/retrievers/VoyageAIRetriever/VoyageAIRerankRetriever.ts
@@ -66,6 +66,10 @@ class VoyageAIRerankRetriever_Retrievers implements INode {
                         name: 'rerank-1'
                     },
                     {
+                        label: 'rerank-lite-2',
+                        name: 'rerank-lite-2'
+                    },
+                    {
                         label: 'rerank-lite-1',
                         name: 'rerank-lite-1'
                     }

--- a/packages/components/src/modelLoader.ts
+++ b/packages/components/src/modelLoader.ts
@@ -6,7 +6,8 @@ import { INodeOptionsValue } from './Interface'
 export enum MODEL_TYPE {
     CHAT = 'chat',
     LLM = 'llm',
-    EMBEDDING = 'embedding'
+    EMBEDDING = 'embedding',
+    RERANKER = 'reranker'
 }
 
 const getModelsJSONPath = (): string => {


### PR DESCRIPTION
## Proposed changes

The Voyage AI embedding and reranker nodes were missing several newer models. The embeddings list in models.json didn't have voyage-multimodal-3, voyage-3.5, voyage-code-3, or voyage-3-large. The reranker dropdown was stuck on older models and missing rerank-2.5 entirely. This adds all current Voyage AI models to both nodes and bumps the reranker default to rerank-2.5.

## Issue(s)

Closes #3442

## How to test or reproduce

1. `pnpm build && pnpm start`
2. Create a chatflow with a VoyageAI Embedding node — confirm voyage-multimodal-3, voyage-3.5, voyage-code-3 etc. appear in the model dropdown
3. Add a Voyage AI Rerank Retriever node — confirm rerank-2.5, rerank-2.5-lite, rerank-2-lite appear and rerank-2.5 is the default

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] Lint and unit tests pass locally with my changes