### PR TITLE
docs/ui: fix typos in user-facing copy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,5 +84,5 @@ Public Disclosure occurs exactly 30 days after the next official release that in
 
 #### Reaching out to the Security team
 
-To report a new vulnerability, please submit a Github security Security Advisory report.
+To report a new vulnerability, please submit a GitHub Security Advisory report.
 If you have any questions or concerns about the existing Security Advisory, please contact security-team@flowiseai.com.

--- a/packages/components/credentials/JiraApi.credential.ts
+++ b/packages/components/credentials/JiraApi.credential.ts
@@ -12,7 +12,7 @@ class JiraApi implements INodeCredential {
         this.name = 'jiraApi'
         this.version = 1.0
         this.description =
-            'Refer to <a target="_blank" href="https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/">official guide</a> on how to get accessToken on Github'
+            'Refer to <a target="_blank" href="https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/">official guide</a> on how to get an access token on Jira'
         this.inputs = [
             {
                 label: 'User Name',

--- a/packages/components/credentials/StripeApi.credential.ts
+++ b/packages/components/credentials/StripeApi.credential.ts
@@ -12,7 +12,7 @@ class StripeApi implements INodeCredential {
         this.name = 'stripeApi'
         this.version = 1.0
         this.description =
-            'Refer to <a target="_blank" href="https://support.airtable.com/docs/creating-and-using-api-keys-and-access-tokens">official guide</a> on how to get accessToken on Airtable'
+            'Refer to <a target="_blank" href="https://docs.stripe.com/keys">official guide</a> on how to get an API key from Stripe'
         this.inputs = [
             {
                 label: 'Stripe API Token',

--- a/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ViewMessagesDialog.jsx
@@ -312,7 +312,7 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
 
             await chatmessageApi.deleteChatmessage(chatflowid, obj)
             enqueueSnackbar({
-                message: 'Succesfully deleted messages',
+                message: 'Successfully deleted messages',
                 options: {
                     key: new Date().getTime() + Math.random(),
                     variant: 'success',
@@ -430,8 +430,8 @@ const ViewMessagesDialog = ({ show, dialogProps, onCancel }) => {
                 await chatmessageApi.deleteChatmessage(chatflowid, obj)
                 const description =
                     chatmsg.sessionId && chatmsg.memoryType
-                        ? `Succesfully cleared session id: ${chatmsg.sessionId} from ${chatmsg.memoryType}`
-                        : `Succesfully cleared messages`
+                        ? `Successfully cleared session id: ${chatmsg.sessionId} from ${chatmsg.memoryType}`
+                        : `Successfully cleared messages`
                 enqueueSnackbar({
                     message: description,
                     options: {

--- a/packages/ui/src/views/chatmessage/ChatPopUp.jsx
+++ b/packages/ui/src/views/chatmessage/ChatPopUp.jsx
@@ -101,7 +101,7 @@ const ChatPopUp = ({ chatflowid, isAgentCanvas, onOpenChange }) => {
                 removeLocalStorageChatHistory(chatflowid)
                 resetChatDialog()
                 enqueueSnackbar({
-                    message: 'Succesfully cleared all chat history',
+                    message: 'Successfully cleared all chat history',
                     options: {
                         key: new Date().getTime() + Math.random(),
                         variant: 'success',

--- a/packages/ui/src/views/vectorstore/UpsertHistoryDialog.jsx
+++ b/packages/ui/src/views/vectorstore/UpsertHistoryDialog.jsx
@@ -250,7 +250,7 @@ const UpsertHistoryDialog = ({ show, dialogProps, onCancel }) => {
         try {
             await vectorstoreApi.deleteUpsertHistory(selected)
             enqueueSnackbar({
-                message: 'Succesfully deleted upsert history',
+                message: 'Successfully deleted upsert history',
                 options: {
                     key: new Date().getTime() + Math.random(),
                     variant: 'success',

--- a/packages/ui/src/views/vectorstore/VectorStoreDialog.jsx
+++ b/packages/ui/src/views/vectorstore/VectorStoreDialog.jsx
@@ -308,7 +308,7 @@ formData.append("openAIApiKey[openAIEmbeddings_0]", "sk-my-openai-2nd-key")`
         try {
             const res = await vectorstoreApi.upsertVectorStore(dialogProps.chatflowid, { stopNodeId: vectorStoreNode.data.id })
             enqueueSnackbar({
-                message: 'Succesfully upserted vector store. You can start chatting now!',
+                message: 'Successfully upserted vector store. You can start chatting now!',
                 options: {
                     key: new Date().getTime() + Math.random(),
                     variant: 'success',


### PR DESCRIPTION
## Summary
- Fix misspelled “Successfully” in user-facing snackbar messages
- Correct Jira and Stripe credential help text
- Fix typo in the security advisory reporting sentence

## Test plan
- Not run; copy-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)