### PR TITLE
fix: randomSeed always ignored in ChatMistral node

### DIFF
--- a/packages/components/nodes/chatmodels/ChatMistral/ChatMistral.ts
+++ b/packages/components/nodes/chatmodels/ChatMistral/ChatMistral.ts
@@ -125,7 +125,7 @@ class ChatMistral_ChatModels implements INode {
         const maxOutputTokens = nodeData.inputs?.maxOutputTokens as string
         const topP = nodeData.inputs?.topP as string
         const safeMode = nodeData.inputs?.safeMode as boolean
-        const randomSeed = nodeData.inputs?.safeMode as string
+        const randomSeed = nodeData.inputs?.randomSeed as string
         const overrideEndpoint = nodeData.inputs?.overrideEndpoint as string
         const streaming = nodeData.inputs?.streaming as boolean
         const cache = nodeData.inputs?.cache as BaseCache


### PR DESCRIPTION
## Problem

In `ChatMistral.ts`, the `randomSeed` variable was reading from the wrong input key:

```typescript
// before (line 128)
const randomSeed = nodeData.inputs?.safeMode as string  // ← reads safeMode, not randomSeed
```

This means the Random Seed UI field is completely ignored — no value entered by the user is ever passed to the model.

Additionally, when `safeMode` is `true`, this bug causes `randomSeed` to receive `"true"` (a string), and `parseFloat("true")` evaluates to `NaN`, which is silently passed to `obj.randomSeed`.

## Fix

```typescript
// after
const randomSeed = nodeData.inputs?.randomSeed as string
```

## Tested

- randomSeed set, safeMode off -> `obj.randomSeed` correctly assigned
- randomSeed empty, safeMode on -> `obj.randomSeed` not set
- randomSeed set, safeMode on -> both fields applied independently

