### PR TITLE
feat: expose searchDomainFilter and searchRecencyFilter in Perplexity…

### DIFF
--- a/packages/components/nodes/chatmodels/ChatPerplexity/ChatPerplexity.ts
+++ b/packages/components/nodes/chatmodels/ChatPerplexity/ChatPerplexity.ts
@@ -110,14 +110,14 @@ class ChatPerplexity_ChatModels implements INode {
                 optional: true,
                 additionalParams: true
             },
-            // {
-            //     label: 'Search Domain Filter',
-            //     name: 'searchDomainFilter',
-            //     type: 'json',
-            //     optional: true,
-            //     additionalParams: true,
-            //     description: 'Limit citations to URLs from specified domains (e.g., ["example.com", "anotherexample.org"])'
-            // },
+            {
+                label: 'Search Domain Filter',
+                name: 'searchDomainFilter',
+                type: 'json',
+                optional: true,
+                additionalParams: true,
+                description: 'Limit citations to URLs from specified domains (e.g., ["example.com", "anotherexample.org"])'
+            },
             // Currently disabled as output is stored as additional_kwargs
             // {
             //     label: 'Return Images',
@@ -136,22 +136,22 @@ class ChatPerplexity_ChatModels implements INode {
             //     additionalParams: true,
             //     description: 'Whether the online model should return related questions'
             // },
-            // {
-            //     label: 'Search Recency Filter',
-            //     name: 'searchRecencyFilter',
-            //     type: 'options',
-            //     options: [
-            //         { label: 'Not Set', name: '' },
-            //         { label: 'Month', name: 'month' },
-            //         { label: 'Week', name: 'week' },
-            //         { label: 'Day', name: 'day' },
-            //         { label: 'Hour', name: 'hour' }
-            //     ],
-            //     default: '',
-            //     optional: true,
-            //     additionalParams: true,
-            //     description: 'Filter search results by time interval (does not apply to images)'
-            // },
+            {
+                label: 'Search Recency Filter',
+                name: 'searchRecencyFilter',
+                type: 'options',
+                options: [
+                    { label: 'Not Set', name: '' },
+                    { label: 'Month', name: 'month' },
+                    { label: 'Week', name: 'week' },
+                    { label: 'Day', name: 'day' },
+                    { label: 'Hour', name: 'hour' }
+                ],
+                default: '',
+                optional: true,
+                additionalParams: true,
+                description: 'Filter search results by time interval (does not apply to images)'
+            },
             {
                 label: 'Proxy Url',
                 name: 'proxyUrl',


### PR DESCRIPTION
## Problem

The Perplexity node had `searchDomainFilter` and `searchRecencyFilter` UI fields commented out, making them inaccessible to users despite being fully supported by both the LangChain wrapper and the Perplexity API.

The `init()` function already reads and passes these fields to the model — only the UI definitions were missing.

## Changes

Uncommented the two UI input fields in `ChatPerplexity.ts`:

- **Search Domain Filter** (`searchDomainFilter`): Allows users to restrict citations to specific domains (e.g., `["example.com", "docs.mycompany.com"]`)
- **Search Recency Filter** (`searchRecencyFilter`): Allows users to filter search results by time interval — `hour`, `day`, `week`, or `month`

`returnImages` and `returnRelatedQuestions` remain disabled as their output is stored in `additional_kwargs` and not yet handled by Flowise's response pipeline.

## Why no backend changes

The LangChain `PerplexityChatInput` interface already declares both fields, and `invocationParams()` already maps them to the Perplexity API (`search_domain_filter`, `search_recency_filter`). The `init()` function in Flowise also already reads and passes them. This PR only restores the UI exposure.
