### PR TITLE
feat(observe): NodeExecutionDetail component

### DIFF
--- a/packages/agentflow/src/core/node-config/nodeIcons.ts
+++ b/packages/agentflow/src/core/node-config/nodeIcons.ts
@@ -1,3 +1,7 @@
+// AGENTFLOW_ICONS registry below is duplicated in
+// packages/observe/src/atoms/NodeIcon.tsx — keep in sync until
+// extracted to packages/shared-ui in FLOWISE-628.
+
 import type { ComponentType } from 'react'
 
 import {

--- a/packages/agentflow/src/core/theme/tokens.ts
+++ b/packages/agentflow/src/core/theme/tokens.ts
@@ -7,6 +7,11 @@
  * Architecture:
  * 1. Base colors - Primitive color values (single source of truth)
  * 2. Semantic colors - Referenced from base colors for consistency
+ *
+ * Base palette and node type colors are duplicated in
+ * packages/observe/src/core/theme/tokens.ts — keep in sync until
+ * extracted to packages/shared-ui in FLOWISE-628. Agentflow extends
+ * the shared base with ReactFlow + syntax highlight tokens, which stay here.
  */
 
 // Base primitive colors - define once, reference everywhere

--- a/packages/observe/ARCHITECTURE.md
+++ b/packages/observe/ARCHITECTURE.md
@@ -394,3 +394,27 @@ import { useObserveApi } from '../../infrastructure/store/ObserveContext'
 | Logic/Types | camelCase.ts                | `execution.ts`, `observe.ts` |
 | API module  | camelCase.ts                | `executions.ts`              |
 | Styles      | kebab-case (co-located)     | `executions.css`             |
+
+### Theme Token Ordering
+
+Inside `core/theme/tokens.ts`, all maps are ordered alphanumerically: `baseColors`, top-level `tokens` groups, subgroups, and keys (e.g. `gray50 < gray75 < gray100 < gray200`). Each `{ dark, light }` / `{ dark, light, main }` pair follows the same rule. Keep new entries in order so diffs stay small.
+
+### Type Location Rule
+
+Domain types live in `core/types/`, **not** alongside their primary component, when they cross any of these boundaries:
+
+-   Imported by a hook (`features/*/hooks/*`)
+-   Imported by another component in a different file
+-   Used in a public API exported via `src/index.ts`
+
+Component-internal types (props interfaces, file-private shapes used only inside the file that defines the component) stay co-located. The rule prevents the inversion where a hook reaches "upward" into a sibling component file just to read a type.
+
+Props interfaces (e.g. `ChatMessageBubbleProps`) are **always** file-local — never lift them to `core/types/` even if another component would re-use one. Re-using a props interface across components is a code smell on its own; the right fix is a shared underlying type, not a shared props interface.
+
+Predicates that narrow into a `core/types/` shape (e.g. `isChatMessageArray(value): value is ChatMessage[]`) live in `core/utils/` next to other domain-aware helpers — never in `atoms/` (atoms cannot import from `core/utils`, only from `core/primitives`).
+
+Example layout:
+
+-   `core/types/nodeDetail.ts` — `ChatMessage`, `ConditionEntry`, `AvailableToolEntry`, `UsedToolEntry`, `UsedToolRef`, `ToolNodeRef`, `NormalizedToolCall`
+-   `core/utils/guards.ts` — `isChatMessageArray`, `isConditionArray`, `isAvailableToolArray`, `isUsedToolArray`
+-   `core/utils/tools.ts` — `resolveTool`, `extractToolCalls` (consumed by `ChatMessageBubble` + `ToolAccordionList`)

--- a/packages/observe/TESTS.md
+++ b/packages/observe/TESTS.md
@@ -28,6 +28,14 @@ Feature-level hooks that orchestrate polling and UI state. Test when adding feat
 
 Presentational components that are mostly JSX. Only add tests if the component contains meaningful business logic. Pure layout/display components do not need tests.
 
+**Currently classified as Tier 3 (no `coverageThreshold` entry):**
+
+-   `ExecutionDetail.tsx` — orchestration shell wiring `useExecutionPoll` + `useExecutionTree` + `useResizableSidebar` + `<ExecutionTreeSidebar>` + `<NodeExecutionDetail>`. The drag-resize logic was lifted to `useResizableSidebar` (testable in isolation); the recursive tree renderer was lifted to `<ExecutionTreeSidebar>`. What remains is composition.
+-   `ExecutionTreeSidebar.tsx` — recursive list rendering with one click branch (skip-on-virtual-node). Add tests if the tree gains filtering, search, or non-trivial expand/collapse behavior.
+-   `ExecutionsListTable.tsx`, `ExecutionsViewer.tsx` — data-table + outer composition shells.
+
+If any of these grows real branching logic (filter predicates, sort comparators, debounced handlers), promote it to Tier 2 by adding a `coverageThreshold` entry in `jest.config.js` and writing the corresponding tests.
+
 ## Writing Tests
 
 ### File Extension Convention
@@ -75,6 +83,50 @@ jest.mock('@/infrastructure/store', () => ({
 ### Custom Jest Environment
 
 `src/__test_utils__/jest-environment-jsdom.js` intercepts `require('canvas')` and returns a mock before jsdom tries to load the native binary. This prevents build failures in environments without native canvas compilation.
+
+## Best Practices
+
+> The same content lives in the `dev-implement-jira` skill so it's discoverable cross-package. Keep both copies in sync when editing.
+
+### Test behavior, not implementation
+
+Assert on what a consumer of the unit observes — return values, rendered output, calls made to dependencies — not on internal state or which private helper ran. A refactor that preserves behavior should not break tests.
+
+### Use Arrange-Act-Assert structure
+
+Group each test into three blocks: set up inputs and mocks, invoke the unit under test, then assert. Keeping the steps visually distinct makes failures easier to diagnose.
+
+### One concept per test
+
+Each `it(...)` should verify a single behavior. Multiple low-level `expect` calls are fine if they describe one concept (e.g. one rendered tree shape), but unrelated assertions belong in separate tests so a failure points to a single cause.
+
+### Write descriptive test names
+
+Name tests by scenario and expected outcome: `it('returns empty tree when execution has no nodes')`, not `it('works')`. Prefer `describe` blocks per function or component, with `it` names that read as full sentences.
+
+### Keep tests independent and deterministic
+
+Reset state between tests — call `jest.clearAllMocks()` in `beforeEach` and avoid module-level mutable variables. No test should depend on execution order. Avoid real timers, real network, or `Date.now()` without `jest.useFakeTimers()`.
+
+### Mock at boundaries, not internals
+
+Mock external dependencies (axios, the API client, browser globals) and let internal modules run as written. Over-mocking internal collaborators couples tests to structure and hides integration bugs.
+
+### Cover meaningful edge cases
+
+For data transforms and hooks, add tests for empty input, single-element input, error/loading states, and any branch in the code. Coverage percentage is a floor — a 100%-covered function with only happy-path tests still has gaps.
+
+### Prefer `userEvent` over `fireEvent`
+
+When testing components, `@testing-library/user-event` simulates real interaction sequences (focus, keystrokes, click order). Use `fireEvent` only for events `userEvent` cannot synthesize.
+
+### Query by accessible role and text
+
+`getByRole`, `getByLabelText`, and `getByText` produce tests that double as accessibility checks. Reach for `getByTestId` only when no semantic query works.
+
+### Keep test data minimal
+
+Build fixtures with the smallest fields needed to exercise the behavior. Use factory helpers (or inline object literals) and override only the fields the test cares about — extraneous data hides what the test is actually asserting.
 
 ## Configuration
 

--- a/packages/observe/examples/index.html
+++ b/packages/observe/examples/index.html
@@ -4,6 +4,9 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>@flowiseai/observe — Examples</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     </head>
     <body>
         <div id="root"></div>

--- a/packages/observe/examples/src/App.tsx
+++ b/packages/observe/examples/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { ObserveProvider } from '@flowiseai/observe'
-import { Box, CssBaseline, Tab, Tabs, Typography } from '@mui/material'
+import { Box, CssBaseline, FormControlLabel, Stack, Switch, Tab, Tabs, Typography } from '@mui/material'
 
 import ExecutionsViewerExample from './demos/ExecutionsViewerExample'
 import StandaloneDetailExample from './demos/StandaloneDetailExample'
@@ -11,14 +11,25 @@ import '@flowiseai/observe/observe.css'
 
 export default function App() {
     const [tab, setTab] = useState(0)
+    const [isDarkMode, setIsDarkMode] = useState(false)
 
     return (
-        <ObserveProvider apiBaseUrl={apiBaseUrl} token={token}>
+        <ObserveProvider apiBaseUrl={apiBaseUrl} token={token} isDarkMode={isDarkMode}>
             <CssBaseline />
-            <Box sx={{ p: 3 }}>
-                <Typography variant='h4' sx={{ mb: 2, fontWeight: 700 }}>
-                    @flowiseai/observe — Examples
-                </Typography>
+            <Box
+                sx={{
+                    p: 3,
+                    minHeight: '100vh',
+                    backgroundColor: 'background.default',
+                    color: 'text.primary'
+                }}
+            >
+                <Stack direction='row' alignItems='center' justifyContent='space-between' sx={{ mb: 2 }}>
+                    <Typography variant='h4' sx={{ fontWeight: 700 }}>
+                        @flowiseai/observe — Examples
+                    </Typography>
+                    <FormControlLabel control={<Switch checked={isDarkMode} onChange={(_, v) => setIsDarkMode(v)} />} label='Dark mode' />
+                </Stack>
                 <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}>
                     <Tab label='Executions Viewer' />
                     <Tab label='Standalone ExecutionDetail' />

--- a/packages/observe/examples/vite.config.ts
+++ b/packages/observe/examples/vite.config.ts
@@ -6,7 +6,16 @@ import { defineConfig } from 'vite'
 export default defineConfig({
     plugins: [react()],
     resolve: {
+        // Dedupe React, MUI, and Emotion so the SDK source (../src/...) and the
+        // example app share a single instance of each. Without this, MUI's
+        // ThemeContext is registered in one copy of @mui/material and read
+        // from another, which silently falls back to MUI defaults (e.g. the
+        // <Chip color='secondary'> renders MUI default #9c27b0 instead of
+        // our theme's #673ab7).
+        dedupe: ['react', 'react-dom', '@mui/material', '@mui/system', '@emotion/react', '@emotion/styled'],
         alias: {
+            react: resolve(__dirname, 'node_modules/react'),
+            'react-dom': resolve(__dirname, 'node_modules/react-dom'),
             '@flowiseai/observe/observe.css': resolve(__dirname, '../src/observe.css'),
             '@flowiseai/observe': resolve(__dirname, '../src/index.ts'),
             '@': resolve(__dirname, '../src')

--- a/packages/observe/jest.config.js
+++ b/packages/observe/jest.config.js
@@ -31,11 +31,30 @@ module.exports = {
     ],
     coverageReporters: ['text', 'text-summary', 'lcov'],
     coverageDirectory: 'coverage',
-    coverageThreshold: {
-        './src/features/executions/hooks/': { branches: 80, functions: 80, lines: 80, statements: 80 },
-        './src/infrastructure/api/executions.ts': { branches: 80, functions: 80, lines: 80, statements: 80 },
-        './src/infrastructure/store/ObserveContext.tsx': { branches: 80, functions: 80, lines: 80, statements: 80 }
-    },
+    coverageThreshold: (() => {
+        const FLOOR = { branches: 80, functions: 80, lines: 80, statements: 80 }
+        return {
+            // Folder-level — every file under these paths has direct tests
+            // (atoms/StatusIndicator is partially covered but the folder
+            // aggregate stays well above the floor).
+            './src/atoms/': FLOOR,
+            './src/core/primitives/': FLOOR,
+            './src/core/theme/': FLOOR,
+            './src/core/utils/': FLOOR,
+            './src/features/executions/hooks/': FLOOR,
+            './src/infrastructure/store/': FLOOR,
+
+            // Tested subset of components — extglob excludes the untested
+            // orchestrators (ExecutionDetail / ExecutionsListTable /
+            // ExecutionsViewer). Promote this to the folder level once those
+            // land tests.
+            './src/features/executions/components/!(ExecutionDetail|ExecutionsListTable|ExecutionsViewer).{ts,tsx}': FLOOR,
+
+            // executions.ts has direct tests; client.ts is exercised only
+            // indirectly through executions.ts so it's not threshold-gated.
+            './src/infrastructure/api/executions.ts': FLOOR
+        }
+    })(),
     projects: [
         {
             ...baseConfig,

--- a/packages/observe/package.json
+++ b/packages/observe/package.json
@@ -74,7 +74,7 @@
         "flowise-react-json-view": "^1.21.7",
         "lodash": "^4.17.21",
         "react-markdown": "^9.0.1",
-        "rehype-raw": "^7.0.0",
+        "react-syntax-highlighter": "15.5.0",
         "remark-gfm": "^4.0.0"
     },
     "devDependencies": {
@@ -85,6 +85,7 @@
         "@types/lodash": "^4.14.195",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@types/react-syntax-highlighter": "15.5.13",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
         "@vitejs/plugin-react": "^4.2.0",

--- a/packages/observe/src/atoms/CodeFenceBlock.test.tsx
+++ b/packages/observe/src/atoms/CodeFenceBlock.test.tsx
@@ -1,0 +1,165 @@
+import type { ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+
+import { CodeFenceBlock } from './CodeFenceBlock'
+
+// react-syntax-highlighter ships pure ESM in dist/esm — Jest can't transform.
+// Stub it so we can focus on header (copy/download) behavior.
+jest.mock('react-syntax-highlighter', () => ({
+    Prism: ({ children, language }: { children?: React.ReactNode; language?: string }) => (
+        <pre data-testid='syntax-highlighter' data-language={language}>
+            {children}
+        </pre>
+    )
+}))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+function renderWithTheme(ui: ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+describe('CodeFenceBlock', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+        act(() => {
+            jest.runOnlyPendingTimers()
+        })
+        jest.useRealTimers()
+        jest.restoreAllMocks()
+    })
+
+    it('renders the code text and language label in the header', () => {
+        renderWithTheme(<CodeFenceBlock value='print("hi")' language='python' />)
+        expect(screen.getByTestId('syntax-highlighter')).toHaveTextContent('print("hi")')
+        expect(screen.getByText('python')).toBeInTheDocument()
+    })
+
+    describe('copy', () => {
+        it('writes the value to the clipboard and swaps the icon to a check on click', async () => {
+            const writeText = jest.fn().mockResolvedValue(undefined)
+            Object.defineProperty(navigator, 'clipboard', {
+                value: { writeText },
+                configurable: true
+            })
+
+            renderWithTheme(<CodeFenceBlock value='hello world' language='text' />)
+            const copyButton = screen.getByRole('button', { name: /copy/i })
+            fireEvent.click(copyButton)
+
+            expect(writeText).toHaveBeenCalledWith('hello world')
+            // Tooltip text should swap to "Copied!" while the timer is running
+            await waitFor(() => expect(screen.getByLabelText(/copied/i)).toBeInTheDocument())
+
+            // After the 1.5s reset window, the tooltip reverts back to "Copy"
+            act(() => {
+                jest.advanceTimersByTime(1500)
+            })
+            await waitFor(() => expect(screen.getByLabelText(/copy/i)).toBeInTheDocument())
+        })
+
+        it('no-ops when navigator.clipboard.writeText is unavailable', () => {
+            Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true })
+            renderWithTheme(<CodeFenceBlock value='hello' language='text' />)
+            // Should not throw; component remains in its initial (un-copied) state
+            expect(() => fireEvent.click(screen.getByRole('button', { name: /copy/i }))).not.toThrow()
+        })
+
+        it('does NOT flash "Copied!" when the clipboard write rejects, and warns to the console', async () => {
+            // Permission denied / secure-context violation / focused-frame
+            // issues all reject the writeText promise. The UI must reflect
+            // that the copy did not happen rather than show a false success,
+            // AND the failure must be logged so it's debuggable in the field.
+            const writeText = jest.fn().mockRejectedValue(new Error('NotAllowedError'))
+            Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+            renderWithTheme(<CodeFenceBlock value='secret' language='text' />)
+            await act(async () => {
+                fireEvent.click(screen.getByRole('button', { name: /copy/i }))
+            })
+            expect(writeText).toHaveBeenCalledWith('secret')
+            expect(screen.getByLabelText(/^copy$/i)).toBeInTheDocument()
+            expect(screen.queryByLabelText(/copied/i)).not.toBeInTheDocument()
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Clipboard copy failed'), expect.any(Error))
+            warnSpy.mockRestore()
+        })
+    })
+
+    describe('download', () => {
+        it('downloads with the language-derived filename and extension', () => {
+            const createObjectURL = jest.fn().mockReturnValue('blob:mock')
+            const revokeObjectURL = jest.fn()
+            // jsdom only ships a stub for createObjectURL; both need overrides.
+            Object.defineProperty(URL, 'createObjectURL', { value: createObjectURL, configurable: true })
+            Object.defineProperty(URL, 'revokeObjectURL', { value: revokeObjectURL, configurable: true })
+
+            const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+            renderWithTheme(<CodeFenceBlock value='{"k":1}' language='json' />)
+            fireEvent.click(screen.getByRole('button', { name: /download/i }))
+
+            expect(createObjectURL).toHaveBeenCalledTimes(1)
+            const blob = createObjectURL.mock.calls[0][0] as Blob
+            expect(blob).toBeInstanceOf(Blob)
+
+            // The synthesized anchor is captured at the moment of click — its
+            // download attribute reflects the language-derived basename + ext.
+            const anchor = clickSpy.mock.instances[0] as unknown as HTMLAnchorElement
+            expect(anchor.download).toBe('snippet-json.json')
+            expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+        })
+
+        it('falls back to .txt and a generic basename when language is missing', () => {
+            const createObjectURL = jest.fn().mockReturnValue('blob:mock')
+            const revokeObjectURL = jest.fn()
+            Object.defineProperty(URL, 'createObjectURL', { value: createObjectURL, configurable: true })
+            Object.defineProperty(URL, 'revokeObjectURL', { value: revokeObjectURL, configurable: true })
+
+            const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+            renderWithTheme(<CodeFenceBlock value='hello' language='' />)
+            fireEvent.click(screen.getByRole('button', { name: /download/i }))
+
+            const anchor = clickSpy.mock.instances[0] as unknown as HTMLAnchorElement
+            expect(anchor.download).toBe('snippet.txt')
+        })
+
+        it('falls back to .txt for an unrecognized language while keeping the language in the filename', () => {
+            const createObjectURL = jest.fn().mockReturnValue('blob:mock')
+            const revokeObjectURL = jest.fn()
+            Object.defineProperty(URL, 'createObjectURL', { value: createObjectURL, configurable: true })
+            Object.defineProperty(URL, 'revokeObjectURL', { value: revokeObjectURL, configurable: true })
+
+            const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+            renderWithTheme(<CodeFenceBlock value='content' language='brainfuck' />)
+            fireEvent.click(screen.getByRole('button', { name: /download/i }))
+
+            const anchor = clickSpy.mock.instances[0] as unknown as HTMLAnchorElement
+            expect(anchor.download).toBe('snippet-brainfuck.txt')
+        })
+
+        it('matches the language map case-insensitively (legacy behavior was case-sensitive)', () => {
+            const createObjectURL = jest.fn().mockReturnValue('blob:mock')
+            const revokeObjectURL = jest.fn()
+            Object.defineProperty(URL, 'createObjectURL', { value: createObjectURL, configurable: true })
+            Object.defineProperty(URL, 'revokeObjectURL', { value: revokeObjectURL, configurable: true })
+
+            const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+            renderWithTheme(<CodeFenceBlock value='print(1)' language='Python' />)
+            fireEvent.click(screen.getByRole('button', { name: /download/i }))
+
+            const anchor = clickSpy.mock.instances[0] as unknown as HTMLAnchorElement
+            // Lookup is case-insensitive AND lowercases for the filename basename.
+            expect(anchor.download).toBe('snippet-python.py')
+        })
+    })
+})

--- a/packages/observe/src/atoms/CodeFenceBlock.tsx
+++ b/packages/observe/src/atoms/CodeFenceBlock.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
+
+import { Box, IconButton, Stack, Tooltip, Typography } from '@mui/material'
+import { IconCheck, IconClipboard, IconDownload } from '@tabler/icons-react'
+
+// Lookup is case-insensitive so common capitalizations LLMs emit
+// ("JavaScript", "Python") map correctly.
+const PROGRAMMING_LANGUAGE_EXT: Record<string, string> = {
+    bash: '.sh',
+    c: '.c',
+    'c#': '.cs',
+    'c++': '.cpp',
+    cpp: '.cpp',
+    css: '.css',
+    go: '.go',
+    haskell: '.hs',
+    html: '.html',
+    java: '.java',
+    javascript: '.js',
+    json: '.json',
+    kotlin: '.kt',
+    lua: '.lua',
+    markdown: '.md',
+    md: '.md',
+    'objective-c': '.m',
+    perl: '.pl',
+    php: '.php',
+    python: '.py',
+    ruby: '.rb',
+    rust: '.rs',
+    scala: '.scala',
+    shell: '.sh',
+    sql: '.sql',
+    swift: '.swift',
+    typescript: '.ts',
+    xml: '.xml',
+    yaml: '.yml',
+    yml: '.yml'
+}
+
+interface CodeFenceBlockProps {
+    value: string
+    language: string
+}
+
+/**
+ * Code-fence renderer with copy + download buttons in a dark header bar.
+ * Uses Prism via react-syntax-highlighter with the oneDark theme.
+ */
+export function CodeFenceBlock({ value, language }: CodeFenceBlockProps) {
+    const [copied, setCopied] = useState(false)
+
+    const handleCopy = () => {
+        if (!navigator.clipboard?.writeText) return
+        // Only flash "Copied!" once the write actually succeeds; rejections
+        // (permission denied, secure-context violation, focused-frame issues)
+        // would otherwise produce a misleading success indication.
+        navigator.clipboard
+            .writeText(value)
+            .then(() => {
+                setCopied(true)
+                setTimeout(() => setCopied(false), 1500)
+            })
+            .catch((err) => {
+                console.warn('[Observe] Clipboard copy failed:', err)
+            })
+    }
+
+    const handleDownload = () => {
+        const lang = language?.toLowerCase() ?? ''
+        const ext = PROGRAMMING_LANGUAGE_EXT[lang] ?? '.txt'
+        const baseName = lang ? `snippet-${lang}` : 'snippet'
+        const blob = new Blob([value], { type: 'text/plain' })
+        const url = URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.download = `${baseName}${ext}`
+        link.href = url
+        link.style.display = 'none'
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+        URL.revokeObjectURL(url)
+    }
+
+    return (
+        <Box sx={{ my: 1, borderRadius: 1, overflow: 'hidden', backgroundColor: '#1e1e1e' }}>
+            <Stack
+                direction='row'
+                alignItems='center'
+                spacing={1}
+                sx={{ px: 1, py: 0.5, color: 'common.white', backgroundColor: 'common.black' }}
+            >
+                <Typography variant='body2' sx={{ color: 'common.white', fontFamily: 'monospace', flex: 1 }}>
+                    {language || ''}
+                </Typography>
+                <Tooltip title={copied ? 'Copied!' : 'Copy'}>
+                    <IconButton size='small' color='success' onClick={handleCopy}>
+                        {copied ? <IconCheck /> : <IconClipboard />}
+                    </IconButton>
+                </Tooltip>
+                <Tooltip title='Download'>
+                    <IconButton size='small' color='primary' onClick={handleDownload}>
+                        <IconDownload />
+                    </IconButton>
+                </Tooltip>
+            </Stack>
+            <SyntaxHighlighter
+                language={language}
+                style={oneDark}
+                wrapLongLines
+                customStyle={{ margin: 0, fontSize: '0.75rem' }}
+                codeTagProps={{ style: { whiteSpace: 'pre-wrap', wordBreak: 'break-word' } }}
+            >
+                {value}
+            </SyntaxHighlighter>
+        </Box>
+    )
+}

--- a/packages/observe/src/atoms/JsonBlock.test.tsx
+++ b/packages/observe/src/atoms/JsonBlock.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+
+import { JsonBlock, JsonPrimitive } from './JsonBlock'
+
+function renderWithTheme(ui: ReactElement, isDark = false) {
+    return render(<ThemeProvider theme={createObserveTheme(isDark)}>{ui}</ThemeProvider>)
+}
+
+describe('JsonBlock', () => {
+    it('renders a flat <pre> containing every key and value from the input object', () => {
+        const { container } = renderWithTheme(<JsonBlock value={{ name: 'Ada', count: 42 }} isDarkMode={false} />)
+        const pre = container.querySelector('pre')
+        expect(pre).not.toBeNull()
+        expect(pre!.textContent).toContain('"name"')
+        expect(pre!.textContent).toContain('"Ada"')
+        expect(pre!.textContent).toContain('"count"')
+        expect(pre!.textContent).toContain('42')
+    })
+
+    it('emits keys, strings, and numbers as styled spans (color set inline)', () => {
+        const { container } = renderWithTheme(<JsonBlock value={{ k: 'v', n: 1 }} isDarkMode={false} />)
+        const keySpan = Array.from(container.querySelectorAll('span')).find((el) => el.textContent === '"k":')
+        const stringSpan = Array.from(container.querySelectorAll('span')).find((el) => el.textContent === '"v"')
+        const numberSpan = Array.from(container.querySelectorAll('span')).find((el) => el.textContent === '1')
+        expect(keySpan?.style.color).toBeTruthy()
+        expect(stringSpan?.style.color).toBeTruthy()
+        expect(numberSpan?.style.color).toBeTruthy()
+        // Punctuation tokens (the leading `{`, whitespace, comma, etc.) carry
+        // no color so they pick up the inherited text color.
+        const punctuationSpan = Array.from(container.querySelectorAll('span')).find((el) => el.textContent?.trim() === '{')
+        expect(punctuationSpan?.style.color).toBe('')
+    })
+
+    it('uses different colors in dark vs light mode for the same value', () => {
+        const { container: light } = renderWithTheme(<JsonBlock value={{ n: 1 }} isDarkMode={false} />)
+        const { container: dark } = renderWithTheme(<JsonBlock value={{ n: 1 }} isDarkMode={true} />, true)
+        const lightNum = Array.from(light.querySelectorAll('span')).find((el) => el.textContent === '1')
+        const darkNum = Array.from(dark.querySelectorAll('span')).find((el) => el.textContent === '1')
+        expect(lightNum?.style.color).toBeTruthy()
+        expect(darkNum?.style.color).toBeTruthy()
+        expect(lightNum?.style.color).not.toBe(darkNum?.style.color)
+    })
+
+    it('round-trips arrays as nested JSON', () => {
+        const { container } = renderWithTheme(<JsonBlock value={{ items: [1, 'two', true, null] }} isDarkMode={false} />)
+        const text = container.querySelector('pre')!.textContent
+        expect(text).toContain('"items"')
+        expect(text).toContain('1')
+        expect(text).toContain('"two"')
+        expect(text).toContain('true')
+        expect(text).toContain('null')
+    })
+})
+
+describe('JsonPrimitive', () => {
+    it('renders a string primitive wrapped in quotes', () => {
+        renderWithTheme(<JsonPrimitive value='hello' isDarkMode={false} />)
+        expect(screen.getByText('"hello"')).toBeInTheDocument()
+    })
+
+    it('renders a number primitive without quotes', () => {
+        renderWithTheme(<JsonPrimitive value={42} isDarkMode={false} />)
+        expect(screen.getByText('42')).toBeInTheDocument()
+    })
+
+    it('renders a boolean primitive', () => {
+        renderWithTheme(<JsonPrimitive value={true} isDarkMode={false} />)
+        expect(screen.getByText('true')).toBeInTheDocument()
+    })
+
+    it('renders null as the literal "null"', () => {
+        renderWithTheme(<JsonPrimitive value={null} isDarkMode={false} />)
+        expect(screen.getByText('null')).toBeInTheDocument()
+    })
+
+    it('renders inside a <pre> wrapped by a bordered Box (visual frame for primitives)', () => {
+        // The bordered wrapper is what gives primitive values their nested
+        // "TextField-style" frame inside Agent message bubbles. Color is
+        // applied via MUI's sx prop (emotion class) so we don't assert on
+        // the computed color directly — JsonBlock spans cover that.
+        const { container } = renderWithTheme(<JsonPrimitive value={42} isDarkMode={false} />)
+        expect(container.querySelector('pre')).not.toBeNull()
+    })
+})

--- a/packages/observe/src/atoms/JsonBlock.test.tsx
+++ b/packages/observe/src/atoms/JsonBlock.test.tsx
@@ -55,6 +55,34 @@ describe('JsonBlock', () => {
         expect(text).toContain('true')
         expect(text).toContain('null')
     })
+
+    describe('maxHeight (PARITY: legacy JSONViewer default)', () => {
+        // MUI's `sx` resolves to emotion class names, not inline styles, so
+        // jsdom can't read the computed pixel value directly. Instead we
+        // compare the generated className against an explicit-value control:
+        // identical class → identical sx → identical maxHeight.
+        const containerClass = (ui: ReactElement) => (renderWithTheme(ui).container.firstChild as HTMLElement).className
+
+        it('applies the 400 default when no maxHeight is provided', () => {
+            const defaultClass = containerClass(<JsonBlock value={{ k: 1 }} isDarkMode={false} />)
+            const explicit400 = containerClass(<JsonBlock value={{ k: 1 }} isDarkMode={false} maxHeight={400} />)
+            expect(defaultClass).toBe(explicit400)
+        })
+
+        it('emits a different class when an explicit maxHeight overrides the default', () => {
+            const defaultClass = containerClass(<JsonBlock value={{ k: 1 }} isDarkMode={false} />)
+            const overridden = containerClass(<JsonBlock value={{ k: 1 }} isDarkMode={false} maxHeight={200} />)
+            expect(overridden).not.toBe(defaultClass)
+        })
+
+        it('accepts string maxHeight values', () => {
+            // String values like "50vh" would be common for responsive layouts.
+            // Just confirm it doesn't crash and produces a stable class.
+            const a = containerClass(<JsonBlock value={{ k: 1 }} isDarkMode={false} maxHeight='50vh' />)
+            const b = containerClass(<JsonBlock value={{ k: 1 }} isDarkMode={false} maxHeight='50vh' />)
+            expect(a).toBe(b)
+        })
+    })
 })
 
 describe('JsonPrimitive', () => {

--- a/packages/observe/src/atoms/JsonBlock.tsx
+++ b/packages/observe/src/atoms/JsonBlock.tsx
@@ -45,16 +45,21 @@ interface JsonBlockProps {
     maxHeight?: number | string
 }
 
+// PARITY: legacy JSONViewer.jsx defaults to maxHeight: '400px' so long
+// HTTP / form / tool payloads scroll inside the bordered frame instead of
+// pushing the rest of the panel off-screen.
+const DEFAULT_MAX_HEIGHT = 400
+
 /**
  * Flat syntax-highlighted JSON pre-block. Used for inline (non-raw) JSON
  * content — Input/Output bubbles for HTTP/form/structured nodes. The
  * interactive tree-view `flowise-react-json-view` is reserved for the Raw view
  * where collapse/expand is useful.
  */
-export function JsonBlock({ value, isDarkMode, maxHeight }: JsonBlockProps) {
+export function JsonBlock({ value, isDarkMode, maxHeight = DEFAULT_MAX_HEIGHT }: JsonBlockProps) {
     const json = JSON.stringify(value, null, 2)
     return (
-        <Box sx={maxHeight !== undefined ? { ...containerSx, maxHeight } : containerSx}>
+        <Box sx={{ ...containerSx, maxHeight }}>
             <Box component='pre' sx={preBaseSx}>
                 {renderTokens(tokenizeJson(json), isDarkMode)}
             </Box>

--- a/packages/observe/src/atoms/JsonBlock.tsx
+++ b/packages/observe/src/atoms/JsonBlock.tsx
@@ -1,0 +1,95 @@
+import { type ReactNode } from 'react'
+
+import { Box } from '@mui/material'
+
+import { type JsonToken, tokenizeJson } from '@/core/primitives'
+import { tokens as designTokens } from '@/core/theme'
+
+const containerSx = {
+    border: 1,
+    borderColor: 'divider',
+    borderRadius: 1,
+    p: 2,
+    backgroundColor: 'background.paper',
+    width: '100%',
+    overflow: 'auto'
+} as const
+
+const preBaseSx = {
+    m: 0,
+    fontFamily: `'Inter', 'Roboto', 'Arial', sans-serif`,
+    fontSize: '0.875rem',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word'
+} as const
+
+function renderTokens(tokens: JsonToken[], isDarkMode: boolean): ReactNode[] {
+    const mode = isDarkMode ? 'dark' : 'light'
+    const palette = designTokens.colors.jsonViewer
+    return tokens.map((token, i) => {
+        if (token.type === 'punctuation') {
+            return <span key={i}>{token.text}</span>
+        }
+        const color = palette[token.type][mode]
+        return (
+            <span key={i} style={{ color }}>
+                {token.text}
+            </span>
+        )
+    })
+}
+
+interface JsonBlockProps {
+    value: object
+    isDarkMode: boolean
+    maxHeight?: number | string
+}
+
+/**
+ * Flat syntax-highlighted JSON pre-block. Used for inline (non-raw) JSON
+ * content — Input/Output bubbles for HTTP/form/structured nodes. The
+ * interactive tree-view `flowise-react-json-view` is reserved for the Raw view
+ * where collapse/expand is useful.
+ */
+export function JsonBlock({ value, isDarkMode, maxHeight }: JsonBlockProps) {
+    const json = JSON.stringify(value, null, 2)
+    return (
+        <Box sx={maxHeight !== undefined ? { ...containerSx, maxHeight } : containerSx}>
+            <Box component='pre' sx={preBaseSx}>
+                {renderTokens(tokenizeJson(json), isDarkMode)}
+            </Box>
+        </Box>
+    )
+}
+
+interface JsonPrimitiveProps {
+    value: string | number | boolean | null
+    isDarkMode: boolean
+}
+
+export function JsonPrimitive({ value, isDarkMode }: JsonPrimitiveProps) {
+    const mode = isDarkMode ? 'dark' : 'light'
+    const palette = designTokens.colors.jsonViewer
+    let color: string
+    let display: string
+    if (typeof value === 'string') {
+        color = palette.string[mode]
+        display = `"${value}"`
+    } else if (typeof value === 'number') {
+        color = palette.number[mode]
+        display = String(value)
+    } else if (typeof value === 'boolean') {
+        color = palette.boolean[mode]
+        display = String(value)
+    } else {
+        color = palette.null[mode]
+        display = 'null'
+    }
+    return (
+        <Box sx={containerSx}>
+            <Box component='pre' sx={{ ...preBaseSx, color }}>
+                {display}
+            </Box>
+        </Box>
+    )
+}

--- a/packages/observe/src/atoms/MetricsDisplay.test.tsx
+++ b/packages/observe/src/atoms/MetricsDisplay.test.tsx
@@ -1,0 +1,67 @@
+import type { ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+
+import { MetricsDisplay } from './MetricsDisplay'
+
+function renderWithTheme(ui: ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+describe('MetricsDisplay', () => {
+    it('renders nothing when output is undefined', () => {
+        const { container } = renderWithTheme(<MetricsDisplay output={undefined} />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('renders nothing when all metric values are absent', () => {
+        const { container } = renderWithTheme(<MetricsDisplay output={{ timeMetadata: undefined, usageMetadata: undefined }} />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('renders only the time chip when only delta is present', () => {
+        renderWithTheme(<MetricsDisplay output={{ timeMetadata: { delta: 1500 } }} />)
+        const group = screen.getByRole('group', { name: /metrics/i })
+        expect(group).toHaveTextContent('1.50 seconds')
+        expect(group).not.toHaveTextContent(/tokens/)
+        expect(group).not.toHaveTextContent(/^\$/)
+    })
+
+    it('hides the time chip when delta is 0 (legacy parity: truthy check)', () => {
+        renderWithTheme(<MetricsDisplay output={{ timeMetadata: { delta: 0 }, usageMetadata: { total_tokens: 5, total_cost: 0 } }} />)
+        expect(screen.queryByText(/seconds/)).not.toBeInTheDocument()
+        expect(screen.getByText('5 tokens')).toBeInTheDocument()
+    })
+
+    it('renders only the tokens chip when only tokens are present', () => {
+        renderWithTheme(<MetricsDisplay output={{ usageMetadata: { total_tokens: 1234, total_cost: 0 } }} />)
+        expect(screen.getByText('1,234 tokens')).toBeInTheDocument()
+    })
+
+    it('formats cost with 6 decimals when below $0.01', () => {
+        renderWithTheme(<MetricsDisplay output={{ usageMetadata: { total_tokens: 0, total_cost: 0.000123 } }} />)
+        expect(screen.getByText('$0.000123')).toBeInTheDocument()
+    })
+
+    it('formats cost with 2 decimals when at or above $0.01', () => {
+        renderWithTheme(<MetricsDisplay output={{ usageMetadata: { total_tokens: 0, total_cost: 0.5 } }} />)
+        expect(screen.getByText('$0.50')).toBeInTheDocument()
+    })
+
+    it('renders all three chips when all metrics are present', () => {
+        renderWithTheme(
+            <MetricsDisplay
+                output={{
+                    timeMetadata: { delta: 2500 },
+                    usageMetadata: { total_tokens: 99, total_cost: 0.25 }
+                }}
+            />
+        )
+        expect(screen.getByText('2.50 seconds')).toBeInTheDocument()
+        expect(screen.getByText('99 tokens')).toBeInTheDocument()
+        expect(screen.getByText('$0.25')).toBeInTheDocument()
+    })
+})

--- a/packages/observe/src/atoms/MetricsDisplay.tsx
+++ b/packages/observe/src/atoms/MetricsDisplay.tsx
@@ -1,6 +1,7 @@
-import { Stack, Tooltip, Typography } from '@mui/material'
-import { IconClock, IconCoins, IconCpu } from '@tabler/icons-react'
+import { Chip, Stack } from '@mui/material'
+import { IconClock, IconCoin, IconCoins } from '@tabler/icons-react'
 
+import { tokens as designTokens } from '@/core/theme'
 import type { NodeExecutionOutput } from '@/core/types'
 
 interface MetricsDisplayProps {
@@ -8,41 +9,68 @@ interface MetricsDisplayProps {
 }
 
 /**
- * Displays time, token, and cost metrics for a node execution.
- * Renders nothing if no metrics are available.
+ * Displays time, token, and cost metrics for a node execution as a chip row.
+ *
+ * Formatting:
+ *  - Time:   `(delta / 1000).toFixed(2)` seconds; hidden when delta is falsy
+ *            (so a 0ms placeholder is suppressed).
+ *  - Tokens: integer count + ` tokens`.
+ *  - Cost:   `$X.XX` when >= $0.01, else `$0.000000` (6 decimals) for tiny amounts.
+ *            Hidden when cost is null/undefined or negative.
+ *
+ * Renders nothing if no metric chip is visible.
  */
 export function MetricsDisplay({ output }: MetricsDisplayProps) {
     const delta = output?.timeMetadata?.delta
     const tokens = output?.usageMetadata?.total_tokens
     const cost = output?.usageMetadata?.total_cost
 
-    if (delta == null && tokens == null && cost == null) return null
+    const showTimeChip = !!delta
+    const showTokensChip = !!tokens
+    const showCostChip = cost != null && Number(cost) >= 0
+    const showMetricsRow = showTimeChip || showTokensChip || showCostChip
+
+    if (!showMetricsRow) return null
+
+    const formatCost = (value: number) => (value >= 0.01 ? `$${value.toFixed(2)}` : `$${value.toFixed(6)}`)
+
+    // Time + tokens use MUI's `color='secondary'` / `color='primary'` props,
+    // which read from theme.palette.secondary.main / primary.main set up in
+    // createObserveTheme. Cost is an explicit gold token (not in MUI palette).
+    const chipIconSx = { '& .MuiChip-icon': { ml: 1, mr: 0.2 } }
 
     return (
-        <Stack direction='row' spacing={2} alignItems='center' sx={{ mt: 1 }}>
-            {delta != null && (
-                <Tooltip title='Execution time'>
-                    <Stack direction='row' spacing={0.5} alignItems='center'>
-                        <IconClock size={14} />
-                        <Typography variant='caption'>{(delta / 1000).toFixed(2)}s</Typography>
-                    </Stack>
-                </Tooltip>
+        <Stack direction='row' spacing={1} alignItems='center' flexWrap='wrap' role='group' aria-label='Node metrics'>
+            {showTimeChip && (
+                <Chip
+                    icon={<IconClock size={17} />}
+                    label={`${(Number(delta) / 1000).toFixed(2)} seconds`}
+                    size='small'
+                    color='secondary'
+                    sx={chipIconSx}
+                />
             )}
-            {tokens != null && (
-                <Tooltip title='Total tokens'>
-                    <Stack direction='row' spacing={0.5} alignItems='center'>
-                        <IconCpu size={14} />
-                        <Typography variant='caption'>{tokens.toLocaleString()}</Typography>
-                    </Stack>
-                </Tooltip>
+            {showTokensChip && (
+                <Chip
+                    icon={<IconCoins size={17} />}
+                    // Format with locale separators for readability
+                    label={`${Number(tokens).toLocaleString()} tokens`}
+                    size='small'
+                    color='primary'
+                    sx={chipIconSx}
+                />
             )}
-            {cost != null && cost > 0 && (
-                <Tooltip title='Estimated cost (USD)'>
-                    <Stack direction='row' spacing={0.5} alignItems='center'>
-                        <IconCoins size={14} />
-                        <Typography variant='caption'>${cost.toFixed(6)}</Typography>
-                    </Stack>
-                </Tooltip>
+            {showCostChip && (
+                <Chip
+                    icon={<IconCoin size={17} />}
+                    label={formatCost(Number(cost))}
+                    size='small'
+                    sx={{
+                        backgroundColor: designTokens.colors.metrics.cost,
+                        color: 'white',
+                        '& .MuiChip-icon': { color: 'white', ml: 1, mr: 0.2 }
+                    }}
+                />
             )}
         </Stack>
     )

--- a/packages/observe/src/atoms/NodeIcon.test.tsx
+++ b/packages/observe/src/atoms/NodeIcon.test.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { render } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+
+import { NodeIcon } from './NodeIcon'
+
+function renderWithTheme(ui: ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+describe('NodeIcon', () => {
+    it('renders the agentflow icon with its color when the name is in the static map', () => {
+        const { container } = renderWithTheme(<NodeIcon name='startAgentflow' />)
+        // Known startAgentflow color from AGENTFLOW_ICONS
+        const wrapper = container.firstChild as HTMLElement
+        expect(wrapper).toHaveStyle({ backgroundColor: '#7EE787' })
+        // The tabler icon renders an inline svg
+        expect(wrapper.querySelector('svg')).not.toBeNull()
+        // Fallback img should not be rendered
+        expect(wrapper.querySelector('img')).toBeNull()
+    })
+
+    it('renders distinct colors for different agentflow types', () => {
+        const { container: startContainer } = renderWithTheme(<NodeIcon name='startAgentflow' />)
+        const { container: agentContainer } = renderWithTheme(<NodeIcon name='agentAgentflow' />)
+        expect(startContainer.firstChild as HTMLElement).toHaveStyle({ backgroundColor: '#7EE787' })
+        expect(agentContainer.firstChild as HTMLElement).toHaveStyle({ backgroundColor: '#4DD0E1' })
+    })
+
+    it('falls back to the API node-icon endpoint for unknown names', () => {
+        const { container } = renderWithTheme(<NodeIcon name='customUnknownNode' apiBaseUrl='http://localhost:3000' />)
+        const img = container.querySelector('img')
+        expect(img).not.toBeNull()
+        expect(img?.getAttribute('src')).toBe('http://localhost:3000/api/v1/node-icon/customUnknownNode')
+    })
+
+    it('respects the size prop on the wrapper', () => {
+        const { container } = renderWithTheme(<NodeIcon name='startAgentflow' size={48} />)
+        const wrapper = container.firstChild as HTMLElement
+        expect(wrapper).toHaveStyle({ width: '48px', height: '48px' })
+    })
+})

--- a/packages/observe/src/atoms/NodeIcon.tsx
+++ b/packages/observe/src/atoms/NodeIcon.tsx
@@ -1,0 +1,119 @@
+// AGENTFLOW_ICONS registry below is duplicated in
+// packages/agentflow/src/core/node-config/nodeIcons.ts — keep in sync until
+// extracted to packages/shared-ui in FLOWISE-628.
+
+import { Box } from '@mui/material'
+import {
+    type Icon,
+    IconArrowsSplit,
+    IconFunctionFilled,
+    IconLibrary,
+    IconMessageCircleFilled,
+    IconNote,
+    IconPlayerPlayFilled,
+    IconRelationOneToManyFilled,
+    IconRepeat,
+    IconReplaceUser,
+    IconRobot,
+    IconSparkles,
+    IconSubtask,
+    IconTools,
+    IconVectorBezier2,
+    IconWorld
+} from '@tabler/icons-react'
+
+import { tokens } from '@/core/theme'
+
+interface AgentflowIconEntry {
+    icon: Icon
+    color: string
+}
+
+const AGENTFLOW_ICONS: Record<string, AgentflowIconEntry> = {
+    conditionAgentflow: { icon: IconArrowsSplit, color: tokens.colors.nodes.condition },
+    startAgentflow: { icon: IconPlayerPlayFilled, color: tokens.colors.nodes.start },
+    llmAgentflow: { icon: IconSparkles, color: tokens.colors.nodes.llm },
+    agentAgentflow: { icon: IconRobot, color: tokens.colors.nodes.agent },
+    humanInputAgentflow: { icon: IconReplaceUser, color: tokens.colors.nodes.humanInput },
+    loopAgentflow: { icon: IconRepeat, color: tokens.colors.nodes.loop },
+    directReplyAgentflow: { icon: IconMessageCircleFilled, color: tokens.colors.nodes.directReply },
+    customFunctionAgentflow: { icon: IconFunctionFilled, color: tokens.colors.nodes.customFunction },
+    toolAgentflow: { icon: IconTools, color: tokens.colors.nodes.tool },
+    retrieverAgentflow: { icon: IconLibrary, color: tokens.colors.nodes.retriever },
+    conditionAgentAgentflow: { icon: IconSubtask, color: tokens.colors.nodes.conditionAgent },
+    stickyNoteAgentflow: { icon: IconNote, color: tokens.colors.nodes.stickyNote },
+    httpAgentflow: { icon: IconWorld, color: tokens.colors.nodes.http },
+    iterationAgentflow: { icon: IconRelationOneToManyFilled, color: tokens.colors.nodes.iteration },
+    executeFlowAgentflow: { icon: IconVectorBezier2, color: tokens.colors.nodes.executeFlow }
+}
+
+interface NodeIconProps {
+    /** Node type name, e.g. "startAgentflow", "agentAgentflow". */
+    name: string
+    /** Pixel size of the rendered avatar/icon. Defaults to 32. */
+    size?: number
+    /**
+     * Base URL of the Flowise server. Used to construct the fallback
+     * `${apiBaseUrl}/api/v1/node-icon/{name}` image when the node is not in
+     * the static AGENTFLOW_ICONS map. If omitted, the fallback img will not
+     * produce a valid request — pass it explicitly to support custom nodes.
+     */
+    apiBaseUrl?: string
+}
+
+/**
+ * Renders the type icon for an agentflow node. Falls back to the server-side
+ * `${apiBaseUrl}/api/v1/node-icon/{name}` endpoint for nodes not in the static
+ * AGENTFLOW_ICONS map (e.g. custom user nodes).
+ */
+export function NodeIcon({ name, size = 32, apiBaseUrl = '' }: NodeIconProps) {
+    const entry = AGENTFLOW_ICONS[name]
+
+    if (entry) {
+        const iconSize = Math.round(size * 0.6)
+        const Icon = entry.icon
+        return (
+            <Box
+                sx={{
+                    width: size,
+                    height: size,
+                    // PARITY: legacy mediumAvatar uses 15px on a 34×34 box
+                    // (15/34 ≈ 0.44). Scale that ratio across other sizes.
+                    borderRadius: `${Math.round(size * 0.44)}px`,
+                    backgroundColor: entry.color,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0
+                }}
+                aria-hidden
+            >
+                <Icon size={iconSize} color='white' />
+            </Box>
+        )
+    }
+
+    return (
+        <Box
+            sx={{
+                width: size,
+                height: size,
+                borderRadius: '50%',
+                backgroundColor: 'common.white',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+                overflow: 'hidden'
+            }}
+            aria-hidden
+        >
+            <Box
+                component='img'
+                src={`${apiBaseUrl}/api/v1/node-icon/${name}`}
+                alt=''
+                sx={{ width: '100%', height: '100%', p: 0.5, objectFit: 'contain' }}
+            />
+        </Box>
+    )
+}

--- a/packages/observe/src/atoms/index.ts
+++ b/packages/observe/src/atoms/index.ts
@@ -1,2 +1,5 @@
+export { CodeFenceBlock } from './CodeFenceBlock'
+export { JsonBlock, JsonPrimitive } from './JsonBlock'
 export { MetricsDisplay } from './MetricsDisplay'
+export { NodeIcon } from './NodeIcon'
 export { StatusIndicator } from './StatusIndicator'

--- a/packages/observe/src/core/primitives/index.ts
+++ b/packages/observe/src/core/primitives/index.ts
@@ -1,0 +1,2 @@
+export type { JsonToken, JsonTokenType, ParseResult } from './json'
+export { tokenizeJson, tryParseJson } from './json'

--- a/packages/observe/src/core/primitives/json.test.ts
+++ b/packages/observe/src/core/primitives/json.test.ts
@@ -1,0 +1,67 @@
+import { tokenizeJson, tryParseJson } from './json'
+
+describe('tryParseJson', () => {
+    it('returns ok=true for objects, arrays, primitives, and null', () => {
+        expect(tryParseJson('{"k":1}')).toEqual({ ok: true, value: { k: 1 } })
+        expect(tryParseJson('[1,2,3]')).toEqual({ ok: true, value: [1, 2, 3] })
+        expect(tryParseJson('42')).toEqual({ ok: true, value: 42 })
+        expect(tryParseJson('"hi"')).toEqual({ ok: true, value: 'hi' })
+        expect(tryParseJson('true')).toEqual({ ok: true, value: true })
+        expect(tryParseJson('null')).toEqual({ ok: true, value: null })
+    })
+
+    it('returns ok=false for unparseable strings', () => {
+        expect(tryParseJson('hello')).toEqual({ ok: false })
+        expect(tryParseJson('{not-json}')).toEqual({ ok: false })
+    })
+
+    it('returns ok=false for empty / whitespace-only strings', () => {
+        // JSON.parse('') is undefined and JSON.parse('  ') throws — both must
+        // collapse to a clean ok=false rather than leaking inconsistent shapes.
+        expect(tryParseJson('')).toEqual({ ok: false })
+        expect(tryParseJson('   ')).toEqual({ ok: false })
+    })
+})
+
+describe('tokenizeJson', () => {
+    it('classifies keys, strings, numbers, booleans, and null', () => {
+        const json = JSON.stringify({ k: 'v', n: 1, b: true, z: null }, null, 2)
+        const tokens = tokenizeJson(json)
+        const byType = (type: string) => tokens.filter((t) => t.type === type).map((t) => t.text)
+        expect(byType('key')).toEqual(['"k":', '"n":', '"b":', '"z":'])
+        expect(byType('string')).toEqual(['"v"'])
+        expect(byType('number')).toEqual(['1'])
+        expect(byType('boolean')).toEqual(['true'])
+        expect(byType('null')).toEqual(['null'])
+    })
+
+    it('preserves whitespace and structural characters as punctuation tokens', () => {
+        const tokens = tokenizeJson('[1, 2]')
+        const reassembled = tokens.map((t) => t.text).join('')
+        expect(reassembled).toBe('[1, 2]')
+        // Brackets, comma, and spaces are punctuation — only the digits are numbers.
+        expect(tokens.filter((t) => t.type === 'number').map((t) => t.text)).toEqual(['1', '2'])
+    })
+
+    it('handles negative numbers, decimals, and exponents', () => {
+        const tokens = tokenizeJson('[-1, 2.5, 1e3, -1.5e-2]')
+        expect(tokens.filter((t) => t.type === 'number').map((t) => t.text)).toEqual(['-1', '2.5', '1e3', '-1.5e-2'])
+    })
+
+    it('classifies a string with a colon-suffix as a key, not a string', () => {
+        // The regex peeks for `\s*:` after the closing quote — anchors object-key detection.
+        const tokens = tokenizeJson('{"k":"v"}')
+        expect(tokens.find((t) => t.text === '"k":')?.type).toBe('key')
+        expect(tokens.find((t) => t.text === '"v"')?.type).toBe('string')
+    })
+
+    it('emits an empty array for an empty input', () => {
+        expect(tokenizeJson('')).toEqual([])
+    })
+
+    it('round-trips: token texts concatenated equal the original input', () => {
+        const json = JSON.stringify({ a: [1, true, null, 'x'], b: { nested: 0.5 } }, null, 2)
+        const tokens = tokenizeJson(json)
+        expect(tokens.map((t) => t.text).join('')).toBe(json)
+    })
+})

--- a/packages/observe/src/core/primitives/json.ts
+++ b/packages/observe/src/core/primitives/json.ts
@@ -1,0 +1,57 @@
+/**
+ * Tagged result for tryParseJson. We can't use `null`/`undefined` as a "not
+ * parseable" sentinel because `JSON.parse('null')` legitimately returns null,
+ * which is a value worth surfacing through the JSON viewer.
+ */
+export type ParseResult = { ok: true; value: unknown } | { ok: false }
+
+/**
+ * Try to parse a string as JSON. Accepts ANY parseable value — objects,
+ * arrays, numbers, booleans, null. Plain text like "hello" fails JSON.parse
+ * and falls through (`ok: false`).
+ */
+export function tryParseJson(value: string): ParseResult {
+    // JSON.parse('') returns undefined and JSON.parse('  ') throws — guard both.
+    if (value.trim() === '') return { ok: false }
+    try {
+        return { ok: true, value: JSON.parse(value) }
+    } catch {
+        return { ok: false }
+    }
+}
+
+export type JsonTokenType = 'punctuation' | 'key' | 'string' | 'boolean' | 'null' | 'number'
+
+export interface JsonToken {
+    type: JsonTokenType
+    text: string
+}
+
+const TOKEN_REGEX = /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(\.\d*)?(?:[eE][+-]?\d+)?)/g
+
+export function tokenizeJson(json: string): JsonToken[] {
+    const out: JsonToken[] = []
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+    const regex = new RegExp(TOKEN_REGEX.source, TOKEN_REGEX.flags)
+    while ((match = regex.exec(json)) !== null) {
+        if (match.index > lastIndex) {
+            out.push({ type: 'punctuation', text: json.slice(lastIndex, match.index) })
+        }
+        const m = match[0]
+        let type: JsonTokenType
+        if (/^"/.test(m)) {
+            type = /:$/.test(m) ? 'key' : 'string'
+        } else if (/^(true|false)$/.test(m)) {
+            type = 'boolean'
+        } else if (/^null$/.test(m)) {
+            type = 'null'
+        } else {
+            type = 'number'
+        }
+        out.push({ type, text: m })
+        lastIndex = match.index + m.length
+    }
+    if (lastIndex < json.length) out.push({ type: 'punctuation', text: json.slice(lastIndex) })
+    return out
+}

--- a/packages/observe/src/core/theme/createObserveTheme.ts
+++ b/packages/observe/src/core/theme/createObserveTheme.ts
@@ -24,8 +24,11 @@ export function createObserveTheme(isDarkMode: boolean): Theme {
             }
         },
         typography: {
+            fontFamily: `'Inter', 'Roboto', 'Arial', sans-serif`,
+            // Match legacy Berry theme weights so section headers (h5) read as
+            // medium-weight subheadings rather than aggressive 600-weight bold.
             h4: { fontSize: '1rem', fontWeight: 600 },
-            h5: { fontSize: '0.875rem', fontWeight: 600 },
+            h5: { fontSize: '0.875rem', fontWeight: 500 },
             h6: { fontSize: '0.75rem', fontWeight: 500 },
             subtitle1: { fontSize: '0.875rem', fontWeight: 500 },
             body1: { fontSize: '0.875rem', fontWeight: 400 },

--- a/packages/observe/src/core/theme/tokens.ts
+++ b/packages/observe/src/core/theme/tokens.ts
@@ -1,11 +1,43 @@
 /**
- * Design Tokens for @flowiseai/observe
- * Shared with @flowiseai/agentflow — kept in sync manually until a @flowiseai/core package is introduced.
+ * Design Tokens for @flowiseai/observe.
+ *
+ * Base palette and node type colors below are duplicated in
+ * packages/agentflow/src/core/theme/tokens.ts — keep in sync until
+ * extracted to packages/shared-ui in FLOWISE-628. Each package
+ * extends the shared base with its own specifics (agentflow: ReactFlow,
+ * syntax highlight; observe: observe-specific semantics).
  */
 
+// Raw palette: each entry is named after the COLOR it represents, not the
+// function it serves. Functional mappings live in the `tokens.colors.*`
+// groups below (semantic, palette, nodes, metrics, jsonViewer, ...).
 const baseColors = {
-    white: '#fff',
+    amber: '#ffe57f',
+    aqua: '#4DDBBB',
     black: '#000',
+    blue: '#2196f3',
+    brightGreen: '#00e676',
+    brightYellow: '#fee440',
+    coral: '#FF7F7F',
+    cornflowerBlue: '#569cd6',
+    cream: '#fefcbf',
+    cyan: '#4DD0E1',
+    darkBrown: '#744210',
+    darkGray100: '#1a1a1a',
+    darkGray200: '#1a1a2e',
+    darkGray300: '#252525',
+    darkGray400: '#2d2d2d',
+    darkGray500: '#404040',
+    darkGray600: '#525252',
+    darkGray700: '#555',
+    darkGray800: '#aaa',
+    darkGreen: '#008000',
+    darkOrange: '#ff8c00',
+    darkPurple: '#5e35b1',
+    darkRed: '#c62828',
+    gold: '#c49331',
+    goldAmber: '#ffc107',
+    goldenYellow: '#FFB938',
     gray50: '#fafafa',
     gray75: '#f5f5f5',
     gray100: '#f8f9fa',
@@ -16,112 +48,111 @@ const baseColors = {
     gray600: '#757575',
     gray700: '#666',
     gray800: '#333',
-    darkGray100: '#1a1a1a',
-    darkGray200: '#1a1a2e',
-    darkGray300: '#252525',
-    darkGray400: '#2d2d2d',
-    darkGray500: '#404040',
-    darkGray600: '#525252',
-    darkGray700: '#555',
-    darkGray800: '#aaa',
-    success: '#4caf50',
-    error: '#f44336',
-    warning: '#ff9800',
-    warningBg: '#fefcbf',
-    warningText: '#744210',
-    info: '#2196f3',
-    primaryLight: '#e3f2fd',
-    primaryMain: '#2196f3',
-    primaryDark: '#1e88e5',
-    secondaryLight: '#ede7f6',
-    secondaryMain: '#673ab7',
-    secondaryDark: '#5e35b1',
-    successLight: '#cdf5d8',
-    successMain: '#00e676',
-    successDark: '#00c853',
-    errorLight: '#f3d2d2',
-    errorMain: '#f44336',
-    errorDark: '#c62828',
-    warningLight: '#fff8e1',
-    warningMain: '#ffe57f',
-    warningDark: '#ffc107',
-    // Node type colors — used in execution tree status indicators
-    nodeCondition: '#FFB938',
-    nodeStart: '#7EE787',
-    nodeLlm: '#64B5F6',
-    nodeAgent: '#4DD0E1',
-    nodeHumanInput: '#6E6EFD',
-    nodeLoop: '#FFA07A',
-    nodeDirectReply: '#4DDBBB',
-    nodeCustomFunction: '#E4B7FF',
-    nodeTool: '#d4a373',
-    nodeRetriever: '#b8bedd',
-    nodeConditionAgent: '#ff8fab',
-    nodeStickyNote: '#fee440',
-    nodeHttp: '#FF7F7F',
-    nodeIteration: '#9C89B8',
-    nodeExecuteFlow: '#a3b18a'
+    green: '#4caf50',
+    iceBlue: '#9cdcfe',
+    keyOrange: '#ff5733',
+    lavender: '#E4B7FF',
+    lightSalmon: '#FFA07A',
+    lilac: '#b8bedd',
+    magenta: '#ff00ff',
+    mauve: '#9C89B8',
+    mediumBlue: '#1e88e5',
+    mintGreen: '#7EE787',
+    mistGray: '#d4d4d4',
+    mossGreen: '#b5cea8',
+    orange: '#ff9800',
+    paleAmber: '#fff8e1',
+    paleBlue: '#e3f2fd',
+    paleGreen: '#cdf5d8',
+    palePurple: '#ede7f6',
+    paleRed: '#f3d2d2',
+    periwinkle: '#6E6EFD',
+    pink: '#ff8fab',
+    purple: '#673ab7',
+    red: '#f44336',
+    sage: '#a3b18a',
+    skyBlue: '#64B5F6',
+    tan: '#d4a373',
+    vividBlue: '#0000ff',
+    vividGreen: '#00c853',
+    white: '#fff'
 } as const
 
 export const tokens = {
+    borderRadius: { lg: 12, md: 8, round: '50%', sm: 4 },
     colors: {
-        nodes: {
-            condition: baseColors.nodeCondition,
-            start: baseColors.nodeStart,
-            llm: baseColors.nodeLlm,
-            agent: baseColors.nodeAgent,
-            humanInput: baseColors.nodeHumanInput,
-            loop: baseColors.nodeLoop,
-            directReply: baseColors.nodeDirectReply,
-            customFunction: baseColors.nodeCustomFunction,
-            tool: baseColors.nodeTool,
-            retriever: baseColors.nodeRetriever,
-            conditionAgent: baseColors.nodeConditionAgent,
-            stickyNote: baseColors.nodeStickyNote,
-            http: baseColors.nodeHttp,
-            iteration: baseColors.nodeIteration,
-            executeFlow: baseColors.nodeExecuteFlow
-        },
         background: {
-            canvas: { light: baseColors.gray100, dark: baseColors.darkGray100 },
-            card: { light: baseColors.white, dark: baseColors.darkGray400 },
-            cardHover: { light: baseColors.gray75, dark: baseColors.darkGray500 },
-            sidebar: { light: baseColors.gray50, dark: baseColors.darkGray300 }
+            canvas: { dark: baseColors.darkGray100, light: baseColors.gray100 },
+            card: { dark: baseColors.darkGray400, light: baseColors.white },
+            cardHover: { dark: baseColors.darkGray500, light: baseColors.gray75 },
+            sidebar: { dark: baseColors.darkGray300, light: baseColors.gray50 }
         },
         border: {
-            default: { light: baseColors.gray300, dark: baseColors.darkGray500 },
-            hover: { light: baseColors.gray400, dark: baseColors.darkGray600 }
+            default: { dark: baseColors.darkGray500, light: baseColors.gray300 },
+            hover: { dark: baseColors.darkGray600, light: baseColors.gray400 }
         },
-        text: {
-            primary: { light: baseColors.gray800, dark: baseColors.white },
-            secondary: { light: baseColors.gray700, dark: baseColors.gray500 },
-            tertiary: { light: baseColors.gray600, dark: baseColors.gray500 }
+        // Light = CSS named colors, dark = VS Code Dark+.
+        jsonViewer: {
+            boolean: { dark: baseColors.cornflowerBlue, light: baseColors.vividBlue },
+            key: { dark: baseColors.keyOrange, light: baseColors.keyOrange },
+            null: { dark: baseColors.mistGray, light: baseColors.magenta },
+            number: { dark: baseColors.mossGreen, light: baseColors.darkOrange },
+            string: { dark: baseColors.iceBlue, light: baseColors.darkGreen }
+        },
+        // Cost chip background. Time + tokens chips use MUI's secondary/primary
+        // palette directly via `color='secondary'` / `color='primary'`, no token
+        // needed. Cost gold isn't in the standard MUI palette so it lives here.
+        metrics: {
+            cost: baseColors.gold
+        },
+        nodes: {
+            agent: baseColors.cyan,
+            condition: baseColors.goldenYellow,
+            conditionAgent: baseColors.pink,
+            customFunction: baseColors.lavender,
+            directReply: baseColors.aqua,
+            executeFlow: baseColors.sage,
+            http: baseColors.coral,
+            humanInput: baseColors.periwinkle,
+            iteration: baseColors.mauve,
+            llm: baseColors.skyBlue,
+            loop: baseColors.lightSalmon,
+            retriever: baseColors.lilac,
+            start: baseColors.mintGreen,
+            stickyNote: baseColors.brightYellow,
+            tool: baseColors.tan
         },
         palette: {
-            primary: { light: baseColors.primaryLight, main: baseColors.primaryMain, dark: baseColors.primaryDark },
-            secondary: { light: baseColors.secondaryLight, main: baseColors.secondaryMain, dark: baseColors.secondaryDark },
-            success: { light: baseColors.successLight, main: baseColors.successMain, dark: baseColors.successDark },
-            error: { light: baseColors.errorLight, main: baseColors.errorMain, dark: baseColors.errorDark },
-            warning: { light: baseColors.warningLight, main: baseColors.warningMain, dark: baseColors.warningDark }
+            error: { dark: baseColors.darkRed, light: baseColors.paleRed, main: baseColors.red },
+            primary: { dark: baseColors.mediumBlue, light: baseColors.paleBlue, main: baseColors.blue },
+            secondary: { dark: baseColors.darkPurple, light: baseColors.palePurple, main: baseColors.purple },
+            success: { dark: baseColors.vividGreen, light: baseColors.paleGreen, main: baseColors.brightGreen },
+            warning: { dark: baseColors.goldAmber, light: baseColors.paleAmber, main: baseColors.amber }
         },
         semantic: {
-            success: baseColors.success,
-            error: baseColors.error,
-            warning: baseColors.warning,
-            warningBg: baseColors.warningBg,
-            warningText: baseColors.warningText,
-            info: baseColors.info
+            error: baseColors.red,
+            info: baseColors.blue,
+            success: baseColors.green,
+            warning: baseColors.orange,
+            warningBg: baseColors.cream,
+            warningText: baseColors.darkBrown
+        },
+        text: {
+            // Light-mode greys match legacy Berry — pure #333 reads too heavy
+            // next to Inter's lower x-height.
+            primary: { dark: baseColors.white, light: baseColors.gray700 },
+            secondary: { dark: baseColors.gray500, light: baseColors.gray500 },
+            tertiary: { dark: baseColors.gray500, light: baseColors.gray600 }
         }
     },
-    spacing: { xs: 4, sm: 8, md: 12, lg: 16, xl: 20, xxl: 24 },
     shadows: {
         card: '0 2px 8px rgba(0, 0, 0, 0.1)',
         toolbar: {
-            light: '0 2px 14px 0 rgb(32 40 45 / 8%)',
-            dark: '0 2px 14px 0 rgb(0 0 0 / 20%)'
+            dark: '0 2px 14px 0 rgb(0 0 0 / 20%)',
+            light: '0 2px 14px 0 rgb(32 40 45 / 8%)'
         }
     },
-    borderRadius: { sm: 4, md: 8, lg: 12, round: '50%' }
+    spacing: { lg: 16, md: 12, sm: 8, xl: 20, xs: 4, xxl: 24 }
 } as const
 
 export type Tokens = typeof tokens

--- a/packages/observe/src/core/types/execution.ts
+++ b/packages/observe/src/core/types/execution.ts
@@ -51,7 +51,11 @@ export interface NodeExecutionOutput {
 export interface NodeExecutionData {
     nodeLabel: string
     nodeId: string
-    /** Node output data — shape varies by node type */
+    /**
+     * Node payload — the runtime emits this as `{ input, output, state, error, ... }`.
+     * `data.output` carries `content`, `timeMetadata`, `usageMetadata`, etc.
+     * Shape varies by node type, hence `Record<string, unknown>`.
+     */
     data: Record<string, unknown>
     previousNodeIds: string[]
     status: ExecutionState
@@ -62,7 +66,6 @@ export interface NodeExecutionData {
     iterationContext?: Record<string, unknown>
     /** Parent node ID for iteration child nodes */
     parentNodeId?: string
-    output?: NodeExecutionOutput
 }
 
 // ============================================================================
@@ -74,7 +77,13 @@ export interface ExecutionTreeNode {
     nodeId: string
     nodeLabel: string
     status: ExecutionState
-    name?: string
+    /**
+     * Resolved node type name — `useExecutionTree` always populates this for
+     * non-virtual nodes (falling back to `data.name` then `nodeId.split('_')[0]`).
+     * Empty string for virtual iteration container nodes (consumers gate on
+     * `isVirtualNode` before reading).
+     */
+    name: string
     /** True for virtual iteration container nodes (not real execution nodes) */
     isVirtualNode?: boolean
     iterationIndex?: number

--- a/packages/observe/src/core/types/index.ts
+++ b/packages/observe/src/core/types/index.ts
@@ -14,6 +14,17 @@ export type {
     UsageMetadata
 } from './execution'
 export type {
+    // Node-detail domain shapes (shared across NodeExecutionDetail
+    // subcomponents and the useNodeData hook).
+    AvailableToolEntry,
+    ChatMessage,
+    ConditionEntry,
+    NormalizedToolCall,
+    ToolNodeRef,
+    UsedToolEntry,
+    UsedToolRef
+} from './nodeDetail'
+export type {
     // Component props
     ExecutionDetailProps,
     ExecutionsViewerProps,

--- a/packages/observe/src/core/types/nodeDetail.ts
+++ b/packages/observe/src/core/types/nodeDetail.ts
@@ -1,0 +1,53 @@
+/**
+ * Domain types shared across the node-detail rendering surface
+ * (NodeExecutionDetail + ChatMessageBubble + tool/condition components +
+ * useNodeData hook). Lifted out of their owning components so the hook
+ * doesn't have to import upward into sibling component files.
+ */
+
+export interface ChatMessage {
+    role?: string
+    name?: string
+    content?: unknown
+    tool_calls?: unknown
+    tool_call_id?: string
+    additional_kwargs?: {
+        usedTools?: UsedToolEntry[]
+    }
+}
+
+export interface ToolNodeRef {
+    name?: string
+    label?: string
+}
+
+export interface AvailableToolEntry {
+    name?: string
+    toolNode?: ToolNodeRef
+    [key: string]: unknown
+}
+
+export interface UsedToolRef {
+    tool?: string
+    [key: string]: unknown
+}
+
+export interface UsedToolEntry {
+    tool?: string
+    error?: unknown
+    [key: string]: unknown
+}
+
+export interface NormalizedToolCall {
+    raw: unknown
+    name: string
+}
+
+export interface ConditionEntry {
+    type?: string
+    operation?: string
+    value1?: unknown
+    value2?: unknown
+    isFulfilled?: boolean
+    [key: string]: unknown
+}

--- a/packages/observe/src/core/utils/guards.ts
+++ b/packages/observe/src/core/utils/guards.ts
@@ -1,0 +1,33 @@
+import type { AvailableToolEntry, ChatMessage, ConditionEntry, UsedToolEntry } from '@/core/types'
+
+/**
+ * Domain-aware type guards used across NodeExecutionDetail and useNodeData
+ * to decide which sub-renderer to dispatch for `data.input.messages`,
+ * `data.output.conditions`, `data.output.availableTools`, and
+ * `data.output.usedTools`. Live in core/utils since they understand the
+ * shape of the runtime payload.
+ */
+
+export function isChatMessageArray(value: unknown): value is ChatMessage[] {
+    return (
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((m) => m !== null && typeof m === 'object' && !Array.isArray(m) && 'role' in (m as Record<string, unknown>))
+    )
+}
+
+export function isConditionArray(value: unknown): value is ConditionEntry[] {
+    return (
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((c) => c !== null && typeof c === 'object' && !Array.isArray(c) && 'isFulfilled' in (c as Record<string, unknown>))
+    )
+}
+
+export function isAvailableToolArray(value: unknown): value is AvailableToolEntry[] {
+    return Array.isArray(value) && value.length > 0 && value.every((t) => t !== null && typeof t === 'object' && !Array.isArray(t))
+}
+
+export function isUsedToolArray(value: unknown): value is UsedToolEntry[] {
+    return Array.isArray(value) && value.length > 0 && value.every((t) => t !== null && typeof t === 'object' && !Array.isArray(t))
+}

--- a/packages/observe/src/core/utils/index.ts
+++ b/packages/observe/src/core/utils/index.ts
@@ -1,0 +1,2 @@
+export { isAvailableToolArray, isChatMessageArray, isConditionArray, isUsedToolArray } from './guards'
+export { extractToolCalls, resolveTool } from './tools'

--- a/packages/observe/src/core/utils/tools.test.ts
+++ b/packages/observe/src/core/utils/tools.test.ts
@@ -1,0 +1,83 @@
+import { extractToolCalls, resolveTool } from './tools'
+
+describe('resolveTool', () => {
+    it('returns the matched toolNode display fields when a name matches', () => {
+        const tools = [{ name: 'search', toolNode: { name: 'searchNode', label: 'Search' } }]
+        expect(resolveTool('search', tools)).toEqual({ iconName: 'searchNode', label: 'Search' })
+    })
+
+    it('falls back to the raw name when no match is found', () => {
+        expect(resolveTool('unknown', [])).toEqual({ iconName: 'unknown', label: 'unknown' })
+        expect(resolveTool('unknown', undefined)).toEqual({ iconName: 'unknown', label: 'unknown' })
+    })
+
+    it('falls back to the raw name when toolNode display fields are missing', () => {
+        const tools = [{ name: 'search' }]
+        expect(resolveTool('search', tools)).toEqual({ iconName: 'search', label: 'search' })
+    })
+})
+
+describe('extractToolCalls', () => {
+    it('returns the OpenAI-style tool_calls array (preserving raw)', () => {
+        const result = extractToolCalls({
+            tool_calls: [{ name: 'search', args: { q: 'x' } }, { name: 'lookup' }]
+        })
+        expect(result.calls).toHaveLength(2)
+        expect(result.calls[0].name).toBe('search')
+        expect(result.calls[1].name).toBe('lookup')
+        expect(result.suppressContent).toBe(false)
+    })
+
+    it('falls back to "Tool Call" when an OpenAI-style entry has no name', () => {
+        const result = extractToolCalls({ tool_calls: [{ args: {} }] })
+        expect(result.calls).toHaveLength(1)
+        expect(result.calls[0].name).toBe('Tool Call')
+    })
+
+    it('filters out non-object entries from tool_calls', () => {
+        const result = extractToolCalls({ tool_calls: ['oops', null, { name: 'good' }] })
+        expect(result.calls).toHaveLength(1)
+        expect(result.calls[0].name).toBe('good')
+    })
+
+    it('suppressContent=true when content carries the same calls in Gemini shape', () => {
+        const result = extractToolCalls({
+            tool_calls: [{ name: 'search' }],
+            content: [{ type: 'functionCall', functionCall: { name: 'search' } }]
+        })
+        expect(result.suppressContent).toBe(true)
+    })
+
+    it('extracts Gemini-style functionCall items from content when tool_calls is empty', () => {
+        const result = extractToolCalls({
+            content: [{ type: 'functionCall', functionCall: { name: 'lookup' } }]
+        })
+        expect(result.calls).toHaveLength(1)
+        expect(result.calls[0].name).toBe('lookup')
+        expect(result.suppressContent).toBe(true)
+    })
+
+    it('keeps text portion visible when content mixes functionCalls + plain items', () => {
+        const result = extractToolCalls({
+            content: [
+                { type: 'text', text: 'reply' },
+                { type: 'functionCall', functionCall: { name: 'lookup' } }
+            ]
+        })
+        expect(result.calls).toHaveLength(1)
+        expect(result.suppressContent).toBe(false)
+    })
+
+    it('returns no calls when neither shape carries any', () => {
+        expect(extractToolCalls({})).toEqual({ calls: [], suppressContent: false })
+        expect(extractToolCalls({ content: 'plain' })).toEqual({ calls: [], suppressContent: false })
+    })
+
+    it('falls back to "Tool Call" when a Gemini functionCall has no name', () => {
+        const result = extractToolCalls({
+            content: [{ type: 'functionCall', functionCall: {} }]
+        })
+        expect(result.calls).toHaveLength(1)
+        expect(result.calls[0].name).toBe('Tool Call')
+    })
+})

--- a/packages/observe/src/core/utils/tools.ts
+++ b/packages/observe/src/core/utils/tools.ts
@@ -1,0 +1,63 @@
+import type { AvailableToolEntry, NormalizedToolCall } from '@/core/types'
+
+/**
+ * Resolves a tool reference (typically `message.name` or a tool_call function
+ * name) against the runtime's `availableTools` list, falling back to the raw
+ * name for both icon lookup and display label when no match is found.
+ */
+export function resolveTool(name: string, availableTools: AvailableToolEntry[] | undefined): { iconName: string; label: string } {
+    const matching = availableTools?.find((t) => t.name === name)
+    return {
+        iconName: matching?.toolNode?.name ?? name,
+        label: matching?.toolNode?.label ?? name
+    }
+}
+
+function isFunctionCallItem(item: unknown): boolean {
+    if (item === null || typeof item !== 'object' || Array.isArray(item)) return false
+    const rec = item as Record<string, unknown>
+    return rec.type === 'functionCall' && rec.functionCall !== null && typeof rec.functionCall === 'object'
+}
+
+/**
+ * Tool calls arrive in two shapes: OpenAI-style `message.tool_calls`, or
+ * Gemini-style `message.content` of `{ type: 'functionCall', functionCall }`.
+ * `suppressContent` tells the caller to hide the content dump when it carries
+ * the same data as the accordions (some providers send both shapes at once).
+ */
+export function extractToolCalls(message: { tool_calls?: unknown; content?: unknown }): {
+    calls: NormalizedToolCall[]
+    suppressContent: boolean
+} {
+    if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+        const calls = message.tool_calls
+            .filter((c): c is Record<string, unknown> => c !== null && typeof c === 'object' && !Array.isArray(c))
+            .map((c) => ({
+                raw: c,
+                name: typeof c.name === 'string' ? c.name : 'Tool Call'
+            }))
+        const contentIsAllFunctionCalls =
+            Array.isArray(message.content) && message.content.length > 0 && message.content.every(isFunctionCallItem)
+        return { calls, suppressContent: contentIsAllFunctionCalls }
+    }
+
+    if (Array.isArray(message.content) && message.content.length > 0) {
+        const calls: NormalizedToolCall[] = []
+        for (const item of message.content) {
+            if (!isFunctionCallItem(item)) continue
+            const rec = item as Record<string, unknown>
+            const fc = rec.functionCall as Record<string, unknown>
+            calls.push({
+                raw: rec,
+                name: typeof fc.name === 'string' ? fc.name : 'Tool Call'
+            })
+        }
+        // Mixed content (text + functionCalls) keeps the text portion visible.
+        if (calls.length > 0 && calls.length === message.content.length) {
+            return { calls, suppressContent: true }
+        }
+        return { calls, suppressContent: false }
+    }
+
+    return { calls: [], suppressContent: false }
+}

--- a/packages/observe/src/features/executions/components/ChatMessageBubble.test.tsx
+++ b/packages/observe/src/features/executions/components/ChatMessageBubble.test.tsx
@@ -1,0 +1,166 @@
+import React, { type ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+import { isChatMessageArray } from '@/core/utils'
+
+import { ChatMessageBubble } from './ChatMessageBubble'
+
+// Stub the heavy markdown stack so this presentational test stays focused
+// on the bubble itself (chips + content slot).
+jest.mock('react-markdown', () => {
+    const ReactMarkdownStub = ({ children }: { children?: React.ReactNode }) => <div data-testid='react-markdown'>{children}</div>
+    return { __esModule: true, default: ReactMarkdownStub }
+})
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => null }))
+jest.mock('react-syntax-highlighter', () => ({
+    Prism: ({ children }: { children?: React.ReactNode }) => <pre data-testid='syntax-highlighter'>{children}</pre>
+}))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+function renderWithTheme(ui: ReactElement, isDark = false) {
+    return render(<ThemeProvider theme={createObserveTheme(isDark)}>{ui}</ThemeProvider>)
+}
+
+describe('isChatMessageArray', () => {
+    it('returns true for a non-empty array of objects each carrying a `role` key', () => {
+        expect(isChatMessageArray([{ role: 'user' }, { role: 'assistant', content: 'hi' }])).toBe(true)
+    })
+
+    it('returns false for an empty array', () => {
+        expect(isChatMessageArray([])).toBe(false)
+    })
+
+    it('returns false when entries are missing the `role` key', () => {
+        expect(isChatMessageArray([{ content: 'hi' }])).toBe(false)
+    })
+
+    it('returns false for non-array values', () => {
+        expect(isChatMessageArray('user' as unknown)).toBe(false)
+        expect(isChatMessageArray(null as unknown)).toBe(false)
+        expect(isChatMessageArray({ role: 'user' } as unknown)).toBe(false)
+    })
+})
+
+describe('ChatMessageBubble', () => {
+    it('renders the role as a chip', () => {
+        renderWithTheme(<ChatMessageBubble message={{ role: 'user', content: 'hello' }} isDarkMode={false} />)
+        expect(screen.getByText('user')).toBeInTheDocument()
+        expect(screen.getByText('hello')).toBeInTheDocument()
+    })
+
+    it('renders message.name as a second chip when present (non-tool role)', () => {
+        // Use a non-tool role so the new tool-header path doesn't also render
+        // the name as a header label (which would put `searchTool` in two
+        // distinct DOM nodes — chip label + header typography).
+        renderWithTheme(<ChatMessageBubble message={{ role: 'assistant', name: 'searchTool', content: 'result' }} isDarkMode={false} />)
+        expect(screen.getByText('assistant')).toBeInTheDocument()
+        expect(screen.getByText('searchTool')).toBeInTheDocument()
+    })
+
+    it('renders the tool header (icon + label + tool_call_id chip) for role="tool" messages', () => {
+        renderWithTheme(
+            <ChatMessageBubble
+                message={{ role: 'tool', name: 'search_repositories', content: 'tool result', tool_call_id: '7xdxc3kf' }}
+                isDarkMode={false}
+                availableTools={[{ name: 'search_repositories', toolNode: { name: 'githubMcp', label: 'Github MCP' } }]}
+            />
+        )
+        // Tool name chip in the role row + Github MCP label in the header (resolved from availableTools)
+        expect(screen.getByText('search_repositories')).toBeInTheDocument()
+        expect(screen.getByText('Github MCP')).toBeInTheDocument()
+        expect(screen.getByText('7xdxc3kf')).toBeInTheDocument()
+    })
+
+    it('does not render a tool header when role is not "tool"', () => {
+        renderWithTheme(<ChatMessageBubble message={{ role: 'user', name: 'searchTool', tool_call_id: 'abc' }} isDarkMode={false} />)
+        // Only the role chip area should mention searchTool — no tool header,
+        // and the tool_call_id chip is a tool-header-only thing.
+        expect(screen.queryByText('abc')).not.toBeInTheDocument()
+    })
+
+    it('falls back to the literal "unknown" when role is missing', () => {
+        renderWithTheme(<ChatMessageBubble message={{ content: 'orphaned' }} isDarkMode={false} />)
+        expect(screen.getByText('unknown')).toBeInTheDocument()
+    })
+
+    it('renders no chip for `name` when not provided', () => {
+        renderWithTheme(<ChatMessageBubble message={{ role: 'system', content: 'sys' }} isDarkMode={false} />)
+        // Only one chip — the role
+        const chips = screen.getAllByText(/system|sys/)
+        expect(chips.length).toBeGreaterThanOrEqual(1)
+        // No second chip means we shouldn't find a name chip
+        expect(screen.queryByText(/^searchTool$/)).not.toBeInTheDocument()
+    })
+
+    it('renders an outlined tool chip for each entry in additional_kwargs.usedTools', () => {
+        renderWithTheme(
+            <ChatMessageBubble
+                message={{
+                    role: 'user',
+                    name: 'research_agent',
+                    content: 'PR 6226 in flowise ai repo',
+                    additional_kwargs: {
+                        usedTools: [{ tool: 'search_repositories' }, { tool: 'get_issue' }]
+                    }
+                }}
+                isDarkMode={false}
+            />
+        )
+        expect(screen.getByText('search_repositories')).toBeInTheDocument()
+        expect(screen.getByText('get_issue')).toBeInTheDocument()
+    })
+
+    it('does not render a tool chip row when usedTools is empty', () => {
+        renderWithTheme(
+            <ChatMessageBubble message={{ role: 'user', content: 'hi', additional_kwargs: { usedTools: [] } }} isDarkMode={false} />
+        )
+        expect(screen.queryByText(/search_repositories|get_issue/)).not.toBeInTheDocument()
+    })
+
+    it('renders a "Called" accordion for each entry in message.tool_calls', () => {
+        renderWithTheme(
+            <ChatMessageBubble
+                message={{
+                    role: 'assistant',
+                    content: '',
+                    tool_calls: [{ name: 'search_repositories', args: { query: 'Flowise AI' }, id: 'abc' }]
+                }}
+                isDarkMode={false}
+            />
+        )
+        expect(screen.getByText('Called')).toBeInTheDocument()
+        expect(screen.getByText('search_repositories')).toBeInTheDocument()
+    })
+
+    it('renders Gemini-style functionCall items from content as accordions and suppresses the JSON dump', () => {
+        renderWithTheme(
+            <ChatMessageBubble
+                message={{
+                    role: 'assistant',
+                    content: [
+                        {
+                            type: 'functionCall',
+                            functionCall: { name: 'search_repositories', args: { query: 'Flowise AI' }, id: 'abc' }
+                        }
+                    ]
+                }}
+                isDarkMode={false}
+            />
+        )
+        // Accordion summary rendered
+        expect(screen.getByText('Called')).toBeInTheDocument()
+        // The same content array should NOT render twice — suppressed
+        // NodeContentRenderer below the accordions. The accordion body
+        // (mounted but visually collapsed) accounts for exactly ONE JsonBlock
+        // <pre>; a second <pre> would mean the content also dumped below.
+        expect(document.querySelectorAll('pre')).toHaveLength(1)
+        // The tool name appears once (in the accordion summary). A duplicate
+        // JsonBlock would also tokenize "search_repositories" into the body.
+        // Body is rendered (collapsed) → use queryAllByText which sees it
+        // regardless of CSS visibility.
+        expect(screen.queryAllByText('search_repositories').length).toBeGreaterThanOrEqual(1)
+    })
+})

--- a/packages/observe/src/features/executions/components/ChatMessageBubble.tsx
+++ b/packages/observe/src/features/executions/components/ChatMessageBubble.tsx
@@ -1,0 +1,76 @@
+import { Box, Chip, Stack, type SxProps, type Theme, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import { NodeIcon } from '@/atoms'
+import type { AvailableToolEntry, ChatMessage } from '@/core/types'
+import { extractToolCalls, resolveTool } from '@/core/utils'
+
+import { NodeContentRenderer } from './NodeContentRenderer'
+import { getRoleColors } from './roleColors'
+import { ToolAccordionList } from './ToolAccordionList'
+import { UsedToolChips } from './UsedToolChips'
+
+const MESSAGE_JSON_MAX_HEIGHT = 400
+
+interface ChatMessageBubbleProps {
+    message: ChatMessage
+    isDarkMode: boolean
+    sx?: SxProps<Theme>
+    availableTools?: AvailableToolEntry[]
+    apiBaseUrl?: string
+}
+
+export function ChatMessageBubble({ message, isDarkMode, sx, availableTools, apiBaseUrl }: ChatMessageBubbleProps) {
+    const theme = useTheme()
+    const role = message.role ?? 'unknown'
+    const colors = getRoleColors(role, theme, isDarkMode)
+    const chipSx = { backgroundColor: colors.bg, color: colors.color, borderColor: colors.border }
+    const usedTools = message.additional_kwargs?.usedTools?.filter(Boolean) ?? []
+    const { calls: toolCalls, suppressContent: hideContent } = extractToolCalls(message)
+    const isToolMessage = role === 'tool' && !!message.name
+    const toolHeader = isToolMessage ? resolveTool(message.name as string, availableTools) : null
+
+    return (
+        <Box sx={sx}>
+            {/* Inline (not Stack) — a flex container offsets the first chip a
+                few px right of the markdown paragraph below it. */}
+            <Box sx={{ mb: 1 }}>
+                <Chip label={role} size='small' variant='outlined' sx={chipSx} />
+                {message.name && <Chip label={message.name} size='small' variant='outlined' sx={{ ...chipSx, ml: 1 }} />}
+            </Box>
+            {usedTools.length > 0 && <UsedToolChips tools={usedTools} sx={{ mb: 1 }} />}
+            {toolCalls.length > 0 && (
+                <ToolAccordionList
+                    variant='called'
+                    calls={toolCalls}
+                    availableTools={availableTools}
+                    isDarkMode={isDarkMode}
+                    apiBaseUrl={apiBaseUrl}
+                />
+            )}
+            {toolHeader && (
+                <Stack direction='row' alignItems='center' sx={{ mt: 1, mb: 1 }}>
+                    <NodeIcon name={toolHeader.iconName} size={28} apiBaseUrl={apiBaseUrl} />
+                    <Typography variant='body1' sx={{ ml: 1 }}>
+                        {toolHeader.label}
+                    </Typography>
+                    {message.tool_call_id && (
+                        <Chip
+                            label={message.tool_call_id}
+                            size='small'
+                            variant='outlined'
+                            sx={{
+                                ml: 1,
+                                height: 20,
+                                borderColor: isDarkMode ? 'common.white' : 'divider'
+                            }}
+                        />
+                    )}
+                </Stack>
+            )}
+            {!hideContent && (
+                <NodeContentRenderer value={message.content} isDarkMode={isDarkMode} jsonMaxHeight={MESSAGE_JSON_MAX_HEIGHT} />
+            )}
+        </Box>
+    )
+}

--- a/packages/observe/src/features/executions/components/ChatMessageBubble.tsx
+++ b/packages/observe/src/features/executions/components/ChatMessageBubble.tsx
@@ -10,8 +10,6 @@ import { getRoleColors } from './roleColors'
 import { ToolAccordionList } from './ToolAccordionList'
 import { UsedToolChips } from './UsedToolChips'
 
-const MESSAGE_JSON_MAX_HEIGHT = 400
-
 interface ChatMessageBubbleProps {
     message: ChatMessage
     isDarkMode: boolean
@@ -68,9 +66,7 @@ export function ChatMessageBubble({ message, isDarkMode, sx, availableTools, api
                     )}
                 </Stack>
             )}
-            {!hideContent && (
-                <NodeContentRenderer value={message.content} isDarkMode={isDarkMode} jsonMaxHeight={MESSAGE_JSON_MAX_HEIGHT} />
-            )}
+            {!hideContent && <NodeContentRenderer value={message.content} isDarkMode={isDarkMode} />}
         </Box>
     )
 }

--- a/packages/observe/src/features/executions/components/ExecutionDetail.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 
-import { Box, Chip, CircularProgress, Divider, IconButton, Stack, Tooltip, Typography } from '@mui/material'
+import { Box, Chip, CircularProgress, IconButton, Stack, Tooltip, Typography, useMediaQuery } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { IconCopy, IconRefresh } from '@tabler/icons-react'
 
@@ -9,12 +9,15 @@ import type { ExecutionDetailProps, ExecutionState, ExecutionTreeNode } from '@/
 
 import { useExecutionPoll } from '../hooks/useExecutionPoll'
 import { useExecutionTree } from '../hooks/useExecutionTree'
+import { useResizableSidebar } from '../hooks/useResizableSidebar'
 
+import { ExecutionTreeSidebar } from './ExecutionTreeSidebar'
 import { NodeExecutionDetail } from './NodeExecutionDetail'
 
-const MIN_SIDEBAR_WIDTH = 240
+const MIN_SIDEBAR_WIDTH = 180
 const MAX_SIDEBAR_WIDTH = 480
-const DEFAULT_SIDEBAR_WIDTH = 300
+const DEFAULT_SIDEBAR_WIDTH_WIDE = 300
+const DEFAULT_SIDEBAR_WIDTH_NARROW = 220
 
 /**
  * Full execution detail view: resizable tree sidebar (left) + node detail panel (right).
@@ -28,46 +31,23 @@ export function ExecutionDetail({
     onAgentflowClick
 }: ExecutionDetailProps) {
     const theme = useTheme()
+    const isNarrowViewport = useMediaQuery(theme.breakpoints.down('lg'))
+    const defaultSidebarWidth = isNarrowViewport ? DEFAULT_SIDEBAR_WIDTH_NARROW : DEFAULT_SIDEBAR_WIDTH_WIDE
     const { execution, isLoading, error, refresh } = useExecutionPoll({ executionId, pollInterval })
     const tree = useExecutionTree(execution?.executionData ?? null)
     const [selectedNode, setSelectedNode] = useState<ExecutionTreeNode | null>(null)
-    const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH)
+    const { width: sidebarWidth, onMouseDown: onSidebarHandleMouseDown } = useResizableSidebar({
+        defaultWidth: defaultSidebarWidth,
+        minWidth: MIN_SIDEBAR_WIDTH,
+        maxWidth: MAX_SIDEBAR_WIDTH
+    })
     const [copied, setCopied] = useState(false)
-    const isDragging = useRef(false)
-    const dragStartX = useRef(0)
-    const dragStartWidth = useRef(DEFAULT_SIDEBAR_WIDTH)
-
-    const handleMouseDown = (e: React.MouseEvent) => {
-        isDragging.current = true
-        dragStartX.current = e.clientX
-        dragStartWidth.current = sidebarWidth
-        document.addEventListener('mousemove', handleMouseMove)
-        document.addEventListener('mouseup', handleMouseUp)
-    }
-
-    const handleMouseMove = useCallback((e: MouseEvent) => {
-        if (!isDragging.current) return
-        const delta = e.clientX - dragStartX.current
-        const newWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, dragStartWidth.current + delta))
-        setSidebarWidth(newWidth)
-    }, [])
-
-    const handleMouseUp = useCallback(() => {
-        isDragging.current = false
-        document.removeEventListener('mousemove', handleMouseMove)
-        document.removeEventListener('mouseup', handleMouseUp)
-    }, [handleMouseMove])
-
-    useEffect(() => {
-        return () => {
-            document.removeEventListener('mousemove', handleMouseMove)
-            document.removeEventListener('mouseup', handleMouseUp)
-        }
-    }, [handleMouseMove, handleMouseUp])
 
     const copyId = () => {
         if (navigator.clipboard) {
-            navigator.clipboard.writeText(executionId)
+            navigator.clipboard.writeText(executionId).catch((err) => {
+                console.warn('[Observe] Clipboard copy failed:', err)
+            })
             setCopied(true)
             setTimeout(() => setCopied(false), 2000)
         }
@@ -130,22 +110,13 @@ export function ExecutionDetail({
 
             {/* Split pane */}
             <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
-                {/* Tree sidebar */}
                 <Box sx={{ width: sidebarWidth, flexShrink: 0, overflow: 'auto', borderRight: `1px solid ${theme.palette.divider}` }}>
-                    {tree.length === 0 ? (
-                        <Box sx={{ p: 2 }}>
-                            <Typography variant='body2' color='text.secondary'>
-                                No execution steps recorded.
-                            </Typography>
-                        </Box>
-                    ) : (
-                        <TreeNodeList nodes={tree} selectedId={selectedNode?.id ?? null} onSelect={setSelectedNode} depth={0} />
-                    )}
+                    <ExecutionTreeSidebar tree={tree} selectedId={selectedNode?.id ?? null} onSelect={setSelectedNode} />
                 </Box>
 
                 {/* Drag handle */}
                 <Box
-                    onMouseDown={handleMouseDown}
+                    onMouseDown={onSidebarHandleMouseDown}
                     sx={{
                         width: 4,
                         cursor: 'col-resize',
@@ -174,82 +145,5 @@ export function ExecutionDetail({
                 </Box>
             </Box>
         </Box>
-    )
-}
-
-// ============================================================================
-// Tree rendering — recursive node list
-// ============================================================================
-
-interface TreeNodeListProps {
-    nodes: ExecutionTreeNode[]
-    selectedId: string | null
-    onSelect: (node: ExecutionTreeNode) => void
-    depth: number
-}
-
-function TreeNodeList({ nodes, selectedId, onSelect, depth }: TreeNodeListProps) {
-    return (
-        <>
-            {nodes.map((node) => (
-                <TreeNodeItem key={node.id} node={node} selectedId={selectedId} onSelect={onSelect} depth={depth} />
-            ))}
-        </>
-    )
-}
-
-interface TreeNodeItemProps {
-    node: ExecutionTreeNode
-    selectedId: string | null
-    onSelect: (node: ExecutionTreeNode) => void
-    depth: number
-}
-
-function TreeNodeItem({ node, selectedId, onSelect, depth }: TreeNodeItemProps) {
-    const theme = useTheme()
-    const [expanded, setExpanded] = useState(true)
-    const isSelected = node.id === selectedId
-    const hasChildren = node.children.length > 0
-
-    return (
-        <>
-            <Box
-                onClick={() => {
-                    if (!node.isVirtualNode) onSelect(node)
-                    if (hasChildren) setExpanded((v) => !v)
-                }}
-                sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    pl: 1.5 + depth * 1.5,
-                    pr: 1.5,
-                    py: 0.75,
-                    cursor: node.isVirtualNode ? 'default' : 'pointer',
-                    backgroundColor: isSelected ? theme.palette.action.selected : 'transparent',
-                    '&:hover': { backgroundColor: theme.palette.action.hover },
-                    borderBottom: `1px solid ${theme.palette.divider}`
-                }}
-            >
-                {node.isVirtualNode ? (
-                    <Typography variant='caption' color='text.secondary' sx={{ fontStyle: 'italic' }}>
-                        {node.nodeLabel}
-                    </Typography>
-                ) : (
-                    <>
-                        <StatusIndicator state={node.status as ExecutionState} size={12} />
-                        <Typography variant='body2' sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                            {node.nodeLabel}
-                        </Typography>
-                    </>
-                )}
-            </Box>
-            {hasChildren && expanded && (
-                <>
-                    <Divider />
-                    <TreeNodeList nodes={node.children} selectedId={selectedId} onSelect={onSelect} depth={depth + 1} />
-                </>
-            )}
-        </>
     )
 }

--- a/packages/observe/src/features/executions/components/ExecutionTreeSidebar.test.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionTreeSidebar.test.tsx
@@ -1,0 +1,164 @@
+import type { ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+import type { ExecutionTreeNode } from '@/core/types'
+
+import { ExecutionTreeSidebar } from './ExecutionTreeSidebar'
+
+// Stub the syntax highlighter pulled in transitively via @/atoms
+// (CodeFenceBlock → react-syntax-highlighter, ESM-only).
+jest.mock('react-syntax-highlighter', () => ({ Prism: () => null }))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+jest.mock('@/infrastructure/store', () => ({
+    useObserveConfig: () => ({ isDarkMode: false, apiBaseUrl: 'http://localhost:3000' })
+}))
+
+function renderWithTheme(ui: ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+function makeNode(overrides: Partial<ExecutionTreeNode> = {}): ExecutionTreeNode {
+    return {
+        id: overrides.id ?? overrides.nodeId ?? 'node-1',
+        nodeId: overrides.nodeId ?? 'node-1',
+        nodeLabel: 'Step 1',
+        status: 'FINISHED',
+        name: 'startAgentflow',
+        children: [],
+        ...overrides
+    }
+}
+
+describe('ExecutionTreeSidebar', () => {
+    describe('empty state', () => {
+        it('renders the empty placeholder when tree is []', () => {
+            renderWithTheme(<ExecutionTreeSidebar tree={[]} selectedId={null} onSelect={jest.fn()} />)
+            expect(screen.getByText(/No execution steps recorded/i)).toBeInTheDocument()
+        })
+    })
+
+    describe('rendering', () => {
+        it('renders one row per top-level node with its label', () => {
+            const tree = [
+                makeNode({ id: 'a', nodeId: 'a', nodeLabel: 'Start' }),
+                makeNode({ id: 'b', nodeId: 'b', nodeLabel: 'Agent', name: 'agentAgentflow' })
+            ]
+            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={jest.fn()} />)
+            expect(screen.getByText('Start')).toBeInTheDocument()
+            expect(screen.getByText('Agent')).toBeInTheDocument()
+        })
+
+        it('recursively renders child rows under their parent', () => {
+            const tree = [
+                makeNode({
+                    id: 'parent',
+                    nodeId: 'parent',
+                    nodeLabel: 'Loop',
+                    name: 'loopAgentflow',
+                    children: [makeNode({ id: 'child', nodeId: 'child', nodeLabel: 'Inner Step' })]
+                })
+            ]
+            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={jest.fn()} />)
+            expect(screen.getByText('Loop')).toBeInTheDocument()
+            expect(screen.getByText('Inner Step')).toBeInTheDocument()
+        })
+
+        it('renders virtual iteration container nodes as italic captions instead of clickable rows', () => {
+            const tree: ExecutionTreeNode[] = [
+                {
+                    id: 'iter-0',
+                    nodeId: 'iter-0',
+                    nodeLabel: 'Iteration #1',
+                    status: 'FINISHED',
+                    isVirtualNode: true,
+                    name: '',
+                    children: []
+                }
+            ]
+            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={jest.fn()} />)
+            const label = screen.getByText('Iteration #1')
+            expect(label).toBeInTheDocument()
+            // Virtual labels render as a Typography caption with italic style;
+            // not wrapped in the clickable Box's role-pointer cursor.
+            expect(label.tagName.toLowerCase()).toBe('span')
+        })
+    })
+
+    describe('selection', () => {
+        it('fires onSelect with the clicked node (skipping virtual nodes)', () => {
+            const onSelect = jest.fn()
+            const tree = [
+                makeNode({ id: 'real', nodeId: 'real', nodeLabel: 'Real' }),
+                {
+                    id: 'iter-0',
+                    nodeId: 'iter-0',
+                    nodeLabel: 'Iteration #1',
+                    status: 'FINISHED' as const,
+                    isVirtualNode: true,
+                    name: '',
+                    children: []
+                }
+            ]
+            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={onSelect} />)
+
+            fireEvent.click(screen.getByText('Real'))
+            expect(onSelect).toHaveBeenCalledTimes(1)
+            expect(onSelect.mock.calls[0][0].nodeId).toBe('real')
+
+            // Clicking the virtual row must NOT call onSelect.
+            fireEvent.click(screen.getByText('Iteration #1'))
+            expect(onSelect).toHaveBeenCalledTimes(1)
+        })
+
+        it('still calls onSelect on a row even when it matches selectedId (idempotent re-click)', () => {
+            // Sanity: passing selectedId doesn't disable the row's click target.
+            // (MUI's `sx` background highlight isn't observable from jsdom's
+            // computed style, so we anchor on the click behavior here.)
+            const onSelect = jest.fn()
+            const tree = [makeNode({ id: 'a', nodeId: 'a', nodeLabel: 'First' })]
+            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId='a' onSelect={onSelect} />)
+            fireEvent.click(screen.getByText('First'))
+            expect(onSelect).toHaveBeenCalledTimes(1)
+            expect(onSelect.mock.calls[0][0].nodeId).toBe('a')
+        })
+    })
+
+    describe('expand/collapse', () => {
+        it('renders children expanded by default', () => {
+            const tree = [
+                makeNode({
+                    id: 'parent',
+                    nodeId: 'parent',
+                    nodeLabel: 'Parent',
+                    children: [makeNode({ id: 'child', nodeId: 'child', nodeLabel: 'Child' })]
+                })
+            ]
+            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={jest.fn()} />)
+            expect(screen.getByText('Child')).toBeInTheDocument()
+        })
+
+        it('toggles children visibility when a parent row with children is clicked', () => {
+            const onSelect = jest.fn()
+            const tree = [
+                makeNode({
+                    id: 'parent',
+                    nodeId: 'parent',
+                    nodeLabel: 'Parent',
+                    children: [makeNode({ id: 'child', nodeId: 'child', nodeLabel: 'Child' })]
+                })
+            ]
+            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={onSelect} />)
+            expect(screen.getByText('Child')).toBeInTheDocument()
+
+            fireEvent.click(screen.getByText('Parent'))
+            expect(screen.queryByText('Child')).not.toBeInTheDocument()
+
+            fireEvent.click(screen.getByText('Parent'))
+            expect(screen.getByText('Child')).toBeInTheDocument()
+        })
+    })
+})

--- a/packages/observe/src/features/executions/components/ExecutionTreeSidebar.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionTreeSidebar.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+
+import { Box, Divider, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import { NodeIcon, StatusIndicator } from '@/atoms'
+import type { ExecutionState, ExecutionTreeNode } from '@/core/types'
+import { useObserveConfig } from '@/infrastructure/store'
+
+interface ExecutionTreeSidebarProps {
+    tree: ExecutionTreeNode[]
+    selectedId: string | null
+    onSelect: (node: ExecutionTreeNode) => void
+}
+
+/**
+ * Recursive tree of nodes for the left pane of `ExecutionDetail`. Virtual
+ * iteration container nodes render as italic captions and are not selectable.
+ */
+export function ExecutionTreeSidebar({ tree, selectedId, onSelect }: ExecutionTreeSidebarProps) {
+    if (tree.length === 0) {
+        return (
+            <Box sx={{ p: 2 }}>
+                <Typography variant='body2' color='text.secondary'>
+                    No execution steps recorded.
+                </Typography>
+            </Box>
+        )
+    }
+
+    return <TreeNodeList nodes={tree} selectedId={selectedId} onSelect={onSelect} depth={0} />
+}
+
+interface TreeNodeListProps {
+    nodes: ExecutionTreeNode[]
+    selectedId: string | null
+    onSelect: (node: ExecutionTreeNode) => void
+    depth: number
+}
+
+function TreeNodeList({ nodes, selectedId, onSelect, depth }: TreeNodeListProps) {
+    return (
+        <>
+            {nodes.map((node) => (
+                <TreeNodeItem key={node.id} node={node} selectedId={selectedId} onSelect={onSelect} depth={depth} />
+            ))}
+        </>
+    )
+}
+
+interface TreeNodeItemProps {
+    node: ExecutionTreeNode
+    selectedId: string | null
+    onSelect: (node: ExecutionTreeNode) => void
+    depth: number
+}
+
+function TreeNodeItem({ node, selectedId, onSelect, depth }: TreeNodeItemProps) {
+    const theme = useTheme()
+    const { apiBaseUrl } = useObserveConfig()
+    const [expanded, setExpanded] = useState(true)
+    const isSelected = node.id === selectedId
+    const hasChildren = node.children.length > 0
+
+    return (
+        <>
+            <Box
+                onClick={() => {
+                    if (!node.isVirtualNode) onSelect(node)
+                    if (hasChildren) setExpanded((v) => !v)
+                }}
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    pl: 1.5 + depth * 1.5,
+                    pr: 1.5,
+                    py: 0.75,
+                    cursor: node.isVirtualNode ? 'default' : 'pointer',
+                    backgroundColor: isSelected ? theme.palette.action.selected : 'transparent',
+                    '&:hover': { backgroundColor: theme.palette.action.hover },
+                    borderBottom: `1px solid ${theme.palette.divider}`
+                }}
+            >
+                {node.isVirtualNode ? (
+                    <Typography variant='caption' color='text.secondary' sx={{ fontStyle: 'italic' }}>
+                        {node.nodeLabel}
+                    </Typography>
+                ) : (
+                    <>
+                        <NodeIcon name={node.name} size={22} apiBaseUrl={apiBaseUrl} />
+                        <Typography variant='body2' sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {node.nodeLabel}
+                        </Typography>
+                        <StatusIndicator state={node.status as ExecutionState} size={14} />
+                    </>
+                )}
+            </Box>
+            {hasChildren && expanded && (
+                <>
+                    <Divider />
+                    <TreeNodeList nodes={node.children} selectedId={selectedId} onSelect={onSelect} depth={depth + 1} />
+                </>
+            )}
+        </>
+    )
+}

--- a/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
@@ -247,7 +247,7 @@ export function ExecutionsViewer({
                 anchor='right'
                 open={!!drawerExecution}
                 onClose={() => setDrawerExecution(null)}
-                PaperProps={{ sx: { width: { xs: '100vw', sm: '70vw', md: '60vw' } } }}
+                PaperProps={{ sx: { width: { xs: '100vw', sm: '90vw', md: '85vw', lg: '80vw' } } }}
             >
                 {drawerExecution && (
                     <ExecutionDetail

--- a/packages/observe/src/features/executions/components/FulfilledConditionsBlock.test.tsx
+++ b/packages/observe/src/features/executions/components/FulfilledConditionsBlock.test.tsx
@@ -63,18 +63,30 @@ describe('FulfilledConditionsBlock', () => {
         expect(container.firstChild).toBeNull()
     })
 
-    it('preserves the original index when only later entries are fulfilled', () => {
-        // Index labels reflect the position in the *original* array, so a
-        // single fulfilled entry at index 2 should render as "Condition 2",
-        // not "Condition 0". (Current implementation uses .filter then .map
-        // with the post-filter index — anchored here as a behavior pin.)
+    it('labels each fulfilled entry with its index in the original array', () => {
+        // The displayed number must match the branch the user configured in
+        // the Condition node editor. A single fulfilled entry at original
+        // index 2 renders as "Condition 2", not "Condition 0".
         const conditions: ConditionEntry[] = [
             { type: 'string', value1: 'a', value2: 'b', isFulfilled: false },
             { type: 'string', value1: 'a', value2: 'c', isFulfilled: false },
             { type: 'string', value1: 'a', value2: 'a', isFulfilled: true }
         ]
         renderWithTheme(<FulfilledConditionsBlock conditions={conditions} isDarkMode={false} />)
+        expect(screen.getByText('Condition 2')).toBeInTheDocument()
+        expect(screen.queryByText('Condition 0')).not.toBeInTheDocument()
+    })
+
+    it('preserves gaps when non-contiguous entries are fulfilled', () => {
+        const conditions: ConditionEntry[] = [
+            { type: 'string', value1: 'a', value2: 'a', isFulfilled: true },
+            { type: 'string', value1: 'a', value2: 'b', isFulfilled: false },
+            { type: 'string', value1: 'a', value2: 'a', isFulfilled: true }
+        ]
+        renderWithTheme(<FulfilledConditionsBlock conditions={conditions} isDarkMode={false} />)
         expect(screen.getByText('Condition 0')).toBeInTheDocument()
+        expect(screen.queryByText('Condition 1')).not.toBeInTheDocument()
+        expect(screen.getByText('Condition 2')).toBeInTheDocument()
     })
 
     it('renders the condition object as inline JSON in the body', () => {

--- a/packages/observe/src/features/executions/components/FulfilledConditionsBlock.test.tsx
+++ b/packages/observe/src/features/executions/components/FulfilledConditionsBlock.test.tsx
@@ -1,0 +1,87 @@
+import type { ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+import type { ConditionEntry } from '@/core/types'
+import { isConditionArray } from '@/core/utils'
+
+import { FulfilledConditionsBlock } from './FulfilledConditionsBlock'
+
+// JsonBlock is imported transitively through atoms/index.ts → CodeFenceBlock,
+// which pulls in react-syntax-highlighter (ESM-only). Stub it so jest can
+// load the module graph without a custom transformer.
+jest.mock('react-syntax-highlighter', () => ({ Prism: () => null }))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+function renderWithTheme(ui: ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+describe('isConditionArray', () => {
+    it('returns true for a non-empty array of objects each carrying `isFulfilled`', () => {
+        expect(isConditionArray([{ isFulfilled: true }, { isFulfilled: false }])).toBe(true)
+    })
+
+    it('returns false for empty arrays and arrays missing isFulfilled', () => {
+        expect(isConditionArray([])).toBe(false)
+        expect(isConditionArray([{ value1: 'a' }])).toBe(false)
+    })
+
+    it('returns false for non-array values', () => {
+        expect(isConditionArray(null)).toBe(false)
+        expect(isConditionArray({ isFulfilled: true })).toBe(false)
+    })
+})
+
+describe('FulfilledConditionsBlock', () => {
+    it('renders only fulfilled conditions, hiding unfulfilled ones', () => {
+        const conditions: ConditionEntry[] = [
+            { type: 'string', operation: 'equal', value1: 'a', value2: 'a', isFulfilled: true },
+            { type: 'string', operation: 'equal', value1: 'b', value2: 'c', isFulfilled: false }
+        ]
+        renderWithTheme(<FulfilledConditionsBlock conditions={conditions} isDarkMode={false} />)
+        expect(screen.getByText('Condition 0')).toBeInTheDocument()
+        expect(screen.queryByText('Condition 1')).not.toBeInTheDocument()
+        expect(screen.getAllByText('Fulfilled')).toHaveLength(1)
+    })
+
+    it('labels the empty-string equal branch as "Else condition fulfilled"', () => {
+        const conditions: ConditionEntry[] = [{ type: 'string', operation: 'equal', value1: '', value2: '', isFulfilled: true }]
+        renderWithTheme(<FulfilledConditionsBlock conditions={conditions} isDarkMode={false} />)
+        expect(screen.getByText('Else condition fulfilled')).toBeInTheDocument()
+        expect(screen.getByText('Fulfilled')).toBeInTheDocument()
+        // Else branches do NOT render a "Condition N" header — they use the
+        // sentence-style label instead.
+        expect(screen.queryByText(/^Condition /)).not.toBeInTheDocument()
+    })
+
+    it('renders nothing when no condition is fulfilled', () => {
+        const conditions: ConditionEntry[] = [{ type: 'string', operation: 'equal', value1: 'a', value2: 'b', isFulfilled: false }]
+        const { container } = renderWithTheme(<FulfilledConditionsBlock conditions={conditions} isDarkMode={false} />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('preserves the original index when only later entries are fulfilled', () => {
+        // Index labels reflect the position in the *original* array, so a
+        // single fulfilled entry at index 2 should render as "Condition 2",
+        // not "Condition 0". (Current implementation uses .filter then .map
+        // with the post-filter index — anchored here as a behavior pin.)
+        const conditions: ConditionEntry[] = [
+            { type: 'string', value1: 'a', value2: 'b', isFulfilled: false },
+            { type: 'string', value1: 'a', value2: 'c', isFulfilled: false },
+            { type: 'string', value1: 'a', value2: 'a', isFulfilled: true }
+        ]
+        renderWithTheme(<FulfilledConditionsBlock conditions={conditions} isDarkMode={false} />)
+        expect(screen.getByText('Condition 0')).toBeInTheDocument()
+    })
+
+    it('renders the condition object as inline JSON in the body', () => {
+        const conditions: ConditionEntry[] = [{ type: 'string', operation: 'equal', value1: 'foo', value2: 'foo', isFulfilled: true }]
+        const { container } = renderWithTheme(<FulfilledConditionsBlock conditions={conditions} isDarkMode={false} />)
+        const pre = container.querySelectorAll('pre')
+        const flat = Array.from(pre).find((el) => el.textContent?.includes('"value1"') && el.textContent?.includes('"foo"'))
+        expect(flat).toBeDefined()
+    })
+})

--- a/packages/observe/src/features/executions/components/FulfilledConditionsBlock.tsx
+++ b/packages/observe/src/features/executions/components/FulfilledConditionsBlock.tsx
@@ -1,0 +1,63 @@
+import { Box, Chip, Stack, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+import { JsonBlock } from '@/atoms'
+import type { ConditionEntry } from '@/core/types'
+
+function isElseCondition(c: ConditionEntry): boolean {
+    return c.type === 'string' && c.operation === 'equal' && c.value1 === '' && c.value2 === ''
+}
+
+interface FulfilledConditionsBlockProps {
+    conditions: ConditionEntry[]
+    isDarkMode: boolean
+}
+
+/**
+ * Renders only the fulfilled entries from a condition node's
+ * `data.output.conditions` array — success-bordered boxes with a "Fulfilled"
+ * chip. The "else" branch (string/equal with both values empty) shows a
+ * sentence-style label; other branches show "Condition {n}" with the raw
+ * condition object as JSON. Mirrors legacy `renderFullfilledConditions` in
+ * NodeExecutionDetails.jsx.
+ */
+export function FulfilledConditionsBlock({ conditions, isDarkMode }: FulfilledConditionsBlockProps) {
+    const theme = useTheme()
+    const fulfilled = conditions.filter((c) => c.isFulfilled)
+    if (fulfilled.length === 0) return null
+
+    const boxSx = {
+        border: 1,
+        borderColor: 'success.main',
+        borderRadius: 1,
+        p: 2,
+        backgroundColor: 'background.paper'
+    } as const
+    const chipSx = { color: theme.palette.common.white, backgroundColor: theme.palette.success.dark }
+
+    return (
+        <Stack spacing={1}>
+            {fulfilled.map((condition, index) => {
+                if (isElseCondition(condition)) {
+                    return (
+                        <Box key={`else-${index}`} sx={boxSx}>
+                            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                <Typography variant='body1'>Else condition fulfilled</Typography>
+                                <Chip label='Fulfilled' size='small' variant='filled' sx={chipSx} />
+                            </Box>
+                        </Box>
+                    )
+                }
+                return (
+                    <Box key={`condition-${index}`} sx={boxSx}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                            <Typography variant='subtitle2'>Condition {index}</Typography>
+                            <Chip label='Fulfilled' size='small' variant='filled' sx={chipSx} />
+                        </Box>
+                        <JsonBlock value={condition} isDarkMode={isDarkMode} />
+                    </Box>
+                )
+            })}
+        </Stack>
+    )
+}

--- a/packages/observe/src/features/executions/components/FulfilledConditionsBlock.tsx
+++ b/packages/observe/src/features/executions/components/FulfilledConditionsBlock.tsx
@@ -17,14 +17,17 @@ interface FulfilledConditionsBlockProps {
  * Renders only the fulfilled entries from a condition node's
  * `data.output.conditions` array — success-bordered boxes with a "Fulfilled"
  * chip. The "else" branch (string/equal with both values empty) shows a
- * sentence-style label; other branches show "Condition {n}" with the raw
- * condition object as JSON. Mirrors legacy `renderFullfilledConditions` in
- * NodeExecutionDetails.jsx.
+ * sentence-style label; other branches show "Condition {n}" using the index
+ * from the original `conditions` array, so the displayed number matches the
+ * branch the user configured in the Condition node editor.
+ *
+ * PARITY: deviation — legacy `renderFullfilledConditions` filtered first then
+ * indexed by post-filter position, which mislabeled "branch 2 fired" as
+ * "Condition 0". Iterating over the original array fixes that.
  */
 export function FulfilledConditionsBlock({ conditions, isDarkMode }: FulfilledConditionsBlockProps) {
     const theme = useTheme()
-    const fulfilled = conditions.filter((c) => c.isFulfilled)
-    if (fulfilled.length === 0) return null
+    if (!conditions.some((c) => c.isFulfilled)) return null
 
     const boxSx = {
         border: 1,
@@ -37,7 +40,8 @@ export function FulfilledConditionsBlock({ conditions, isDarkMode }: FulfilledCo
 
     return (
         <Stack spacing={1}>
-            {fulfilled.map((condition, index) => {
+            {conditions.map((condition, index) => {
+                if (!condition.isFulfilled) return null
                 if (isElseCondition(condition)) {
                     return (
                         <Box key={`else-${index}`} sx={boxSx}>

--- a/packages/observe/src/features/executions/components/HitlPanel.test.tsx
+++ b/packages/observe/src/features/executions/components/HitlPanel.test.tsx
@@ -1,0 +1,157 @@
+import type { ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+
+import type { HumanInputState } from '../hooks/useHumanInput'
+
+import { HitlPanel } from './HitlPanel'
+
+function renderWithTheme(ui: ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+function makeState(overrides: Partial<HumanInputState> = {}): HumanInputState {
+    return {
+        isSubmitting: false,
+        submitError: null,
+        feedbackOpen: false,
+        feedbackText: '',
+        setFeedbackText: jest.fn(),
+        dismissError: jest.fn(),
+        handleProceed: jest.fn(),
+        handleReject: jest.fn(),
+        cancelFeedbackDialog: jest.fn(),
+        submitFeedback: jest.fn(),
+        ...overrides
+    }
+}
+
+describe('HitlPanel', () => {
+    describe('action bar gating', () => {
+        it('hides the floating action bar when show=false', () => {
+            renderWithTheme(<HitlPanel show={false} state={makeState()} />)
+            expect(screen.queryByTestId('hitl-action-bar')).not.toBeInTheDocument()
+            expect(screen.queryByRole('button', { name: 'Proceed' })).not.toBeInTheDocument()
+        })
+
+        it('renders Proceed + Reject buttons when show=true', () => {
+            renderWithTheme(<HitlPanel show state={makeState()} />)
+            expect(screen.getByTestId('hitl-action-bar')).toBeInTheDocument()
+            expect(screen.getByRole('button', { name: 'Proceed' })).toBeEnabled()
+            expect(screen.getByRole('button', { name: 'Reject' })).toBeEnabled()
+        })
+
+        it('disables both buttons while a submission is in flight', () => {
+            // The loading-overlay Dialog sets aria-hidden on its siblings, so
+            // the role-based query needs `hidden: true` to reach the bar.
+            renderWithTheme(<HitlPanel show state={makeState({ isSubmitting: true })} />)
+            expect(screen.getByRole('button', { name: 'Proceed', hidden: true })).toBeDisabled()
+            expect(screen.getByRole('button', { name: 'Reject', hidden: true })).toBeDisabled()
+        })
+
+        it('fires handleProceed and handleReject when their buttons are clicked', () => {
+            const state = makeState()
+            renderWithTheme(<HitlPanel show state={state} />)
+            fireEvent.click(screen.getByRole('button', { name: 'Proceed' }))
+            fireEvent.click(screen.getByRole('button', { name: 'Reject' }))
+            expect(state.handleProceed).toHaveBeenCalledTimes(1)
+            expect(state.handleReject).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('inline error', () => {
+        it('hides the Alert when submitError is null', () => {
+            renderWithTheme(<HitlPanel show state={makeState()} />)
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        })
+
+        it('renders the Alert with the error message when submitError is set', () => {
+            renderWithTheme(<HitlPanel show state={makeState({ submitError: 'Network down' })} />)
+            expect(screen.getByRole('alert')).toHaveTextContent('Network down')
+        })
+
+        it('fires dismissError when the Alert close button is clicked', () => {
+            const state = makeState({ submitError: 'Boom' })
+            renderWithTheme(<HitlPanel show state={state} />)
+            fireEvent.click(screen.getByRole('button', { name: /close/i }))
+            expect(state.dismissError).toHaveBeenCalledTimes(1)
+        })
+
+        it('does not render the Alert when show=false even if submitError is set', () => {
+            renderWithTheme(<HitlPanel show={false} state={makeState({ submitError: 'X' })} />)
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('feedback dialog', () => {
+        it('does not render the dialog when feedbackOpen=false', () => {
+            renderWithTheme(<HitlPanel show state={makeState()} />)
+            expect(screen.queryByText('Provide Feedback')).not.toBeInTheDocument()
+        })
+
+        it('renders the dialog with the textarea preloaded with feedbackText', () => {
+            renderWithTheme(<HitlPanel show state={makeState({ feedbackOpen: true, feedbackText: 'draft' })} />)
+            expect(screen.getByText('Provide Feedback')).toBeInTheDocument()
+            expect(screen.getByLabelText('Feedback')).toHaveValue('draft')
+        })
+
+        it('fires setFeedbackText with the new value when the user types', () => {
+            const state = makeState({ feedbackOpen: true })
+            renderWithTheme(<HitlPanel show state={state} />)
+            fireEvent.change(screen.getByLabelText('Feedback'), { target: { value: 'looks good' } })
+            expect(state.setFeedbackText).toHaveBeenCalledWith('looks good')
+        })
+
+        it('fires cancelFeedbackDialog when Cancel is clicked', () => {
+            const state = makeState({ feedbackOpen: true })
+            renderWithTheme(<HitlPanel show state={state} />)
+            fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+            expect(state.cancelFeedbackDialog).toHaveBeenCalledTimes(1)
+        })
+
+        it('fires submitFeedback when Submit is clicked', () => {
+            const state = makeState({ feedbackOpen: true })
+            renderWithTheme(<HitlPanel show state={state} />)
+            fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+            expect(state.submitFeedback).toHaveBeenCalledTimes(1)
+        })
+
+        it('disables the textarea + Cancel + Submit while submitting', () => {
+            // The loading-overlay Dialog opens above the feedback dialog and
+            // sets aria-hidden on siblings — `hidden: true` reaches the
+            // already-mounted feedback dialog buttons.
+            renderWithTheme(<HitlPanel show state={makeState({ feedbackOpen: true, isSubmitting: true })} />)
+            expect(screen.getByLabelText('Feedback', { selector: 'textarea' })).toBeDisabled()
+            expect(screen.getByRole('button', { name: 'Cancel', hidden: true })).toBeDisabled()
+            expect(screen.getByRole('button', { name: 'Submit', hidden: true })).toBeDisabled()
+        })
+
+        it('mounts the dialog regardless of show (dialog only opens via the bar, but stays mounted)', () => {
+            // show=false hides the bar, but if a parent keeps state.feedbackOpen=true
+            // (e.g. preserving state across visibility changes), the dialog renders.
+            renderWithTheme(<HitlPanel show={false} state={makeState({ feedbackOpen: true })} />)
+            expect(screen.getByText('Provide Feedback')).toBeInTheDocument()
+        })
+    })
+
+    describe('loading overlay', () => {
+        it('does not render the overlay when isSubmitting=false', () => {
+            renderWithTheme(<HitlPanel show state={makeState()} />)
+            expect(screen.queryByLabelText('Submitting response')).not.toBeInTheDocument()
+        })
+
+        it('renders the overlay with progress + label when isSubmitting=true', () => {
+            renderWithTheme(<HitlPanel show state={makeState({ isSubmitting: true })} />)
+            expect(screen.getByLabelText('Submitting response')).toBeInTheDocument()
+            expect(screen.getByText('Submitting response...')).toBeInTheDocument()
+        })
+
+        it('renders the overlay even when show=false (submission can outlive the gating window)', () => {
+            renderWithTheme(<HitlPanel show={false} state={makeState({ isSubmitting: true })} />)
+            expect(screen.getByLabelText('Submitting response')).toBeInTheDocument()
+        })
+    })
+})

--- a/packages/observe/src/features/executions/components/HitlPanel.tsx
+++ b/packages/observe/src/features/executions/components/HitlPanel.tsx
@@ -1,0 +1,132 @@
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Stack,
+    TextField,
+    Typography
+} from '@mui/material'
+
+import type { HumanInputState } from '../hooks/useHumanInput'
+
+interface HitlPanelProps {
+    /**
+     * Controls visibility of the floating Proceed/Reject bar. Driven by the
+     * caller's gating logic (onHumanInput provided && node is humanInput &&
+     * status is INPROGRESS). The feedback dialog and loading overlay render
+     * regardless — they're scoped to `state.feedbackOpen` / `state.isSubmitting`,
+     * which only flip when the bar has already been used.
+     */
+    show: boolean
+    state: HumanInputState
+}
+
+/**
+ * Floating Proceed/Reject bar + optional feedback dialog + submission overlay
+ * for HITL nodes. Single mount in NodeExecutionDetail; submission lifecycle
+ * lives in the `useHumanInput` hook.
+ */
+export function HitlPanel({ show, state }: HitlPanelProps) {
+    const {
+        isSubmitting,
+        submitError,
+        feedbackOpen,
+        feedbackText,
+        setFeedbackText,
+        dismissError,
+        handleProceed,
+        handleReject,
+        cancelFeedbackDialog,
+        submitFeedback
+    } = state
+
+    return (
+        <>
+            {show && (
+                <>
+                    <Box
+                        sx={{
+                            position: 'fixed',
+                            bottom: 15,
+                            right: 25,
+                            p: 1.5,
+                            backgroundColor: 'background.paper',
+                            boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
+                            borderRadius: '25px',
+                            display: 'flex',
+                            justifyContent: 'flex-end',
+                            gap: 1,
+                            zIndex: 1000
+                        }}
+                        data-testid='hitl-action-bar'
+                    >
+                        <Button
+                            variant='outlined'
+                            color='error'
+                            sx={{ borderRadius: '25px' }}
+                            disabled={isSubmitting}
+                            onClick={handleReject}
+                        >
+                            Reject
+                        </Button>
+                        <Button
+                            variant='contained'
+                            color='primary'
+                            sx={{ borderRadius: '25px' }}
+                            disabled={isSubmitting}
+                            onClick={handleProceed}
+                        >
+                            Proceed
+                        </Button>
+                    </Box>
+                    {submitError && (
+                        <Alert severity='error' sx={{ position: 'fixed', bottom: 80, right: 25, zIndex: 1000 }} onClose={dismissError}>
+                            {submitError}
+                        </Alert>
+                    )}
+                </>
+            )}
+
+            <Dialog open={feedbackOpen} onClose={cancelFeedbackDialog} maxWidth='sm' fullWidth>
+                <DialogTitle>Provide Feedback</DialogTitle>
+                <DialogContent>
+                    <TextField
+                        autoFocus
+                        multiline
+                        fullWidth
+                        rows={3}
+                        label='Feedback'
+                        variant='outlined'
+                        value={feedbackText}
+                        onChange={(e) => setFeedbackText(e.target.value)}
+                        disabled={isSubmitting}
+                        sx={{ mt: 1 }}
+                        inputProps={{ 'aria-label': 'Feedback' }}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={cancelFeedbackDialog} disabled={isSubmitting}>
+                        Cancel
+                    </Button>
+                    <Button onClick={submitFeedback} variant='contained' disabled={isSubmitting}>
+                        Submit
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <Dialog open={isSubmitting} aria-label='Submitting response'>
+                <DialogContent>
+                    <Stack direction='column' alignItems='center' spacing={2} sx={{ p: 2 }}>
+                        <CircularProgress size={48} />
+                        <Typography variant='body1'>Submitting response...</Typography>
+                    </Stack>
+                </DialogContent>
+            </Dialog>
+        </>
+    )
+}

--- a/packages/observe/src/features/executions/components/NodeContentRenderer.test.tsx
+++ b/packages/observe/src/features/executions/components/NodeContentRenderer.test.tsx
@@ -1,0 +1,194 @@
+import React, { type ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+
+import { NodeContentRenderer } from './NodeContentRenderer'
+
+// react-markdown ships ESM-only — Jest can't parse it with our ts-jest
+// preset. Stub it with a minimal implementation that *invokes* the
+// `components.code` callback for both inline (single-tick) and fenced
+// (triple-tick) snippets so we can drive the production `code` renderer's
+// branching logic from a test without changing production code.
+jest.mock('react-markdown', () => {
+    type MarkdownComponentProps = { className?: string; children?: React.ReactNode }
+    type MarkdownComponents = { code?: (props: MarkdownComponentProps) => React.ReactNode }
+    const ReactMarkdownStub = ({ children, components = {} }: { children?: string; components?: MarkdownComponents }) => {
+        const Code = components.code
+        const text = String(children ?? '')
+        const out: React.ReactNode[] = []
+        let i = 0
+        let key = 0
+        while (i < text.length) {
+            const fence = text.indexOf('```', i)
+            const tick = text.indexOf('`', i)
+            if (fence !== -1 && (tick === -1 || fence <= tick)) {
+                if (fence > i) out.push(<span key={`t-${key++}`}>{text.slice(i, fence)}</span>)
+                const langEnd = text.indexOf('\n', fence + 3)
+                const close = text.indexOf('```', langEnd === -1 ? fence + 3 : langEnd)
+                const lang = langEnd === -1 ? '' : text.slice(fence + 3, langEnd)
+                const body =
+                    langEnd === -1
+                        ? text.slice(fence + 3, close === -1 ? text.length : close)
+                        : text.slice(langEnd + 1, close === -1 ? text.length : close)
+                const fenceK = `code-${key++}`
+                out.push(
+                    <React.Fragment key={fenceK}>
+                        {Code ? Code({ className: lang ? `language-${lang}` : '', children: body }) : null}
+                    </React.Fragment>
+                )
+                i = close === -1 ? text.length : close + 3
+                continue
+            }
+            if (tick !== -1) {
+                if (tick > i) out.push(<span key={`t-${key++}`}>{text.slice(i, tick)}</span>)
+                const closeTick = text.indexOf('`', tick + 1)
+                const body = text.slice(tick + 1, closeTick === -1 ? text.length : closeTick)
+                const inlineK = `code-${key++}`
+                out.push(<React.Fragment key={inlineK}>{Code ? Code({ className: '', children: body }) : null}</React.Fragment>)
+                i = closeTick === -1 ? text.length : closeTick + 1
+                continue
+            }
+            out.push(<span key={`t-${key++}`}>{text.slice(i)}</span>)
+            i = text.length
+        }
+        return <div data-testid='react-markdown'>{out}</div>
+    }
+    return { __esModule: true, default: ReactMarkdownStub }
+})
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => null }))
+jest.mock('react-syntax-highlighter', () => ({
+    Prism: ({ children, language }: { children?: React.ReactNode; language?: string }) => (
+        <pre data-testid='syntax-highlighter' data-language={language}>
+            {children}
+        </pre>
+    )
+}))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+function renderWithTheme(ui: ReactElement, isDark = false) {
+    return render(<ThemeProvider theme={createObserveTheme(isDark)}>{ui}</ThemeProvider>)
+}
+
+describe('NodeContentRenderer', () => {
+    describe('null / undefined / placeholders', () => {
+        it('renders the "No data" placeholder for null', () => {
+            renderWithTheme(<NodeContentRenderer value={null} isDarkMode={false} />)
+            expect(screen.getByText('No data')).toBeInTheDocument()
+        })
+
+        it('renders the "No data" placeholder for undefined', () => {
+            renderWithTheme(<NodeContentRenderer value={undefined} isDarkMode={false} />)
+            expect(screen.getByText('No data')).toBeInTheDocument()
+        })
+    })
+
+    describe('object / JSON-parseable strings', () => {
+        it('renders an object directly through JsonBlock (flat <pre>)', () => {
+            const { container } = renderWithTheme(<NodeContentRenderer value={{ foo: 'bar', baz: 1 }} isDarkMode={false} />)
+            const pre = container.querySelectorAll('pre')
+            const flat = Array.from(pre).find((el) => el.textContent?.includes('"foo"') && el.textContent?.includes('"bar"'))
+            expect(flat).toBeDefined()
+        })
+
+        it('renders a JSON-parseable string-of-an-object through JsonBlock', () => {
+            const { container } = renderWithTheme(<NodeContentRenderer value={JSON.stringify({ foo: 'bar' })} isDarkMode={false} />)
+            const pre = container.querySelectorAll('pre')
+            const flat = Array.from(pre).find((el) => el.textContent?.includes('"foo"'))
+            expect(flat).toBeDefined()
+        })
+
+        it('renders a JSON-parseable primitive string through JsonPrimitive (not the tree viewer)', () => {
+            // The string '42' parses as the number 42. PARITY: legacy renders this through
+            // a JsonViewer with a number-syntax color — we mirror with a styled span.
+            renderWithTheme(<NodeContentRenderer value='42' isDarkMode={false} />)
+            expect(screen.getByText('42')).toBeInTheDocument()
+            expect(screen.queryByTestId('react-json-view')).not.toBeInTheDocument()
+        })
+
+        it('skips JsonPrimitive when parsePrimitiveAsJson=false (simple input path)', () => {
+            // The simple-input path (Start / Direct Reply) renders strings as
+            // markdown text without the inner bordered frame.
+            renderWithTheme(<NodeContentRenderer value='42' isDarkMode={false} parsePrimitiveAsJson={false} />)
+            expect(screen.getByText('42')).toBeInTheDocument()
+        })
+    })
+
+    describe('plain primitives', () => {
+        it('renders a number via the typography fallback', () => {
+            renderWithTheme(<NodeContentRenderer value={42} isDarkMode={false} />)
+            expect(screen.getByText('42')).toBeInTheDocument()
+        })
+
+        it('renders a plain (non-markdown) string in a Typography body', () => {
+            renderWithTheme(<NodeContentRenderer value='hello' isDarkMode={false} />)
+            expect(screen.getByText('hello')).toBeInTheDocument()
+            expect(screen.queryByTestId('react-markdown')).not.toBeInTheDocument()
+        })
+
+        it('renders a markdown-looking string via react-markdown', () => {
+            const md = '# Heading\n\nSome **bold** text'
+            renderWithTheme(<NodeContentRenderer value={md} isDarkMode={false} />)
+            expect(screen.getByTestId('react-markdown')).toHaveTextContent('# Heading')
+        })
+
+        it('renders an HTML-looking string as escaped markdown text (no rehype-raw)', () => {
+            // PARITY: legacy MemoizedReactMarkdown does NOT enable rehype-raw,
+            // so HTML payloads in markdown render as escaped text.
+            renderWithTheme(<NodeContentRenderer value='<div class="x">hi</div>' isDarkMode={false} />)
+            expect(screen.getByText(/hi/)).toBeInTheDocument()
+        })
+    })
+
+    describe('inline-code branch (markdown stub drives the code renderer)', () => {
+        it('renders single-tick inline code as a styled <code> element', () => {
+            renderWithTheme(<NodeContentRenderer value='Use `npm install` to add it.' isDarkMode={false} />)
+            const code = screen.getByText('npm install')
+            expect(code.tagName.toLowerCase()).toBe('code')
+            expect(screen.queryByTestId('syntax-highlighter')).not.toBeInTheDocument()
+        })
+
+        it('does NOT route inline code through the fenced CodeFenceBlock', () => {
+            renderWithTheme(<NodeContentRenderer value='hello `inline` world' isDarkMode={false} />)
+            // CodeFenceBlock would render copy/download icon buttons.
+            expect(screen.queryByRole('button', { name: /copy/i })).not.toBeInTheDocument()
+            expect(screen.queryByRole('button', { name: /download/i })).not.toBeInTheDocument()
+        })
+
+        it('routes triple-backtick fenced code through CodeFenceBlock with a language', () => {
+            renderWithTheme(<NodeContentRenderer value={'Result:\n```js\nconst x = 1;\n```'} isDarkMode={false} />)
+            const block = screen.getByTestId('syntax-highlighter')
+            expect(block).toHaveAttribute('data-language', 'js')
+            expect(block).toHaveTextContent('const x = 1;')
+        })
+
+        it('uses distinct chip backgrounds for light and dark mode', () => {
+            const { container: light } = renderWithTheme(<NodeContentRenderer value='Try `flag` here.' isDarkMode={false} />, false)
+            const { container: dark } = renderWithTheme(<NodeContentRenderer value='Try `flag` here.' isDarkMode={true} />, true)
+            const lightCode = light.querySelector('code') as HTMLElement
+            const darkCode = dark.querySelector('code') as HTMLElement
+            const lightBg = lightCode.style.backgroundColor || getComputedStyle(lightCode).backgroundColor
+            const darkBg = darkCode.style.backgroundColor || getComputedStyle(darkCode).backgroundColor
+            // Implementation: dark = rgba(255,255,255,0.08), light = rgba(0,0,0,0.08).
+            expect(lightBg).toBe('rgba(0, 0, 0, 0.08)')
+            expect(darkBg).toBe('rgba(255, 255, 255, 0.08)')
+        })
+    })
+
+    describe('mid-line fence preprocessing (PARITY: react-markdown v9)', () => {
+        it('routes a mid-line fenced block through CodeFenceBlock (no stray empty fence at end)', () => {
+            // CommonMark requires fences to begin at a line start. Agent outputs
+            // frequently embed mid-line fences ("Summary: ```json\n…"). The
+            // preprocessing step injects \n before mid-line fences so v9 parses
+            // them as proper blocks rather than misreading the closing ``` as a
+            // new opening fence with no body.
+            renderWithTheme(<NodeContentRenderer value={'Summary: ```json\n{"k":1}\n```'} isDarkMode={false} />)
+            const blocks = screen.getAllByTestId('syntax-highlighter')
+            expect(blocks).toHaveLength(1)
+            expect(blocks[0]).toHaveAttribute('data-language', 'json')
+            expect(blocks[0]).toHaveTextContent('{"k":1}')
+        })
+    })
+})

--- a/packages/observe/src/features/executions/components/NodeContentRenderer.test.tsx
+++ b/packages/observe/src/features/executions/components/NodeContentRenderer.test.tsx
@@ -114,6 +114,23 @@ describe('NodeContentRenderer', () => {
             renderWithTheme(<NodeContentRenderer value='42' isDarkMode={false} parsePrimitiveAsJson={false} />)
             expect(screen.getByText('42')).toBeInTheDocument()
         })
+
+        it('forwards jsonMaxHeight to JsonBlock (different class vs default)', () => {
+            // jsonMaxHeight is a thin pass-through onto JsonBlock's sx, which
+            // resolves to an emotion className. A non-default value must
+            // produce a different class — proving the prop wires through.
+            const findJsonBox = (root: HTMLElement): HTMLElement | null =>
+                Array.from(root.querySelectorAll('[class*="MuiBox-root"]')).find((el) => el.querySelector('pre')) as HTMLElement | null
+
+            const defaultRender = renderWithTheme(<NodeContentRenderer value={{ k: 1 }} isDarkMode={false} />)
+            const overriddenRender = renderWithTheme(<NodeContentRenderer value={{ k: 1 }} isDarkMode={false} jsonMaxHeight={123} />)
+
+            const defaultBox = findJsonBox(defaultRender.container as HTMLElement)
+            const overriddenBox = findJsonBox(overriddenRender.container as HTMLElement)
+            expect(defaultBox).toBeTruthy()
+            expect(overriddenBox).toBeTruthy()
+            expect(overriddenBox!.className).not.toBe(defaultBox!.className)
+        })
     })
 
     describe('plain primitives', () => {

--- a/packages/observe/src/features/executions/components/NodeContentRenderer.tsx
+++ b/packages/observe/src/features/executions/components/NodeContentRenderer.tsx
@@ -25,14 +25,12 @@ export interface NodeContentRendererProps {
      */
     parsePrimitiveAsJson?: boolean
     /**
-     * Caps the height of the bordered JSON viewer. Matches legacy JSONViewer's
-     * default of 400 — long HTTP / form payloads scroll inside the frame
-     * instead of pushing the rest of the panel off-screen.
+     * Override the bordered JSON viewer's max height. Defaults to JsonBlock's
+     * value (400) — set this only when the embedding context (e.g. a
+     * compact list cell) needs a smaller cap.
      */
     jsonMaxHeight?: number | string
 }
-
-const DEFAULT_JSON_MAX_HEIGHT = 400
 
 // react-markdown v9 dropped the `inline` prop — we infer block vs inline by
 // inspecting `className` (language-*) and `children` (newlines).
@@ -83,12 +81,7 @@ function MarkdownCode({ className, children, isDarkMode, ...rest }: MarkdownCode
  * malformed HTML fragments which crash the rehype-raw HTML tokenizer. Without
  * it, ReactMarkdown safely escapes HTML as text.
  */
-export function NodeContentRenderer({
-    value,
-    isDarkMode,
-    parsePrimitiveAsJson = true,
-    jsonMaxHeight = DEFAULT_JSON_MAX_HEIGHT
-}: NodeContentRendererProps) {
+export function NodeContentRenderer({ value, isDarkMode, parsePrimitiveAsJson = true, jsonMaxHeight }: NodeContentRendererProps) {
     if (value === null || value === undefined) {
         return (
             <Typography variant='body2' color='text.secondary' sx={{ fontStyle: 'italic' }}>

--- a/packages/observe/src/features/executions/components/NodeContentRenderer.tsx
+++ b/packages/observe/src/features/executions/components/NodeContentRenderer.tsx
@@ -1,0 +1,154 @@
+import { type ReactNode } from 'react'
+import ReactMarkdown from 'react-markdown'
+
+import { Box, Typography } from '@mui/material'
+import remarkGfm from 'remark-gfm'
+
+import { CodeFenceBlock, JsonBlock, JsonPrimitive } from '@/atoms'
+import { tryParseJson } from '@/core/primitives'
+
+// Loose markdown heuristic: false positives still render correctly because
+// react-markdown passes plain text through unchanged.
+function looksLikeMarkdown(value: string): boolean {
+    return value.includes('\n') || value.includes('**') || value.includes('##') || value.includes('```') || value.includes('`')
+}
+
+export interface NodeContentRendererProps {
+    value: unknown
+    isDarkMode: boolean
+    /**
+     * When true (default), string content that parses as a JSON primitive
+     * (e.g. `"6092"` → 6092) is rendered through `JsonPrimitive` with its own
+     * bordered frame. Pass `false` for the simple input rendering path
+     * (Start / Direct Reply nodes), which renders `data.input.question` as
+     * plain markdown text without a nested inner border.
+     */
+    parsePrimitiveAsJson?: boolean
+    /**
+     * Caps the height of the bordered JSON viewer. Matches legacy JSONViewer's
+     * default of 400 — long HTTP / form payloads scroll inside the frame
+     * instead of pushing the rest of the panel off-screen.
+     */
+    jsonMaxHeight?: number | string
+}
+
+const DEFAULT_JSON_MAX_HEIGHT = 400
+
+// react-markdown v9 dropped the `inline` prop — we infer block vs inline by
+// inspecting `className` (language-*) and `children` (newlines).
+//
+// `ReactMarkdownCodeProps` mirrors the subset of the v9 `code` component
+// signature we actually use; matching it lets ReactMarkdown's component
+// override accept `MarkdownCode` directly without a cast.
+interface ReactMarkdownCodeProps {
+    className?: string
+    children?: ReactNode
+}
+
+interface MarkdownCodeProps extends ReactMarkdownCodeProps {
+    isDarkMode: boolean
+}
+
+function MarkdownCode({ className, children, isDarkMode, ...rest }: MarkdownCodeProps) {
+    const text = String(children ?? '')
+    const langMatch = /language-(\w+)/.exec(className ?? '')
+    const isBlock = !!langMatch || text.includes('\n')
+
+    if (!isBlock) {
+        return (
+            <Box
+                component='code'
+                className={className}
+                sx={{
+                    px: 0.5,
+                    borderRadius: 0.5,
+                    backgroundColor: isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+                    fontFamily: 'monospace',
+                    fontSize: '0.85em'
+                }}
+                {...rest}
+            >
+                {children}
+            </Box>
+        )
+    }
+
+    return <CodeFenceBlock value={text.replace(/\n$/, '')} language={langMatch?.[1] ?? ''} />
+}
+
+/**
+ * Renders a single value as JSON, markdown, or plain text.
+ *
+ * We deliberately do NOT enable `rehype-raw`: agent inputs frequently contain
+ * malformed HTML fragments which crash the rehype-raw HTML tokenizer. Without
+ * it, ReactMarkdown safely escapes HTML as text.
+ */
+export function NodeContentRenderer({
+    value,
+    isDarkMode,
+    parsePrimitiveAsJson = true,
+    jsonMaxHeight = DEFAULT_JSON_MAX_HEIGHT
+}: NodeContentRendererProps) {
+    if (value === null || value === undefined) {
+        return (
+            <Typography variant='body2' color='text.secondary' sx={{ fontStyle: 'italic' }}>
+                No data
+            </Typography>
+        )
+    }
+
+    if (typeof value === 'object') {
+        return <JsonBlock value={value as object} isDarkMode={isDarkMode} maxHeight={jsonMaxHeight} />
+    }
+
+    if (typeof value === 'string') {
+        if (parsePrimitiveAsJson) {
+            const parsed = tryParseJson(value)
+            if (parsed.ok) {
+                const v = parsed.value
+                if (v !== null && typeof v === 'object')
+                    return <JsonBlock value={v as object} isDarkMode={isDarkMode} maxHeight={jsonMaxHeight} />
+                return <JsonPrimitive value={v as string | number | boolean | null} isDarkMode={isDarkMode} />
+            }
+        }
+
+        if (looksLikeMarkdown(value)) {
+            // CommonMark requires fenced code blocks to start at the beginning
+            // of a line. Agent outputs frequently embed mid-line fences like
+            // `Summary: ```json\n{...}\n```` — v8 (legacy) parsed these
+            // leniently, but v9 (current) follows spec and treats them as
+            // plain text. Insert a newline before any mid-line fence so v9
+            // detects it. Without this, the closing ``` (which IS at line
+            // start) gets misread as a new opening fence with no closing,
+            // producing an empty CodeFenceBlock at the end.
+            const withFenceBoundaries = value.replace(/(?<!\n|^)(```)/g, '\n$1')
+            // Promote single `\n` to a hard break (`  \n`) for ReactMarkdown v9
+            // since v9 collapses soft breaks. Skip the transform inside fenced
+            // ``` blocks so the fence content / detection isn't polluted.
+            const withHardBreaks = withFenceBoundaries
+                .split(/(```[\s\S]*?```)/g)
+                .map((part, i) => (i % 2 === 0 ? part.replace(/(?<!\n)\n(?!\n)/g, '  \n') : part))
+                .join('')
+            return (
+                <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                        p: ({ children }) => <p style={{ margin: '0.25em 0' }}>{children}</p>,
+                        code: (props: ReactMarkdownCodeProps) => <MarkdownCode {...props} isDarkMode={isDarkMode} />
+                    }}
+                >
+                    {withHardBreaks}
+                </ReactMarkdown>
+            )
+        }
+
+        return (
+            <Typography variant='body2' sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {value}
+            </Typography>
+        )
+    }
+
+    // Numbers, booleans, etc.
+    return <Typography variant='body2'>{String(value)}</Typography>
+}

--- a/packages/observe/src/features/executions/components/NodeExecutionDetail.test.tsx
+++ b/packages/observe/src/features/executions/components/NodeExecutionDetail.test.tsx
@@ -1,0 +1,326 @@
+import React from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+import type { ExecutionTreeNode, NodeExecutionData } from '@/core/types'
+
+import { NodeExecutionDetail } from './NodeExecutionDetail'
+
+// ============================================================================
+// Mocks — focused on what the orchestrator wires up. Unit-level behaviors
+// (curated values, HITL state machine, content rendering, JsonBlock palette,
+// metrics formatting, conditions) live in their own test files.
+// ============================================================================
+
+jest.mock('flowise-react-json-view', () => {
+    const ReactJsonStub = ({ src }: { src: unknown }) => <pre data-testid='react-json-view'>{JSON.stringify(src)}</pre>
+    return { __esModule: true, default: ReactJsonStub }
+})
+
+jest.mock('react-markdown', () => {
+    const ReactMarkdownStub = ({ children }: { children?: React.ReactNode }) => <div data-testid='react-markdown'>{children}</div>
+    return { __esModule: true, default: ReactMarkdownStub }
+})
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => null }))
+
+jest.mock('react-syntax-highlighter', () => ({
+    Prism: ({ children }: { children?: React.ReactNode }) => <pre data-testid='syntax-highlighter'>{children}</pre>
+}))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+jest.mock('@/infrastructure/store', () => ({
+    useObserveConfig: () => ({ isDarkMode: false, apiBaseUrl: 'http://localhost:3000' })
+}))
+
+// ============================================================================
+// Factories
+// ============================================================================
+
+function makeNodeData(overrides: Partial<NodeExecutionData> = {}): NodeExecutionData {
+    return {
+        nodeId: 'node-1',
+        nodeLabel: 'Step 1',
+        status: 'FINISHED',
+        data: {},
+        previousNodeIds: [],
+        ...overrides
+    }
+}
+
+function makeTreeNode(overrides: Partial<ExecutionTreeNode> = {}, raw?: NodeExecutionData): ExecutionTreeNode {
+    const rawData = raw ?? makeNodeData(overrides as Partial<NodeExecutionData>)
+    return {
+        id: rawData.nodeId,
+        nodeId: rawData.nodeId,
+        nodeLabel: rawData.nodeLabel,
+        status: rawData.status,
+        name: rawData.name ?? '',
+        children: [],
+        raw: rawData,
+        ...overrides
+    }
+}
+
+function renderWithTheme(ui: React.ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+const baseProps = {
+    agentflowId: 'flow-1',
+    sessionId: 'sess-1'
+}
+
+// ============================================================================
+// Integration smoke — orchestration only
+// ============================================================================
+
+describe('NodeExecutionDetail (integration smoke)', () => {
+    describe('header', () => {
+        it('renders the node label', () => {
+            const node = makeTreeNode({ nodeLabel: 'My Node' }, makeNodeData({ nodeLabel: 'My Node' }))
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            expect(screen.getByText('My Node')).toBeInTheDocument()
+        })
+
+        it('does not surface the raw node type name in the header (icon already conveys type)', () => {
+            const node = makeTreeNode(undefined, makeNodeData({ name: 'agentAgentflow', nodeLabel: 'Agent A' }))
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            expect(screen.queryByText('agentAgentflow')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('rendered/raw toggle', () => {
+        it('defaults to rendered view (Input + Output sections present, no full payload dump)', () => {
+            const data = { input: 'hello world', output: 'goodbye' }
+            const node = makeTreeNode(undefined, makeNodeData({ data }))
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            expect(screen.getByText('Input')).toBeInTheDocument()
+            expect(screen.getByText('Output')).toBeInTheDocument()
+            expect(screen.queryByText(JSON.stringify(data))).not.toBeInTheDocument()
+        })
+
+        it('switches to raw view when the raw toggle is clicked, dumping the full payload', () => {
+            const data = { input: 'hello', output: 'world' }
+            const node = makeTreeNode(undefined, makeNodeData({ data }))
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            fireEvent.click(screen.getByRole('button', { name: 'Raw' }))
+            const dump = screen.getAllByTestId('react-json-view').find((el) => el.textContent === JSON.stringify(data))
+            expect(dump).toBeDefined()
+        })
+
+        it('null-guards the toggle when the user deselects the active button', () => {
+            const node = makeTreeNode(undefined, makeNodeData({ data: { input: 'hi' } }))
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            expect(screen.getByText('Input')).toBeInTheDocument()
+            // MUI emits null when clicking the active button — no crash, no swap.
+            fireEvent.click(screen.getByRole('button', { name: 'Rendered' }))
+            expect(screen.getByText('Input')).toBeInTheDocument()
+        })
+    })
+
+    describe('section wiring', () => {
+        it('renders Error section only when data.error is truthy', () => {
+            const without = makeTreeNode(undefined, makeNodeData({ data: { output: 'ok' } }))
+            const { unmount } = renderWithTheme(<NodeExecutionDetail node={without} {...baseProps} />)
+            expect(screen.queryByText('Error')).not.toBeInTheDocument()
+            unmount()
+
+            const withError = makeTreeNode(undefined, makeNodeData({ data: { error: 'Boom' } }))
+            renderWithTheme(<NodeExecutionDetail node={withError} {...baseProps} />)
+            expect(screen.getByText('Error')).toBeInTheDocument()
+            expect(screen.getByText('Boom')).toBeInTheDocument()
+        })
+
+        it('renders State section only when data.state is a non-empty object', () => {
+            const empty = makeTreeNode(undefined, makeNodeData({ data: { state: {} } }))
+            const { unmount } = renderWithTheme(<NodeExecutionDetail node={empty} {...baseProps} />)
+            expect(screen.queryByText('State')).not.toBeInTheDocument()
+            unmount()
+
+            const withState = makeTreeNode(undefined, makeNodeData({ data: { state: { count: 3 } } }))
+            renderWithTheme(<NodeExecutionDetail node={withState} {...baseProps} />)
+            expect(screen.getByText('State')).toBeInTheDocument()
+        })
+
+        it('routes chat-style messages through ChatMessageBubble (role chips above content)', () => {
+            const node = makeTreeNode(
+                undefined,
+                makeNodeData({
+                    data: {
+                        input: {
+                            messages: [
+                                { role: 'system', content: 'You are a helpful assistant.' },
+                                { role: 'user', content: 'Summarize the PR' }
+                            ]
+                        }
+                    }
+                })
+            )
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            expect(screen.getByText('system')).toBeInTheDocument()
+            expect(screen.getByText('user')).toBeInTheDocument()
+            expect(screen.getByText('You are a helpful assistant.')).toBeInTheDocument()
+            expect(screen.getByText('Summarize the PR')).toBeInTheDocument()
+        })
+
+        it('routes a condition node output through FulfilledConditionsBlock', () => {
+            const node = makeTreeNode(
+                undefined,
+                makeNodeData({
+                    data: {
+                        output: {
+                            conditions: [{ type: 'string', operation: 'equal', value1: 'a', value2: 'a', isFulfilled: true }]
+                        }
+                    }
+                })
+            )
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            expect(screen.getByText('Condition 0')).toBeInTheDocument()
+            expect(screen.getByText('Fulfilled')).toBeInTheDocument()
+        })
+
+        it('renders a Tools section above Input when data.output.availableTools is present', () => {
+            const node = makeTreeNode(
+                undefined,
+                makeNodeData({
+                    data: {
+                        output: {
+                            availableTools: [
+                                { name: 'search_repositories', toolNode: { name: 'githubMcp', label: 'Github MCP' } },
+                                { name: 'get_issue' }
+                            ],
+                            usedTools: [{ tool: 'search_repositories' }]
+                        }
+                    }
+                })
+            )
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            expect(screen.getByText('Tools')).toBeInTheDocument()
+            expect(screen.getByText('Github MCP')).toBeInTheDocument()
+            expect(screen.getByText('get_issue')).toBeInTheDocument()
+            expect(screen.getByText('Used')).toBeInTheDocument()
+        })
+
+        it('omits the Tools section when availableTools is missing or empty', () => {
+            const empty = makeTreeNode(undefined, makeNodeData({ data: { output: { availableTools: [] } } }))
+            const { unmount } = renderWithTheme(<NodeExecutionDetail node={empty} {...baseProps} />)
+            expect(screen.queryByText('Tools')).not.toBeInTheDocument()
+            unmount()
+
+            const missing = makeTreeNode(undefined, makeNodeData({ data: { output: { content: 'ok' } } }))
+            renderWithTheme(<NodeExecutionDetail node={missing} {...baseProps} />)
+            expect(screen.queryByText('Tools')).not.toBeInTheDocument()
+        })
+
+        it('renders usedTools chips inside the Output section when present', () => {
+            const node = makeTreeNode(
+                undefined,
+                makeNodeData({
+                    data: {
+                        output: {
+                            content: 'The repo does X',
+                            usedTools: [{ tool: 'search_repositories' }, { tool: 'get_file_contents' }]
+                        }
+                    }
+                })
+            )
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            expect(screen.getByText('search_repositories')).toBeInTheDocument()
+            expect(screen.getByText('get_file_contents')).toBeInTheDocument()
+        })
+
+        it('renders the metrics row when output carries time/token/cost metadata', () => {
+            const node = makeTreeNode(
+                undefined,
+                makeNodeData({
+                    data: { output: { timeMetadata: { delta: 2500 }, usageMetadata: { total_tokens: 99, total_cost: 0.25 } } }
+                })
+            )
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} />)
+            const group = screen.getByRole('group', { name: /metrics/i })
+            expect(within(group).getByText('2.50 seconds')).toBeInTheDocument()
+            expect(within(group).getByText('99 tokens')).toBeInTheDocument()
+            expect(within(group).getByText('$0.25')).toBeInTheDocument()
+        })
+    })
+
+    describe('HITL gating', () => {
+        const hitlNode = (overrides: Partial<NodeExecutionData> = {}) =>
+            makeTreeNode(
+                { status: 'INPROGRESS' },
+                makeNodeData({
+                    name: 'humanInputAgentflow',
+                    status: 'INPROGRESS',
+                    data: { question: 'Approve this?' },
+                    ...overrides
+                })
+            )
+
+        it('hides the action bar when no onHumanInput callback is provided', () => {
+            renderWithTheme(<NodeExecutionDetail node={hitlNode()} {...baseProps} />)
+            expect(screen.queryByTestId('hitl-action-bar')).not.toBeInTheDocument()
+        })
+
+        it('hides the action bar when the node name is not humanInputAgentflow', () => {
+            const onHumanInput = jest.fn()
+            const node = makeTreeNode(
+                { status: 'INPROGRESS' },
+                makeNodeData({ name: 'llmAgentflow', status: 'INPROGRESS', data: { question: 'q' } })
+            )
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} onHumanInput={onHumanInput} />)
+            expect(screen.queryByTestId('hitl-action-bar')).not.toBeInTheDocument()
+        })
+
+        it('hides the action bar when the node is not INPROGRESS', () => {
+            const onHumanInput = jest.fn()
+            const node = makeTreeNode(
+                { status: 'FINISHED' },
+                makeNodeData({ name: 'humanInputAgentflow', status: 'FINISHED', data: { question: 'q' } })
+            )
+            renderWithTheme(<NodeExecutionDetail node={node} {...baseProps} onHumanInput={onHumanInput} />)
+            expect(screen.queryByTestId('hitl-action-bar')).not.toBeInTheDocument()
+        })
+
+        it('shows the floating action bar with Proceed + Reject buttons when all conditions are met', () => {
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            renderWithTheme(<NodeExecutionDetail node={hitlNode()} {...baseProps} onHumanInput={onHumanInput} />)
+            const bar = screen.getByTestId('hitl-action-bar')
+            expect(within(bar).getByRole('button', { name: 'Proceed' })).toBeInTheDocument()
+            expect(within(bar).getByRole('button', { name: 'Reject' })).toBeInTheDocument()
+        })
+    })
+
+    describe('virtual nodes', () => {
+        const virtualNode = (overrides: Partial<ExecutionTreeNode> = {}): ExecutionTreeNode => ({
+            id: 'iter-0',
+            nodeId: 'loop',
+            nodeLabel: 'Iteration #1',
+            status: 'FINISHED',
+            name: '',
+            children: [],
+            isVirtualNode: true,
+            ...overrides
+        })
+
+        it('does not crash when raw is undefined (renders the label and "No data")', () => {
+            renderWithTheme(<NodeExecutionDetail node={virtualNode()} {...baseProps} />)
+            expect(screen.getByText('Iteration #1')).toBeInTheDocument()
+            expect(screen.getAllByText('No data').length).toBeGreaterThanOrEqual(1)
+        })
+
+        it('does not show HITL controls even if status is INPROGRESS', () => {
+            const onHumanInput = jest.fn()
+            renderWithTheme(<NodeExecutionDetail node={virtualNode({ status: 'INPROGRESS' })} {...baseProps} onHumanInput={onHumanInput} />)
+            expect(screen.queryByTestId('hitl-action-bar')).not.toBeInTheDocument()
+        })
+
+        it('skips the header NodeIcon (avoids 404 on the synthesized nodeId)', () => {
+            const { container } = renderWithTheme(<NodeExecutionDetail node={virtualNode({ nodeId: 'loop-iteration-0' })} {...baseProps} />)
+            const imgs = container.querySelectorAll('img')
+            const nodeIconImg = Array.from(imgs).find((el) => el.getAttribute('src')?.includes('/api/v1/node-icon/'))
+            expect(nodeIconImg).toBeUndefined()
+        })
+    })
+})

--- a/packages/observe/src/features/executions/components/NodeExecutionDetail.tsx
+++ b/packages/observe/src/features/executions/components/NodeExecutionDetail.tsx
@@ -1,30 +1,23 @@
 import { useState } from 'react'
-import ReactMarkdown from 'react-markdown'
 
-import {
-    Box,
-    Button,
-    CircularProgress,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-    Divider,
-    Stack,
-    TextField,
-    ToggleButton,
-    ToggleButtonGroup,
-    Tooltip,
-    Typography
-} from '@mui/material'
+import { Box, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
-import { IconCode, IconEye } from '@tabler/icons-react'
-import ReactJson from 'flowise-react-json-view'
-import remarkGfm from 'remark-gfm'
 
-import { MetricsDisplay, StatusIndicator } from '@/atoms'
-import type { ExecutionState, ExecutionTreeNode, HumanInputParams, NodeExecutionData } from '@/core/types'
+import { MetricsDisplay, NodeIcon } from '@/atoms'
+import type { ExecutionTreeNode, HumanInputParams, UsedToolRef } from '@/core/types'
+import { isAvailableToolArray, isUsedToolArray } from '@/core/utils'
 import { useObserveConfig } from '@/infrastructure/store'
+
+import { useHumanInput } from '../hooks/useHumanInput'
+import { useNodeData } from '../hooks/useNodeData'
+
+import { ChatMessageBubble } from './ChatMessageBubble'
+import { FulfilledConditionsBlock } from './FulfilledConditionsBlock'
+import { HitlPanel } from './HitlPanel'
+import { NodeContentRenderer } from './NodeContentRenderer'
+import { RawJsonPanel } from './RawJsonPanel'
+import { ToolAccordionList } from './ToolAccordionList'
+import { UsedToolChips } from './UsedToolChips'
 
 type DataView = 'rendered' | 'raw'
 
@@ -35,197 +28,196 @@ interface NodeExecutionDetailProps {
     onHumanInput?: (agentflowId: string, params: HumanInputParams) => Promise<void>
 }
 
-function isMarkdown(value: unknown): value is string {
-    return typeof value === 'string' && (value.includes('\n') || value.includes('**') || value.includes('##'))
-}
-
-function renderValue(value: unknown, isDarkMode: boolean) {
-    if (value === null || value === undefined) return null
-    if (typeof value === 'string') {
-        if (isMarkdown(value)) {
-            return <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
-        }
-        return (
-            <Typography variant='body2' sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-                {value}
-            </Typography>
-        )
-    }
-    if (typeof value === 'object') {
-        return (
-            <ReactJson
-                src={value as object}
-                theme={isDarkMode ? 'monokai' : 'rjv-default'}
-                collapsed={2}
-                displayDataTypes={false}
-                displayObjectSize={false}
-                style={{ fontSize: '0.75rem', background: 'transparent' }}
-            />
-        )
-    }
-    return <Typography variant='body2'>{String(value)}</Typography>
-}
-
 /**
  * Right-panel detail view for a selected node in the execution tree.
- * Shows node metadata, metrics, rendered/raw output, and HITL controls when applicable.
+ * Shows node metadata, metrics, rendered/raw output, and HITL controls when
+ * applicable.
+ *
+ * HITL controls render only when ALL of:
+ *  - `onHumanInput` callback is provided
+ *  - the node's `name` is `humanInputAgentflow`
+ *  - the node's `status` is `INPROGRESS`
+ *
+ * The feedback dialog is gated on the `humanInputEnableFeedback` flag inside
+ * the node's data payload.
  */
 export function NodeExecutionDetail({ node, agentflowId, sessionId, onHumanInput }: NodeExecutionDetailProps) {
     const theme = useTheme()
-    const { isDarkMode } = useObserveConfig()
+    const { isDarkMode, apiBaseUrl } = useObserveConfig()
     const [dataView, setDataView] = useState<DataView>('rendered')
-    const [isSubmitting, setIsSubmitting] = useState(false)
-    const [feedbackOpen, setFeedbackOpen] = useState(false)
-    const [feedbackText, setFeedbackText] = useState('')
-    const [pendingType, setPendingType] = useState<'proceed' | 'reject' | null>(null)
 
-    const raw = node.raw as NodeExecutionData | undefined
-    const isHumanInputNode = raw?.name === 'humanInputAgentflow'
-    const isInProgress = node.status === 'INPROGRESS'
-    const showHitlControls = isHumanInputNode && isInProgress && !!onHumanInput
-    const enableFeedback = raw?.data?.humanInputEnableFeedback === true
+    const {
+        payload,
+        dataOutput,
+        inputMessages,
+        inputValue,
+        outputValue,
+        outputConditions,
+        errorValue,
+        stateValue,
+        hasInput,
+        hasError,
+        hasState,
+        isHumanInputNode,
+        enableFeedback
+    } = useNodeData(node)
 
-    const submitHumanInput = async (type: 'proceed' | 'reject', feedback = '') => {
-        if (!onHumanInput) return
-        setIsSubmitting(true)
-        try {
-            await onHumanInput(agentflowId, {
-                question: feedback || (type === 'proceed' ? 'Proceed' : 'Reject'),
-                chatId: sessionId,
-                humanInput: { type, startNodeId: node.nodeId, feedback }
-            })
-        } finally {
-            setIsSubmitting(false)
-        }
+    const showHitlControls = !!onHumanInput && isHumanInputNode && node.status === 'INPROGRESS'
+
+    const hitl = useHumanInput({
+        agentflowId,
+        sessionId,
+        nodeId: node.nodeId,
+        enableFeedback,
+        onHumanInput
+    })
+
+    const handleDataViewChange = (_: unknown, next: DataView | null) => {
+        // Null-guard: ToggleButtonGroup emits null when the user clicks the
+        // active button to deselect. Keep the existing view in that case.
+        if (next === null) return
+        setDataView(next)
     }
 
-    const handleProceed = () => {
-        if (enableFeedback) {
-            setPendingType('proceed')
-            setFeedbackOpen(true)
-        } else {
-            submitHumanInput('proceed')
-        }
-    }
+    const sectionBoxSx = {
+        mt: 1,
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 1,
+        py: 1,
+        px: 2,
+        backgroundColor: 'background.paper'
+    } as const
 
-    const handleReject = () => {
-        if (enableFeedback) {
-            setPendingType('reject')
-            setFeedbackOpen(true)
-        } else {
-            submitHumanInput('reject')
-        }
-    }
-
-    const handleFeedbackSubmit = () => {
-        if (pendingType) submitHumanInput(pendingType, feedbackText)
-        setFeedbackOpen(false)
-        setFeedbackText('')
-        setPendingType(null)
+    // Toggle button: subtle border that adapts to mode. Berry's theme remaps
+    // grey[900] to a LIGHT color in dark mode; ours keeps it dark in both
+    // modes, so use `divider` (auto-mode-aware) for a visible outline.
+    // Berry never overrides `theme.shape.borderRadius`, so legacy's
+    // `borderRadius: 2` resolves against MUI's default 4 → 8px corners. Our
+    // theme sets shape=8, so `borderRadius: 1` (= 1 × 8) reproduces the same
+    // 8px corners; `borderRadius: 2` would render as 16px (too pill-like).
+    const toggleButtonSx = {
+        borderColor: theme.palette.divider,
+        borderRadius: 1,
+        textTransform: 'none' as const,
+        color: isDarkMode ? 'common.white' : 'inherit'
     }
 
     return (
         <Box sx={{ height: '100%', overflow: 'auto', p: 2 }}>
-            {/* Header */}
-            <Stack direction='row' spacing={1} alignItems='center' sx={{ mb: 1.5 }}>
-                <StatusIndicator state={node.status as ExecutionState} size={18} />
-                <Typography variant='h5'>{node.nodeLabel}</Typography>
-                {node.name && (
-                    <Typography variant='caption' color='text.secondary' sx={{ ml: 'auto' }}>
-                        {node.name}
-                    </Typography>
-                )}
+            <Stack direction='row' spacing={1.5} alignItems='center' sx={{ mb: 1.5 }}>
+                {/* Virtual iteration container nodes have a synthesized
+                    nodeId like `${parent}-iteration-${idx}` and no resolvable
+                    type name — skip the icon to avoid a 404 on the fallback
+                    `<img src=…/api/v1/node-icon/${name}>` request. */}
+                {!node.isVirtualNode && <NodeIcon name={node.name} size={36} apiBaseUrl={apiBaseUrl} />}
+                <Typography variant='h5' sx={{ flex: 1 }}>
+                    {node.nodeLabel}
+                </Typography>
+                <MetricsDisplay output={dataOutput} />
             </Stack>
 
-            {/* Metrics */}
-            {raw?.output && <MetricsDisplay output={raw.output} />}
-
-            {/* HITL Controls */}
-            {showHitlControls && (
-                <Box sx={{ my: 2, p: 1.5, border: `1px solid ${theme.palette.divider}`, borderRadius: 1 }}>
-                    <Typography variant='subtitle1' sx={{ mb: 1 }}>
-                        {(raw?.data?.question as string) ?? 'Waiting for your response'}
-                    </Typography>
-                    <Stack direction='row' spacing={1}>
-                        <Button variant='contained' color='success' size='small' disabled={isSubmitting} onClick={handleProceed}>
-                            {isSubmitting ? <CircularProgress size={14} /> : 'Approve'}
-                        </Button>
-                        <Button variant='outlined' color='error' size='small' disabled={isSubmitting} onClick={handleReject}>
-                            Reject
-                        </Button>
-                    </Stack>
-                </Box>
-            )}
-
-            <Divider sx={{ my: 1.5 }} />
-
-            {/* Data view toggle */}
-            <Stack direction='row' justifyContent='space-between' alignItems='center' sx={{ mb: 1 }}>
-                <Typography variant='subtitle1'>Output</Typography>
-                <ToggleButtonGroup size='small' value={dataView} exclusive onChange={(_, val) => val && setDataView(val)}>
-                    <ToggleButton value='rendered'>
-                        <Tooltip title='Rendered'>
-                            <IconEye size={14} />
-                        </Tooltip>
+            <Stack direction='row' justifyContent='flex-start' alignItems='center' sx={{ mt: 2, mb: 1 }}>
+                <ToggleButtonGroup
+                    size='small'
+                    value={dataView}
+                    color='primary'
+                    exclusive
+                    onChange={handleDataViewChange}
+                    aria-label='Data view'
+                    sx={{ borderRadius: 1, maxHeight: 40 }}
+                >
+                    <ToggleButton sx={toggleButtonSx} value='rendered' title='Rendered'>
+                        Rendered
                     </ToggleButton>
-                    <ToggleButton value='raw'>
-                        <Tooltip title='Raw JSON'>
-                            <IconCode size={14} />
-                        </Tooltip>
+                    <ToggleButton sx={toggleButtonSx} value='raw' title='Raw'>
+                        Raw
                     </ToggleButton>
                 </ToggleButtonGroup>
             </Stack>
 
-            {/* Data content */}
-            <Box sx={{ fontSize: '0.8125rem', lineHeight: 1.6 }}>
-                {dataView === 'raw' ? (
-                    <ReactJson
-                        src={raw?.data ?? {}}
-                        theme={isDarkMode ? 'monokai' : 'rjv-default'}
-                        collapsed={1}
-                        displayDataTypes={false}
-                        displayObjectSize={false}
-                        style={{ fontSize: '0.75rem', background: 'transparent' }}
-                    />
-                ) : (
-                    Object.entries(raw?.data ?? {}).map(([key, value]) => (
-                        <Box key={key} sx={{ mb: 1.5 }}>
-                            <Typography
-                                variant='caption'
-                                color='text.secondary'
-                                sx={{ textTransform: 'uppercase', letterSpacing: '0.05em' }}
-                            >
-                                {key}
-                            </Typography>
-                            <Box sx={{ mt: 0.5 }}>{renderValue(value, isDarkMode)}</Box>
+            {dataView === 'raw' ? (
+                <RawJsonPanel src={payload} isDarkMode={isDarkMode} />
+            ) : (
+                <Box>
+                    {isAvailableToolArray(dataOutput?.availableTools) && (
+                        <Box sx={{ mb: 2 }}>
+                            <ToolAccordionList
+                                variant='available'
+                                tools={dataOutput.availableTools}
+                                usedTools={dataOutput.usedTools as UsedToolRef[] | undefined}
+                                isDarkMode={isDarkMode}
+                                apiBaseUrl={apiBaseUrl}
+                            />
                         </Box>
-                    ))
-                )}
-            </Box>
+                    )}
+                    <Box sx={{ mb: 2 }}>
+                        <Typography sx={{ mt: 2 }} variant='h5' gutterBottom>
+                            Input
+                        </Typography>
+                        {inputMessages ? (
+                            <Stack spacing={1}>
+                                {inputMessages.map((message, idx) => (
+                                    <ChatMessageBubble
+                                        key={idx}
+                                        message={message}
+                                        isDarkMode={isDarkMode}
+                                        sx={sectionBoxSx}
+                                        availableTools={
+                                            isAvailableToolArray(dataOutput?.availableTools) ? dataOutput.availableTools : undefined
+                                        }
+                                        apiBaseUrl={apiBaseUrl}
+                                    />
+                                ))}
+                            </Stack>
+                        ) : (
+                            <Box sx={sectionBoxSx}>
+                                {hasInput ? (
+                                    <NodeContentRenderer value={inputValue} isDarkMode={isDarkMode} parsePrimitiveAsJson={false} />
+                                ) : (
+                                    <NodeContentRenderer value={null} isDarkMode={isDarkMode} />
+                                )}
+                            </Box>
+                        )}
+                    </Box>
 
-            {/* Feedback dialog */}
-            <Dialog open={feedbackOpen} onClose={() => setFeedbackOpen(false)} maxWidth='sm' fullWidth>
-                <DialogTitle>Provide Feedback</DialogTitle>
-                <DialogContent>
-                    <TextField
-                        autoFocus
-                        multiline
-                        fullWidth
-                        rows={3}
-                        label='Feedback'
-                        variant='outlined'
-                        value={feedbackText}
-                        onChange={(e) => setFeedbackText(e.target.value)}
-                        sx={{ mt: 1 }}
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => setFeedbackOpen(false)}>Cancel</Button>
-                    <Button onClick={handleFeedbackSubmit} variant='contained' disabled={isSubmitting}>
-                        Submit
-                    </Button>
-                </DialogActions>
-            </Dialog>
+                    <Box sx={{ mb: 2 }}>
+                        <Typography sx={{ mt: 2 }} variant='h5' gutterBottom>
+                            Output
+                        </Typography>
+                        {outputConditions ? (
+                            <FulfilledConditionsBlock conditions={outputConditions} isDarkMode={isDarkMode} />
+                        ) : (
+                            <Box sx={sectionBoxSx}>
+                                {isUsedToolArray(dataOutput?.usedTools) && <UsedToolChips tools={dataOutput.usedTools} sx={{ mb: 1 }} />}
+                                <NodeContentRenderer value={outputValue} isDarkMode={isDarkMode} />
+                            </Box>
+                        )}
+                    </Box>
+
+                    {hasError && (
+                        <Box sx={{ mb: 2 }}>
+                            <Typography sx={{ mt: 2 }} variant='h5' gutterBottom color='error'>
+                                Error
+                            </Typography>
+                            <Box sx={{ ...sectionBoxSx, borderColor: 'error.main' }}>
+                                <NodeContentRenderer value={errorValue} isDarkMode={isDarkMode} />
+                            </Box>
+                        </Box>
+                    )}
+
+                    {hasState && (
+                        <Box sx={{ mb: 2 }}>
+                            <Typography sx={{ mt: 2 }} variant='h5' gutterBottom>
+                                State
+                            </Typography>
+                            <NodeContentRenderer value={stateValue} isDarkMode={isDarkMode} />
+                        </Box>
+                    )}
+                </Box>
+            )}
+
+            <HitlPanel show={showHitlControls} state={hitl} />
         </Box>
     )
 }

--- a/packages/observe/src/features/executions/components/RawJsonPanel.test.tsx
+++ b/packages/observe/src/features/executions/components/RawJsonPanel.test.tsx
@@ -1,0 +1,122 @@
+import { type ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+
+import { RawJsonPanel } from './RawJsonPanel'
+
+// flowise-react-json-view depends on canvas in jsdom and ships its own
+// clipboard hook — stub it so we can drive `enableClipboard` directly with a
+// synthesized event { src }.
+jest.mock('flowise-react-json-view', () => {
+    const ReactJsonStub = ({ src, enableClipboard }: { src: unknown; enableClipboard?: (e: { src: unknown }) => void }) => (
+        <div>
+            <pre data-testid='react-json-view'>{JSON.stringify(src)}</pre>
+            <button data-testid='copy-trigger' onClick={() => enableClipboard?.({ src })}>
+                copy
+            </button>
+        </div>
+    )
+    return { __esModule: true, default: ReactJsonStub }
+})
+
+function renderWithTheme(ui: ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+describe('RawJsonPanel', () => {
+    afterEach(() => jest.restoreAllMocks())
+
+    it('renders the JSON tree of the supplied src', () => {
+        renderWithTheme(<RawJsonPanel src={{ foo: 'bar' }} isDarkMode={false} />)
+        expect(screen.getByTestId('react-json-view')).toHaveTextContent(JSON.stringify({ foo: 'bar' }))
+    })
+
+    it('stops click propagation on its container so wrapping selectors do not steal focus', () => {
+        // The wrapper sets onClick={(e) => e.stopPropagation()}. Render inside
+        // an outer onClick listener and verify it does NOT fire when clicking
+        // inside the panel.
+        const outerHandler = jest.fn()
+        renderWithTheme(
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+            <div onClick={outerHandler} data-testid='outer'>
+                <RawJsonPanel src={{ k: 1 }} isDarkMode={false} />
+            </div>
+        )
+        fireEvent.click(screen.getByTestId('react-json-view'))
+        expect(outerHandler).not.toHaveBeenCalled()
+
+        // Sanity: clicking the *outside* still fires it.
+        fireEvent.click(screen.getByTestId('outer'))
+        expect(outerHandler).toHaveBeenCalledTimes(1)
+    })
+
+    describe('onClipboardCopy', () => {
+        it('pretty-prints object src with 2-space indent', () => {
+            const writeText = jest.fn().mockResolvedValue(undefined)
+            Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+            renderWithTheme(<RawJsonPanel src={{ a: 1, b: { c: 2 } }} isDarkMode={false} />)
+            fireEvent.click(screen.getByTestId('copy-trigger'))
+
+            expect(writeText).toHaveBeenCalledWith(JSON.stringify({ a: 1, b: { c: 2 } }, null, 2))
+        })
+
+        it('pretty-prints array src with 2-space indent', () => {
+            const writeText = jest.fn().mockResolvedValue(undefined)
+            Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+            renderWithTheme(<RawJsonPanel src={[1, 2, 3]} isDarkMode={false} />)
+            fireEvent.click(screen.getByTestId('copy-trigger'))
+
+            expect(writeText).toHaveBeenCalledWith(JSON.stringify([1, 2, 3], null, 2))
+        })
+
+        it('falls back to String() for non-object primitives', () => {
+            // `enableClipboard` can fire with `{ src: 42 }` if the user clicks
+            // a leaf node — we should pass the stringified primitive, not
+            // `JSON.stringify` it (which would quote it as `"42"`).
+            const writeText = jest.fn().mockResolvedValue(undefined)
+            Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+
+            renderWithTheme(<RawJsonPanel src={{ count: 42 }} isDarkMode={false} />)
+            // Synthesize a leaf-node copy by directly invoking the callback
+            // through the stub. The stub only fires `enableClipboard({ src })`
+            // with the whole `src`, so for primitives we use a top-level
+            // primitive payload via a separate render.
+            // (The wrapper accepts `unknown` but the real component types it
+            // as `object` — pass via cast for the primitive path.)
+            ;(navigator.clipboard.writeText as jest.Mock).mockClear()
+
+            const PrimitiveCase = ({ value }: { value: unknown }) => <RawJsonPanel src={value as object} isDarkMode={false} />
+            renderWithTheme(<PrimitiveCase value={42} />)
+            const triggers = screen.getAllByTestId('copy-trigger')
+            fireEvent.click(triggers[triggers.length - 1])
+            expect(writeText).toHaveBeenLastCalledWith('42')
+        })
+
+        it('warns to the console when navigator.clipboard.writeText rejects', async () => {
+            const err = new Error('NotAllowedError')
+            const writeText = jest.fn().mockRejectedValue(err)
+            Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+            renderWithTheme(<RawJsonPanel src={{ k: 1 }} isDarkMode={false} />)
+            fireEvent.click(screen.getByTestId('copy-trigger'))
+            // Allow the rejection microtask to run.
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Clipboard copy failed'), err)
+        })
+
+        it('no-ops when navigator.clipboard.writeText is unavailable', () => {
+            Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true })
+            renderWithTheme(<RawJsonPanel src={{ k: 1 }} isDarkMode={false} />)
+            // Should not throw; no clipboard side-effects observable.
+            expect(() => fireEvent.click(screen.getByTestId('copy-trigger'))).not.toThrow()
+        })
+    })
+})

--- a/packages/observe/src/features/executions/components/RawJsonPanel.tsx
+++ b/packages/observe/src/features/executions/components/RawJsonPanel.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material'
+import ReactJson from 'flowise-react-json-view'
+
+interface RawJsonPanelProps {
+    // ReactJson types `src` as `object`. Callers pass `Record<string, unknown>`
+    // (NodeExecutionDetail's `payload`); narrowing here keeps the consumer
+    // signature aligned with what ReactJson actually accepts.
+    src: object
+    isDarkMode: boolean
+}
+
+/**
+ * Pretty-prints arrays/objects with a 2-space indent instead of the default
+ * minified copy that ReactJson would otherwise emit.
+ */
+function onClipboardCopy(e: { src: unknown }) {
+    if (!navigator.clipboard?.writeText) return
+    const src = e.src
+    const text = Array.isArray(src) || (src !== null && typeof src === 'object') ? JSON.stringify(src, null, 2) : String(src)
+    navigator.clipboard.writeText(text).catch((err) => {
+        console.warn('[Observe] Clipboard copy failed:', err)
+    })
+}
+
+/**
+ * Raw JSON tree viewer used by NodeExecutionDetail's "Raw" tab. Wraps
+ * `flowise-react-json-view` with the bordered frame + theme switch + a
+ * pretty-printing clipboard handler.
+ */
+export function RawJsonPanel({ src, isDarkMode }: RawJsonPanelProps) {
+    return (
+        <Box sx={{ mt: 2, border: 1, borderColor: 'divider', borderRadius: 1, p: 1.25 }} onClick={(e) => e.stopPropagation()}>
+            <ReactJson
+                src={src}
+                theme={isDarkMode ? 'ocean' : 'rjv-default'}
+                collapsed={1}
+                displayDataTypes={false}
+                quotesOnKeys={false}
+                style={{ fontSize: '0.75rem', background: 'transparent' }}
+                enableClipboard={onClipboardCopy}
+            />
+        </Box>
+    )
+}

--- a/packages/observe/src/features/executions/components/ToolAccordionList.test.tsx
+++ b/packages/observe/src/features/executions/components/ToolAccordionList.test.tsx
@@ -1,0 +1,132 @@
+import React, { type ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+
+import { ToolAccordionList } from './ToolAccordionList'
+
+// JsonBlock pulls in the syntax highlighter via @/atoms — stub it.
+jest.mock('react-syntax-highlighter', () => ({
+    Prism: ({ children }: { children?: React.ReactNode }) => <pre data-testid='syntax-highlighter'>{children}</pre>
+}))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+function renderWithTheme(ui: ReactElement, isDark = false) {
+    return render(<ThemeProvider theme={createObserveTheme(isDark)}>{ui}</ThemeProvider>)
+}
+
+describe('ToolAccordionList — variant="available"', () => {
+    it('renders a "Tools" heading and one row per tool', () => {
+        renderWithTheme(<ToolAccordionList variant='available' tools={[{ name: 'search' }, { name: 'lookup' }]} isDarkMode={false} />)
+        expect(screen.getByText('Tools')).toBeInTheDocument()
+        expect(screen.getByText('search')).toBeInTheDocument()
+        expect(screen.getByText('lookup')).toBeInTheDocument()
+    })
+
+    it('returns null when the tools array is empty', () => {
+        const { container } = renderWithTheme(<ToolAccordionList variant='available' tools={[]} isDarkMode={false} />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('prefers toolNode.label / toolNode.name over the raw name', () => {
+        renderWithTheme(
+            <ToolAccordionList
+                variant='available'
+                tools={[{ name: 'raw_name', toolNode: { name: 'iconName', label: 'Pretty Label' } }]}
+                isDarkMode={false}
+            />
+        )
+        expect(screen.getByText('Pretty Label')).toBeInTheDocument()
+        expect(screen.queryByText('raw_name')).not.toBeInTheDocument()
+    })
+
+    it('shows a "Used" chip on rows whose name appears in usedTools', () => {
+        renderWithTheme(
+            <ToolAccordionList
+                variant='available'
+                tools={[{ name: 'search' }, { name: 'lookup' }]}
+                usedTools={[{ tool: 'search' }]}
+                isDarkMode={false}
+            />
+        )
+        const used = screen.getAllByText('Used')
+        expect(used).toHaveLength(1)
+    })
+
+    it('hides the Used chip when usedTools is missing or has no matches', () => {
+        renderWithTheme(<ToolAccordionList variant='available' tools={[{ name: 'search' }]} isDarkMode={false} />)
+        expect(screen.queryByText('Used')).not.toBeInTheDocument()
+    })
+
+    it('paginates with "Show N more" / "Show less" past initialVisibleCount', () => {
+        const tools = Array.from({ length: 7 }, (_, i) => ({ name: `tool_${i}` }))
+        renderWithTheme(<ToolAccordionList variant='available' tools={tools} initialVisibleCount={3} isDarkMode={false} />)
+        expect(screen.getByText('tool_0')).toBeInTheDocument()
+        expect(screen.getByText('tool_2')).toBeInTheDocument()
+        expect(screen.queryByText('tool_3')).not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show 4 more' }))
+        expect(screen.getByText('tool_3')).toBeInTheDocument()
+        expect(screen.getByText('tool_6')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show less' }))
+        expect(screen.queryByText('tool_3')).not.toBeInTheDocument()
+    })
+
+    it('hides the pagination button when tool count is below initialVisibleCount', () => {
+        renderWithTheme(
+            <ToolAccordionList variant='available' tools={[{ name: 'a' }, { name: 'b' }]} initialVisibleCount={5} isDarkMode={false} />
+        )
+        expect(screen.queryByRole('button', { name: /Show / })).not.toBeInTheDocument()
+    })
+})
+
+describe('ToolAccordionList — variant="called"', () => {
+    it('renders a "Called" chip on each call with the resolved label', () => {
+        renderWithTheme(
+            <ToolAccordionList
+                variant='called'
+                calls={[
+                    { raw: { name: 'search', args: {} }, name: 'search' },
+                    { raw: { name: 'lookup', args: {} }, name: 'lookup' }
+                ]}
+                isDarkMode={false}
+            />
+        )
+        expect(screen.getAllByText('Called')).toHaveLength(2)
+        expect(screen.getByText('search')).toBeInTheDocument()
+        expect(screen.getByText('lookup')).toBeInTheDocument()
+    })
+
+    it('returns null when the calls array is empty', () => {
+        const { container } = renderWithTheme(<ToolAccordionList variant='called' calls={[]} isDarkMode={false} />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('uses availableTools to resolve a pretty label when present', () => {
+        renderWithTheme(
+            <ToolAccordionList
+                variant='called'
+                calls={[{ raw: { name: 'search' }, name: 'search' }]}
+                availableTools={[{ name: 'search', toolNode: { name: 'searchIcon', label: 'Web Search' } }]}
+                isDarkMode={false}
+            />
+        )
+        expect(screen.getByText('Web Search')).toBeInTheDocument()
+    })
+
+    it('does NOT render the "Tools" heading or the pagination button', () => {
+        renderWithTheme(
+            <ToolAccordionList
+                variant='called'
+                calls={Array.from({ length: 10 }, (_, i) => ({ raw: { i }, name: `call_${i}` }))}
+                isDarkMode={false}
+            />
+        )
+        expect(screen.queryByText('Tools')).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /Show / })).not.toBeInTheDocument()
+    })
+})

--- a/packages/observe/src/features/executions/components/ToolAccordionList.tsx
+++ b/packages/observe/src/features/executions/components/ToolAccordionList.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react'
+
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Box,
+    Button,
+    Chip,
+    Stack,
+    type SxProps,
+    type Theme,
+    Typography
+} from '@mui/material'
+import { darken, useTheme } from '@mui/material/styles'
+import { IconChevronDown } from '@tabler/icons-react'
+
+import { JsonBlock, NodeIcon } from '@/atoms'
+import type { AvailableToolEntry, NormalizedToolCall, UsedToolRef } from '@/core/types'
+import { resolveTool } from '@/core/utils'
+
+interface AvailableProps {
+    variant: 'available'
+    tools: AvailableToolEntry[]
+    /** Tools listed here get the "Used" chip + green tint. */
+    usedTools?: UsedToolRef[]
+    /** Number of tools to show before the "Show N more" button. Defaults to 5. */
+    initialVisibleCount?: number
+}
+
+interface CalledProps {
+    variant: 'called'
+    calls: NormalizedToolCall[]
+    /** Used to look up an icon + display label for each call's `.name`. */
+    availableTools?: AvailableToolEntry[]
+}
+
+type ToolAccordionListProps = (AvailableProps | CalledProps) & {
+    isDarkMode: boolean
+    apiBaseUrl?: string
+}
+
+interface AccordionRow {
+    iconName: string
+    label: string
+    chip?: { label: string; bg: string; fg: string }
+    json: object
+    /** Container border + tint. */
+    tone: 'success' | 'warning' | 'neutral'
+}
+
+/**
+ * Unified accordion list for tool surfaces:
+ *  - `variant='available'` — agent's available-tools list with optional "Used"
+ *    chips + paginated "Show N more" button (replaces the legacy ToolsList).
+ *  - `variant='called'` — tool-call invocations from a chat message with a
+ *    fixed "Called" chip and warning-toned styling (replaces the legacy
+ *    MessageToolCallList).
+ */
+export function ToolAccordionList(props: ToolAccordionListProps) {
+    const theme = useTheme()
+    const [showAll, setShowAll] = useState(false)
+
+    const isAvailable = props.variant === 'available'
+    const calledChipBg = darken(theme.palette.warning.dark, 0.5)
+
+    let rows: AccordionRow[]
+    if (isAvailable) {
+        if (props.tools.length === 0) return null
+        const usedNames = new Set((props.usedTools ?? []).map((u) => u?.tool).filter((n): n is string => typeof n === 'string'))
+        rows = props.tools.map((tool): AccordionRow => {
+            const isUsed = !!tool.name && usedNames.has(tool.name)
+            return {
+                iconName: tool.toolNode?.name ?? tool.name ?? '',
+                label: tool.toolNode?.label ?? tool.name ?? 'Tool Call',
+                chip: isUsed ? { label: 'Used', bg: theme.palette.success.dark, fg: theme.palette.common.white } : undefined,
+                json: tool,
+                tone: isUsed ? 'success' : 'neutral'
+            }
+        })
+    } else {
+        if (props.calls.length === 0) return null
+        rows = props.calls.map((call): AccordionRow => {
+            const { iconName, label } = resolveTool(call.name, props.availableTools)
+            return {
+                iconName,
+                label,
+                chip: { label: 'Called', bg: calledChipBg, fg: theme.palette.common.white },
+                json: call.raw as object,
+                tone: 'warning'
+            }
+        })
+    }
+
+    // Pagination is intentionally available-only: legacy never paginated tool
+    // calls (their count is bounded per-message), so the 'called' variant
+    // always renders every row.
+    const initialVisible = isAvailable ? props.initialVisibleCount ?? 5 : rows.length
+    const visible = showAll ? rows : rows.slice(0, initialVisible)
+    const hasMore = isAvailable && rows.length > initialVisible
+
+    const containerSx: SxProps<Theme> = isAvailable ? {} : { mb: 1 }
+
+    return (
+        <Box>
+            {isAvailable && (
+                <Typography sx={{ mt: 2 }} variant='h5' gutterBottom>
+                    Tools
+                </Typography>
+            )}
+            <Stack spacing={1} sx={containerSx}>
+                {visible.map((row, idx) => (
+                    <ToolAccordionRow
+                        key={`${props.variant}-${idx}`}
+                        idx={idx}
+                        row={row}
+                        variant={props.variant}
+                        isDarkMode={props.isDarkMode}
+                        apiBaseUrl={props.apiBaseUrl}
+                    />
+                ))}
+            </Stack>
+            {hasMore && (
+                <Button size='small' onClick={() => setShowAll((prev) => !prev)} sx={{ mt: 0.5, textTransform: 'none' }}>
+                    {showAll ? 'Show less' : `Show ${rows.length - initialVisible} more`}
+                </Button>
+            )}
+        </Box>
+    )
+}
+
+interface ToolAccordionRowProps {
+    idx: number
+    row: AccordionRow
+    variant: 'available' | 'called'
+    isDarkMode: boolean
+    apiBaseUrl?: string
+}
+
+function ToolAccordionRow({ idx, row, variant, isDarkMode, apiBaseUrl }: ToolAccordionRowProps) {
+    const theme = useTheme()
+
+    const containerBg = (() => {
+        if (row.tone === 'success') return isDarkMode ? `${theme.palette.success.dark}22` : `${theme.palette.success.light}44`
+        if (row.tone === 'warning') return isDarkMode ? `${theme.palette.warning.dark}22` : `${theme.palette.warning.light}44`
+        return 'background.paper'
+    })()
+    const borderColor = row.tone === 'success' ? 'success.main' : row.tone === 'warning' ? 'warning.main' : 'divider'
+    const chevronColor = isDarkMode ? '#fff' : row.tone === 'warning' ? darken(theme.palette.warning.dark, 0.5) : undefined
+
+    const summaryId = `${variant}-${idx}-header`
+    const contentId = `${variant}-${idx}-content`
+
+    return (
+        <Accordion
+            disableGutters
+            elevation={0}
+            sx={{
+                '&:before': { display: 'none' },
+                backgroundColor: containerBg,
+                border: 1,
+                borderRadius: 1,
+                borderColor,
+                overflow: 'hidden'
+            }}
+        >
+            <AccordionSummary expandIcon={<IconChevronDown size={18} color={chevronColor} />} aria-controls={contentId} id={summaryId}>
+                <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+                    <NodeIcon name={row.iconName} size={28} apiBaseUrl={apiBaseUrl} />
+                    <Typography variant='body1' sx={{ ml: 1 }}>
+                        {row.label}
+                    </Typography>
+                    {row.chip && (
+                        <Chip label={row.chip.label} size='small' sx={{ ml: 2, color: row.chip.fg, backgroundColor: row.chip.bg }} />
+                    )}
+                </Box>
+            </AccordionSummary>
+            <AccordionDetails>
+                <JsonBlock value={row.json} isDarkMode={isDarkMode} />
+            </AccordionDetails>
+        </Accordion>
+    )
+}

--- a/packages/observe/src/features/executions/components/UsedToolChips.test.tsx
+++ b/packages/observe/src/features/executions/components/UsedToolChips.test.tsx
@@ -1,0 +1,56 @@
+import type { ReactElement } from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { render, screen } from '@testing-library/react'
+
+import { createObserveTheme } from '@/core/theme'
+import { isUsedToolArray } from '@/core/utils'
+
+import { UsedToolChips } from './UsedToolChips'
+
+function renderWithTheme(ui: ReactElement, isDark = false) {
+    return render(<ThemeProvider theme={createObserveTheme(isDark)}>{ui}</ThemeProvider>)
+}
+
+describe('isUsedToolArray', () => {
+    it('returns true for a non-empty array of object entries', () => {
+        expect(isUsedToolArray([{ tool: 'a' }])).toBe(true)
+    })
+
+    it('returns false for empty arrays, non-arrays, and arrays of non-objects', () => {
+        expect(isUsedToolArray([])).toBe(false)
+        expect(isUsedToolArray('a')).toBe(false)
+        expect(isUsedToolArray(null)).toBe(false)
+        expect(isUsedToolArray(['a'])).toBe(false)
+    })
+})
+
+describe('UsedToolChips', () => {
+    it('renders a chip per tool with its label', () => {
+        renderWithTheme(<UsedToolChips tools={[{ tool: 'search_repositories' }, { tool: 'get_file_contents' }]} />)
+        expect(screen.getByText('search_repositories')).toBeInTheDocument()
+        expect(screen.getByText('get_file_contents')).toBeInTheDocument()
+    })
+
+    it('renders nothing when the filtered list is empty', () => {
+        const { container } = renderWithTheme(<UsedToolChips tools={[]} />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('flags an errored tool with red border + red text via the error palette', () => {
+        // `error.main` resolves to #f44336 / rgb(244, 67, 54). jsdom normalizes
+        // sx-based `color` to rgb() but keeps inline `borderColor` as the hex.
+        renderWithTheme(<UsedToolChips tools={[{ tool: 'bad_tool', error: 'boom' }]} />)
+        const chip = screen.getByText('bad_tool').closest('.MuiChip-root') as HTMLElement
+        const styles = getComputedStyle(chip)
+        expect(styles.color).toMatch(/rgb\(244,\s*67,\s*54\)|#f44336/i)
+        expect(styles.borderColor).toMatch(/rgb\(244,\s*67,\s*54\)|#f44336/i)
+    })
+
+    it('does not apply the error palette to a successful tool', () => {
+        renderWithTheme(<UsedToolChips tools={[{ tool: 'good_tool' }]} />)
+        const chip = screen.getByText('good_tool').closest('.MuiChip-root') as HTMLElement
+        const styles = getComputedStyle(chip)
+        expect(styles.color).not.toMatch(/rgb\(244,\s*67,\s*54\)|#f44336/i)
+    })
+})

--- a/packages/observe/src/features/executions/components/UsedToolChips.tsx
+++ b/packages/observe/src/features/executions/components/UsedToolChips.tsx
@@ -1,0 +1,36 @@
+import { Box, Chip, type SxProps, type Theme } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { IconTool } from '@tabler/icons-react'
+
+import type { UsedToolEntry } from '@/core/types'
+
+interface UsedToolChipsProps {
+    tools: UsedToolEntry[]
+    sx?: SxProps<Theme>
+}
+
+export function UsedToolChips({ tools, sx }: UsedToolChipsProps) {
+    const theme = useTheme()
+    const filtered = tools.filter(Boolean)
+    if (filtered.length === 0) return null
+
+    return (
+        <Box sx={sx}>
+            {filtered.map((tool, idx) => (
+                <Chip
+                    key={idx}
+                    size='small'
+                    variant='outlined'
+                    label={tool.tool}
+                    icon={<IconTool size={15} color={tool.error ? theme.palette.error.main : undefined} />}
+                    sx={{
+                        mr: 1,
+                        mt: 1,
+                        borderColor: tool.error ? 'error.main' : undefined,
+                        color: tool.error ? 'error.main' : undefined
+                    }}
+                />
+            ))}
+        </Box>
+    )
+}

--- a/packages/observe/src/features/executions/components/roleColors.test.ts
+++ b/packages/observe/src/features/executions/components/roleColors.test.ts
@@ -1,0 +1,69 @@
+import { darken } from '@mui/material/styles'
+
+import { createObserveTheme } from '@/core/theme'
+
+import { getRoleColors } from './roleColors'
+
+const lightTheme = createObserveTheme(false)
+const darkTheme = createObserveTheme(true)
+
+describe('getRoleColors', () => {
+    describe('light mode', () => {
+        it.each([
+            ['assistant', 'success'] as const,
+            ['ai', 'success'] as const,
+            ['system', 'warning'] as const,
+            ['developer', 'info'] as const,
+            ['user', 'primary'] as const,
+            ['human', 'primary'] as const,
+            ['tool', 'secondary'] as const,
+            ['function', 'secondary'] as const
+        ])('maps role "%s" to the %s palette in light mode', (role, paletteKey) => {
+            const colors = getRoleColors(role, lightTheme, false)
+            // user/human use the *main* shade for the primary palette in legacy
+            const expectedBg = paletteKey === 'primary' ? lightTheme.palette.primary.light : lightTheme.palette[paletteKey].light
+            expect(colors.bg).toBe(expectedBg)
+            expect(colors.color).toBe(lightTheme.palette[paletteKey].dark)
+            expect(colors.border).toBe(lightTheme.palette[paletteKey].main)
+        })
+
+        it('falls back to a grey palette for unknown roles in light mode', () => {
+            const colors = getRoleColors('observer', lightTheme, false)
+            expect(colors.bg).toBe(lightTheme.palette.grey[300])
+            expect(colors.color).toBe(lightTheme.palette.grey[800])
+            expect(colors.border).toBe(lightTheme.palette.grey[500])
+        })
+    })
+
+    describe('dark mode', () => {
+        it.each([
+            ['assistant', 'success'] as const,
+            ['system', 'warning'] as const,
+            ['developer', 'info'] as const,
+            ['tool', 'secondary'] as const
+        ])('darkens the palette and uses white text for role "%s" (palette: %s) in dark mode', (role, paletteKey) => {
+            const colors = getRoleColors(role, darkTheme, true)
+            const baseDark =
+                paletteKey === 'success' || paletteKey === 'warning' || paletteKey === 'info'
+                    ? darkTheme.palette[paletteKey].dark
+                    : darkTheme.palette[paletteKey].main
+            expect(colors.bg).toBe(darken(baseDark, 0.5))
+            expect(colors.color).toBe(darkTheme.palette.common.white)
+            expect(colors.border).toBe(darkTheme.palette[paletteKey].main)
+        })
+
+        it('uses the primary.main shade darkened for user/human in dark mode', () => {
+            const colors = getRoleColors('user', darkTheme, true)
+            expect(colors.bg).toBe(darken(darkTheme.palette.primary.main, 0.5))
+            expect(colors.color).toBe(darkTheme.palette.common.white)
+            expect(colors.border).toBe(darkTheme.palette.primary.main)
+        })
+
+        it('falls back to a darkened grey palette for unknown roles in dark mode', () => {
+            const colors = getRoleColors('observer', darkTheme, true)
+            expect(colors.bg).toBe(darken(darkTheme.palette.grey[700], 0.5))
+            expect(colors.color).toBe(darkTheme.palette.common.white)
+            expect(colors.border).toBe(darkTheme.palette.grey[600])
+        })
+    })
+})

--- a/packages/observe/src/features/executions/components/roleColors.ts
+++ b/packages/observe/src/features/executions/components/roleColors.ts
@@ -1,0 +1,56 @@
+import { darken, type Theme } from '@mui/material/styles'
+
+export interface RoleColors {
+    bg: string
+    color: string
+    border: string
+}
+
+/**
+ * Maps a chat message role (assistant, user, system, tool, ...) to a chip
+ * color triple. Mirrors the legacy `getRoleColors` helper in
+ * NodeExecutionDetails.jsx.
+ */
+export function getRoleColors(role: string, theme: Theme, isDarkMode: boolean): RoleColors {
+    switch (role) {
+        case 'assistant':
+        case 'ai':
+            return {
+                bg: isDarkMode ? darken(theme.palette.success.dark, 0.5) : theme.palette.success.light,
+                color: isDarkMode ? theme.palette.common.white : theme.palette.success.dark,
+                border: theme.palette.success.main
+            }
+        case 'system':
+            return {
+                bg: isDarkMode ? darken(theme.palette.warning.dark, 0.5) : theme.palette.warning.light,
+                color: isDarkMode ? theme.palette.common.white : theme.palette.warning.dark,
+                border: theme.palette.warning.main
+            }
+        case 'developer':
+            return {
+                bg: isDarkMode ? darken(theme.palette.info.dark, 0.5) : theme.palette.info.light,
+                color: isDarkMode ? theme.palette.common.white : theme.palette.info.dark,
+                border: theme.palette.info.main
+            }
+        case 'user':
+        case 'human':
+            return {
+                bg: isDarkMode ? darken(theme.palette.primary.main, 0.5) : theme.palette.primary.light,
+                color: isDarkMode ? theme.palette.common.white : theme.palette.primary.dark,
+                border: theme.palette.primary.main
+            }
+        case 'tool':
+        case 'function':
+            return {
+                bg: isDarkMode ? darken(theme.palette.secondary.main, 0.5) : theme.palette.secondary.light,
+                color: isDarkMode ? theme.palette.common.white : theme.palette.secondary.dark,
+                border: theme.palette.secondary.main
+            }
+        default:
+            return {
+                bg: isDarkMode ? darken(theme.palette.grey[700], 0.5) : theme.palette.grey[300],
+                color: isDarkMode ? theme.palette.common.white : theme.palette.grey[800],
+                border: isDarkMode ? theme.palette.grey[600] : theme.palette.grey[500]
+            }
+    }
+}

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
@@ -147,6 +147,44 @@ describe('useExecutionTree', () => {
         })
     })
 
+    describe('resolved node name (drives icon lookup)', () => {
+        it('uses the top-level n.name when present', () => {
+            const node = baseNode({ nodeId: 'agentAgentflow_0', name: 'agentAgentflow' })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            expect(result.current[0].name).toBe('agentAgentflow')
+        })
+
+        it('falls back to data.name when n.name is absent (runtime never emits n.name)', () => {
+            // Per IAgentflowExecutedData, the runtime emits the type identifier
+            // at `data.name`, not the top level. The detail header + tree icons
+            // both rely on this fallback to look up the right AGENTFLOW_ICONS entry.
+            const node = baseNode({ nodeId: 'llmAgentflow_0', data: { name: 'llmAgentflow' } })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            expect(result.current[0].name).toBe('llmAgentflow')
+        })
+
+        it('falls back to nodeId.split("_")[0] when neither name source is present', () => {
+            const node = baseNode({ nodeId: 'startAgentflow_42' })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            expect(result.current[0].name).toBe('startAgentflow')
+        })
+
+        it('prefers n.name over data.name when both are present', () => {
+            const node = baseNode({ nodeId: 'x_0', name: 'fromTop', data: { name: 'fromData' } })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            expect(result.current[0].name).toBe('fromTop')
+        })
+
+        it('ignores a non-string data.name value', () => {
+            // If the runtime payload is malformed (e.g. data.name accidentally
+            // set to an object), we must not pass that through as a name —
+            // the nodeId fallback must kick in instead.
+            const node = baseNode({ nodeId: 'fallback_0', data: { name: { nested: 'oops' } } })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            expect(result.current[0].name).toBe('fallback')
+        })
+    })
+
     describe('raw node reference', () => {
         it('attaches the original NodeExecutionData as raw on leaf nodes', () => {
             const node = baseNode({ nodeId: 'n1', nodeLabel: 'Step' })

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.ts
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.ts
@@ -47,12 +47,18 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
         }
 
         function buildNode(n: NodeExecutionData): ExecutionTreeNode {
+            // The runtime never emits `name` at the top level (per
+            // `IAgentflowExecutedData`); Agent/LLM/etc. put their type
+            // identifier on `data.name`, so the fallback chain is required.
+            const dataName = n.data?.name
+            const resolvedName = n.name ?? (typeof dataName === 'string' ? dataName : undefined) ?? n.nodeId.split('_')[0]
+
             const treeNode: ExecutionTreeNode = {
                 id: `${n.nodeId}-${n.iterationIndex ?? 0}`,
                 nodeId: n.nodeId,
                 nodeLabel: n.nodeLabel,
                 status: n.status,
-                name: n.name,
+                name: resolvedName,
                 iterationIndex: n.iterationIndex,
                 children: [],
                 raw: n
@@ -69,6 +75,7 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
                         nodeId: `${n.nodeId}-iteration-${iterIdx}`,
                         nodeLabel: `Iteration #${iterIdx + 1}`,
                         status: groupChildren[groupChildren.length - 1]?.status ?? 'FINISHED',
+                        name: '',
                         isVirtualNode: true,
                         iterationIndex: iterIdx,
                         children: groupChildren.map(buildNode)

--- a/packages/observe/src/features/executions/hooks/useHumanInput.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useHumanInput.test.tsx
@@ -1,0 +1,180 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useHumanInput } from './useHumanInput'
+
+const baseOpts = {
+    agentflowId: 'flow-1',
+    sessionId: 'sess-1',
+    nodeId: 'human-1',
+    enableFeedback: false
+}
+
+describe('useHumanInput', () => {
+    describe('direct submit (enableFeedback=false)', () => {
+        it('calls onHumanInput with type=proceed and the synthesized question', async () => {
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput }))
+            await act(async () => {
+                result.current.handleProceed()
+            })
+            expect(onHumanInput).toHaveBeenCalledWith('flow-1', {
+                question: 'Proceed',
+                chatId: 'sess-1',
+                humanInput: { type: 'proceed', startNodeId: 'human-1', feedback: '' }
+            })
+        })
+
+        it('calls onHumanInput with type=reject for handleReject', async () => {
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput }))
+            await act(async () => {
+                result.current.handleReject()
+            })
+            expect(onHumanInput).toHaveBeenCalledWith(
+                'flow-1',
+                expect.objectContaining({ humanInput: expect.objectContaining({ type: 'reject' }) })
+            )
+        })
+
+        it('does not open the feedback dialog when enableFeedback=false', () => {
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput }))
+            act(() => {
+                result.current.handleProceed()
+            })
+            expect(result.current.feedbackOpen).toBe(false)
+        })
+
+        it('is a no-op when onHumanInput is not provided', () => {
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput: undefined }))
+            // Should not throw — the hook simply ignores the click.
+            expect(() => {
+                act(() => {
+                    result.current.handleProceed()
+                })
+            }).not.toThrow()
+        })
+    })
+
+    describe('feedback dialog (enableFeedback=true)', () => {
+        it('opens the dialog instead of submitting on handleProceed', () => {
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, enableFeedback: true, onHumanInput }))
+            act(() => {
+                result.current.handleProceed()
+            })
+            expect(result.current.feedbackOpen).toBe(true)
+            expect(onHumanInput).not.toHaveBeenCalled()
+        })
+
+        it('submitFeedback sends the typed feedback as both question and humanInput.feedback', async () => {
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, enableFeedback: true, onHumanInput }))
+            act(() => {
+                result.current.handleProceed()
+                result.current.setFeedbackText('Looks good')
+            })
+            await act(async () => {
+                result.current.submitFeedback()
+            })
+            expect(onHumanInput).toHaveBeenCalledWith('flow-1', {
+                question: 'Looks good',
+                chatId: 'sess-1',
+                humanInput: { type: 'proceed', startNodeId: 'human-1', feedback: 'Looks good' }
+            })
+            // After submission the dialog closes and the text is cleared.
+            expect(result.current.feedbackOpen).toBe(false)
+            expect(result.current.feedbackText).toBe('')
+        })
+
+        it('routes Reject through the dialog when enableFeedback=true', async () => {
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, enableFeedback: true, onHumanInput }))
+            act(() => {
+                result.current.handleReject()
+                result.current.setFeedbackText('Wrong answer')
+            })
+            await act(async () => {
+                result.current.submitFeedback()
+            })
+            expect(onHumanInput).toHaveBeenCalledWith(
+                'flow-1',
+                expect.objectContaining({
+                    question: 'Wrong answer',
+                    humanInput: expect.objectContaining({ type: 'reject', feedback: 'Wrong answer' })
+                })
+            )
+        })
+
+        it('cancelFeedbackDialog closes without submitting', () => {
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, enableFeedback: true, onHumanInput }))
+            act(() => {
+                result.current.handleProceed()
+                result.current.setFeedbackText('changed my mind')
+                result.current.cancelFeedbackDialog()
+            })
+            expect(result.current.feedbackOpen).toBe(false)
+            expect(result.current.feedbackText).toBe('')
+            expect(onHumanInput).not.toHaveBeenCalled()
+        })
+
+        it('submitFeedback is a no-op when no pending type exists', () => {
+            // Calling submitFeedback before handleProceed/handleReject should
+            // not invoke onHumanInput — there's nothing to submit.
+            const onHumanInput = jest.fn().mockResolvedValue(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, enableFeedback: true, onHumanInput }))
+            act(() => {
+                result.current.submitFeedback()
+            })
+            expect(onHumanInput).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('error surfacing', () => {
+        it('captures Error.message into submitError when the callback rejects', async () => {
+            const onHumanInput = jest.fn().mockRejectedValue(new Error('Network down'))
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput }))
+            await act(async () => {
+                result.current.handleProceed()
+            })
+            expect(result.current.submitError).toBe('Network down')
+            expect(result.current.isSubmitting).toBe(false)
+        })
+
+        it('falls back to a generic message for non-Error rejections', async () => {
+            const onHumanInput = jest.fn().mockRejectedValue('something went wrong')
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput }))
+            await act(async () => {
+                result.current.handleProceed()
+            })
+            expect(result.current.submitError).toBe('Failed to submit response')
+        })
+
+        it('dismissError clears the inline error', async () => {
+            const onHumanInput = jest.fn().mockRejectedValue(new Error('Network down'))
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput }))
+            await act(async () => {
+                result.current.handleProceed()
+            })
+            expect(result.current.submitError).toBe('Network down')
+            act(() => {
+                result.current.dismissError()
+            })
+            expect(result.current.submitError).toBeNull()
+        })
+
+        it('clears any prior error when a new submission starts', async () => {
+            const onHumanInput = jest.fn().mockRejectedValueOnce(new Error('first failure')).mockResolvedValueOnce(undefined)
+            const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput }))
+            await act(async () => {
+                result.current.handleProceed()
+            })
+            expect(result.current.submitError).toBe('first failure')
+            await act(async () => {
+                result.current.handleProceed()
+            })
+            expect(result.current.submitError).toBeNull()
+        })
+    })
+})

--- a/packages/observe/src/features/executions/hooks/useHumanInput.ts
+++ b/packages/observe/src/features/executions/hooks/useHumanInput.ts
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+
+import type { HumanInputParams } from '@/core/types'
+
+type HumanInputType = 'proceed' | 'reject'
+
+interface UseHumanInputOptions {
+    agentflowId: string
+    sessionId: string
+    nodeId: string
+    enableFeedback: boolean
+    onHumanInput?: (agentflowId: string, params: HumanInputParams) => Promise<void>
+}
+
+export interface HumanInputState {
+    isSubmitting: boolean
+    submitError: string | null
+    feedbackOpen: boolean
+    feedbackText: string
+    setFeedbackText: (value: string) => void
+    dismissError: () => void
+    handleProceed: () => void
+    handleReject: () => void
+    cancelFeedbackDialog: () => void
+    submitFeedback: () => void
+}
+
+/**
+ * Owns the HITL submission lifecycle for `NodeExecutionDetail`:
+ *  - Direct submit if `enableFeedback === false`
+ *  - Open feedback dialog otherwise (then submit on confirmation)
+ *  - Tracks isSubmitting / submitError surfaces for the action bar
+ *
+ * The hook is a no-op when `onHumanInput` is undefined — callers can still
+ * mount the action bar; clicks resolve to nothing.
+ */
+export function useHumanInput({ agentflowId, sessionId, nodeId, enableFeedback, onHumanInput }: UseHumanInputOptions): HumanInputState {
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [submitError, setSubmitError] = useState<string | null>(null)
+    const [feedbackOpen, setFeedbackOpen] = useState(false)
+    const [feedbackText, setFeedbackText] = useState('')
+    const [pendingType, setPendingType] = useState<HumanInputType | null>(null)
+
+    const submit = async (type: HumanInputType, feedback = '') => {
+        if (!onHumanInput) return
+        setIsSubmitting(true)
+        setSubmitError(null)
+        try {
+            await onHumanInput(agentflowId, {
+                question: feedback || (type === 'proceed' ? 'Proceed' : 'Reject'),
+                chatId: sessionId,
+                humanInput: { type, startNodeId: nodeId, feedback }
+            })
+        } catch (err) {
+            // Surface the error rather than silently swallowing it. The host
+            // app may also show its own snackbar — this in-component message
+            // guarantees users see *something* even when no toast handler exists.
+            const message = err instanceof Error ? err.message : 'Failed to submit response'
+            setSubmitError(message)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    const requestSubmission = (type: HumanInputType) => {
+        if (enableFeedback) {
+            setPendingType(type)
+            setFeedbackOpen(true)
+        } else {
+            void submit(type)
+        }
+    }
+
+    return {
+        isSubmitting,
+        submitError,
+        feedbackOpen,
+        feedbackText,
+        setFeedbackText,
+        dismissError: () => setSubmitError(null),
+        handleProceed: () => requestSubmission('proceed'),
+        handleReject: () => requestSubmission('reject'),
+        cancelFeedbackDialog: () => {
+            if (isSubmitting) return
+            setFeedbackOpen(false)
+            setFeedbackText('')
+            setPendingType(null)
+        },
+        submitFeedback: () => {
+            if (!pendingType) return
+            const type = pendingType
+            const feedback = feedbackText
+            setFeedbackOpen(false)
+            setFeedbackText('')
+            setPendingType(null)
+            void submit(type, feedback)
+        }
+    }
+}

--- a/packages/observe/src/features/executions/hooks/useNodeData.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useNodeData.test.tsx
@@ -1,0 +1,209 @@
+import { renderHook } from '@testing-library/react'
+
+import type { ExecutionTreeNode, NodeExecutionData } from '@/core/types'
+
+import { useNodeData } from './useNodeData'
+
+// useNodeData transitively imports ChatMessageBubble → NodeContentRenderer,
+// which loads ESM-only react-markdown / react-syntax-highlighter. Stub them
+// so jest can resolve the module graph; the hook itself reads no React tree.
+jest.mock('react-markdown', () => ({ __esModule: true, default: () => null }))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => null }))
+jest.mock('react-syntax-highlighter', () => ({ Prism: () => null }))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+function makeNode(raw?: Partial<NodeExecutionData> | undefined): ExecutionTreeNode {
+    if (!raw) {
+        return { id: 'v', nodeId: 'v', nodeLabel: 'v', status: 'FINISHED', name: '', children: [], isVirtualNode: true }
+    }
+    const rawData: NodeExecutionData = {
+        nodeId: 'n1',
+        nodeLabel: 'Node',
+        status: 'FINISHED',
+        previousNodeIds: [],
+        data: {},
+        ...raw
+    }
+    return {
+        id: rawData.nodeId,
+        nodeId: rawData.nodeId,
+        nodeLabel: rawData.nodeLabel,
+        status: rawData.status,
+        name: rawData.name ?? '',
+        children: [],
+        raw: rawData
+    }
+}
+
+describe('useNodeData', () => {
+    describe('virtual / empty nodes', () => {
+        it('handles a virtual node with no `raw` (no crash, all fields default)', () => {
+            const { result } = renderHook(() => useNodeData(makeNode()))
+            expect(result.current.raw).toBeUndefined()
+            expect(result.current.payload).toEqual({})
+            expect(result.current.dataInput).toBeUndefined()
+            expect(result.current.dataOutput).toBeUndefined()
+            expect(result.current.inputMessages).toBeNull()
+            expect(result.current.outputConditions).toBeNull()
+            expect(result.current.hasInput).toBe(false)
+            expect(result.current.hasError).toBe(false)
+            expect(result.current.hasState).toBe(false)
+            expect(result.current.isHumanInputNode).toBe(false)
+            expect(result.current.enableFeedback).toBe(false)
+        })
+
+        it('returns hasInput=false for empty data', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: {} })))
+            expect(result.current.hasInput).toBe(false)
+            expect(result.current.inputValue).toBeUndefined()
+        })
+    })
+
+    describe('inputValue', () => {
+        it('returns data.input.question when present (simple fallback path)', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { input: { question: 'pick one', extra: 'ignored' } } })))
+            expect(result.current.inputValue).toBe('pick one')
+        })
+
+        it('falls back to the whole data.input when no `question` key exists', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { input: { other: 1 } } })))
+            expect(result.current.inputValue).toEqual({ other: 1 })
+        })
+
+        it('returns the raw input string when data.input is a primitive', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { input: 'a question' } })))
+            expect(result.current.inputValue).toBe('a question')
+        })
+
+        it('treats an empty input object as no input (hasInput=false)', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { input: {} } })))
+            expect(result.current.hasInput).toBe(false)
+        })
+    })
+
+    describe('inputMessages (chat detection)', () => {
+        it('detects a chat message array at data.input.messages', () => {
+            const messages = [
+                { role: 'system', content: 'You are a helpful assistant.' },
+                { role: 'user', content: 'hi' }
+            ]
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { input: { messages } } })))
+            expect(result.current.inputMessages).toEqual(messages)
+            expect(result.current.hasInput).toBe(true)
+        })
+
+        it('returns null when data.input.messages is missing or shaped wrong', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { input: { messages: 'nope' } } })))
+            expect(result.current.inputMessages).toBeNull()
+        })
+    })
+
+    describe('outputValue (legacy parity)', () => {
+        it('prefers data.output.form over content', () => {
+            const form = { fields: { name: 'Ada' } }
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: { form, content: 'should-not-render' } } })))
+            expect(result.current.outputValue).toBe(form)
+        })
+
+        it('prefers data.output.http over content', () => {
+            const http = { status: 200 }
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: { http, content: 'should-not-render' } } })))
+            expect(result.current.outputValue).toBe(http)
+        })
+
+        it('falls through to content when form is empty/falsy (PARITY: truthy check)', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: { form: '', content: 'real content' } } })))
+            expect(result.current.outputValue).toBe('real content')
+        })
+
+        it('returns content when no form/http key exists', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: { content: 'just-text' } } })))
+            expect(result.current.outputValue).toBe('just-text')
+        })
+
+        it('returns undefined when output is an object with no form/http/content', () => {
+            // PARITY: legacy treats { nested: ... } as runtime metadata, not user-facing.
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: { nested: { ok: true } } } })))
+            expect(result.current.outputValue).toBeUndefined()
+        })
+
+        it('returns the raw value when output is a primitive', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: 'hello' } })))
+            expect(result.current.outputValue).toBe('hello')
+        })
+
+        it('returns undefined when output is null', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: null } })))
+            expect(result.current.outputValue).toBeUndefined()
+        })
+    })
+
+    describe('outputConditions', () => {
+        it('returns the conditions array when data.output.conditions is shaped right', () => {
+            const conditions = [{ type: 'string', operation: 'equal', value1: 'a', value2: 'a', isFulfilled: true }]
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: { conditions } } })))
+            expect(result.current.outputConditions).toEqual(conditions)
+        })
+
+        it('returns null when data.output.conditions is missing', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: { content: 'x' } } })))
+            expect(result.current.outputConditions).toBeNull()
+        })
+
+        it('returns null when data.output is not an object', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { output: 'plain' } })))
+            expect(result.current.outputConditions).toBeNull()
+        })
+    })
+
+    describe('error / state flags', () => {
+        it('hasError=true when data.error is a non-empty string', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { error: 'Boom' } })))
+            expect(result.current.hasError).toBe(true)
+            expect(result.current.errorValue).toBe('Boom')
+        })
+
+        it('hasError=false when data.error is empty/undefined', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { error: '' } })))
+            expect(result.current.hasError).toBe(false)
+        })
+
+        it('hasState=true only when data.state is a non-empty object', () => {
+            const withKeys = renderHook(() => useNodeData(makeNode({ data: { state: { count: 3 } } })))
+            expect(withKeys.result.current.hasState).toBe(true)
+
+            const empty = renderHook(() => useNodeData(makeNode({ data: { state: {} } })))
+            expect(empty.result.current.hasState).toBe(false)
+
+            const absent = renderHook(() => useNodeData(makeNode({ data: {} })))
+            expect(absent.result.current.hasState).toBe(false)
+        })
+    })
+
+    describe('HITL fields', () => {
+        it('isHumanInputNode is true only for name === "humanInputAgentflow"', () => {
+            const yes = renderHook(() => useNodeData(makeNode({ name: 'humanInputAgentflow', data: {} })))
+            expect(yes.result.current.isHumanInputNode).toBe(true)
+
+            const no = renderHook(() => useNodeData(makeNode({ name: 'llmAgentflow', data: {} })))
+            expect(no.result.current.isHumanInputNode).toBe(false)
+        })
+
+        it('enableFeedback reads from data.input.humanInputEnableFeedback', () => {
+            const { result } = renderHook(() =>
+                useNodeData(makeNode({ data: { input: { question: 'q', humanInputEnableFeedback: true } } }))
+            )
+            expect(result.current.enableFeedback).toBe(true)
+        })
+
+        it('enableFeedback falls back to data.humanInputEnableFeedback for backward compat', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { humanInputEnableFeedback: true } })))
+            expect(result.current.enableFeedback).toBe(true)
+        })
+
+        it('enableFeedback is false when neither path is set', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { input: { question: 'q' } } })))
+            expect(result.current.enableFeedback).toBe(false)
+        })
+    })
+})

--- a/packages/observe/src/features/executions/hooks/useNodeData.ts
+++ b/packages/observe/src/features/executions/hooks/useNodeData.ts
@@ -1,0 +1,143 @@
+import { useMemo } from 'react'
+
+import type { ChatMessage, ConditionEntry, ExecutionTreeNode, NodeExecutionData, NodeExecutionOutput } from '@/core/types'
+import { isChatMessageArray, isConditionArray } from '@/core/utils'
+
+/** Narrows an unknown to a non-array object record, or undefined otherwise. */
+function asObjectRecord<T extends Record<string, unknown> = Record<string, unknown>>(value: unknown): T | undefined {
+    return value !== null && typeof value === 'object' && !Array.isArray(value) ? (value as T) : undefined
+}
+
+export interface DerivedNodeData {
+    /** Raw node data (or undefined for virtual iteration nodes). */
+    raw: NodeExecutionData | undefined
+    /** Whole `data` payload, defaulted to {}. */
+    payload: Record<string, unknown>
+    /** `data.output` as a record (used for metrics + content selection). */
+    dataOutput: NodeExecutionOutput | undefined
+    /** `data.input` as a record. */
+    dataInput: Record<string, unknown> | undefined
+    /** Chat-style message array if `data.input.messages` is one, else null. */
+    inputMessages: ChatMessage[] | null
+    /** Curated input value: `data.input.question` if present, else `data.input`. */
+    inputValue: unknown
+    /** Curated output value: `output.form` | `output.http` | `output.content`. */
+    outputValue: unknown
+    /**
+     * Condition-node output (`data.output.conditions`) when present. Rendered
+     * as success-bordered "Fulfilled" boxes instead of through the generic
+     * content renderer. Mirrors legacy `renderFullfilledConditions`.
+     */
+    outputConditions: ConditionEntry[] | null
+    errorValue: unknown
+    stateValue: unknown
+    hasInput: boolean
+    hasError: boolean
+    hasState: boolean
+    /**
+     * Whether this is the special HITL node — `name === 'humanInputAgentflow'`.
+     */
+    isHumanInputNode: boolean
+    /**
+     * Whether the runtime requested the optional feedback dialog before the
+     * proceed/reject submission. Stored at `data.input.humanInputEnableFeedback`
+     * with backward-compat fallback to `data.humanInputEnableFeedback`.
+     */
+    enableFeedback: boolean
+}
+
+/**
+ * Derive the curated values used by `NodeExecutionDetail` from a tree node.
+ * Encapsulates the legacy parity rules:
+ *
+ *  - Input: chat-style nodes (Agent / LLM) put a message history at
+ *    `data.input.messages`. Otherwise prefer the simple `question` field,
+ *    falling back to the raw input value.
+ *  - Output: prefer `data.output.form` → `data.output.http` →
+ *    `data.output.content`. Other output keys (timeMetadata, usageMetadata,
+ *    usedTools, ...) are metadata, not user-facing content.
+ *  - Empty objects in input fall back to "No data" placeholder rather than
+ *    a `root: {}` JSON dump.
+ */
+export function useNodeData(node: ExecutionTreeNode): DerivedNodeData {
+    return useMemo(() => {
+        const raw = node.raw as NodeExecutionData | undefined
+        const payload = (raw?.data ?? {}) as Record<string, unknown>
+
+        const dataOutput = asObjectRecord<NodeExecutionOutput>(payload.output)
+        const dataInput = asObjectRecord(payload.input)
+
+        const inputMessages: ChatMessage[] | null = (() => {
+            const messages = (payload.input as Record<string, unknown> | undefined)?.messages
+            return isChatMessageArray(messages) ? messages : null
+        })()
+
+        const inputValue: unknown = (() => {
+            const input = payload.input
+            if (input === null || input === undefined) return undefined
+            if (typeof input === 'object' && !Array.isArray(input) && 'question' in (input as Record<string, unknown>)) {
+                return (input as Record<string, unknown>).question
+            }
+            return input
+        })()
+
+        const outputConditions: ConditionEntry[] | null = (() => {
+            const out = payload.output
+            if (out === null || typeof out !== 'object' || Array.isArray(out)) return null
+            const conditions = (out as Record<string, unknown>).conditions
+            return isConditionArray(conditions) ? conditions : null
+        })()
+
+        const outputValue: unknown = (() => {
+            const out = payload.output
+            if (out === null || out === undefined) return undefined
+            if (typeof out === 'object' && !Array.isArray(out)) {
+                const o = out as Record<string, unknown>
+                // PARITY: truthy check (not `!= null`). With `form: ''` or
+                // `http: 0`, legacy falls through to content — matching that
+                // avoids an empty/zero placeholder over the real payload.
+                if (o.form) return o.form
+                if (o.http) return o.http
+                return o.content ?? undefined
+            }
+            return out
+        })()
+
+        const errorValue: unknown = payload.error
+        const stateValue: unknown = payload.state
+
+        const isEmptyObject =
+            inputValue !== null &&
+            typeof inputValue === 'object' &&
+            !Array.isArray(inputValue) &&
+            Object.keys(inputValue as Record<string, unknown>).length === 0
+        const hasInput = inputMessages !== null || (inputValue !== undefined && inputValue !== null && inputValue !== '' && !isEmptyObject)
+        const hasError = errorValue !== undefined && errorValue !== null && errorValue !== ''
+        const hasState =
+            stateValue !== undefined &&
+            stateValue !== null &&
+            typeof stateValue === 'object' &&
+            Object.keys(stateValue as Record<string, unknown>).length > 0
+
+        const isHumanInputNode = raw?.name === 'humanInputAgentflow'
+        const enableFeedback = dataInput?.humanInputEnableFeedback === true || payload.humanInputEnableFeedback === true
+
+        return {
+            raw,
+            payload,
+            dataOutput,
+            dataInput,
+            inputMessages,
+            inputValue,
+            outputValue,
+            outputConditions,
+            errorValue,
+            stateValue,
+            hasInput,
+            hasError,
+            hasState,
+            isHumanInputNode,
+            enableFeedback
+        }
+    }, [node])
+}

--- a/packages/observe/src/features/executions/hooks/useResizableSidebar.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useResizableSidebar.test.tsx
@@ -1,0 +1,113 @@
+import { act, fireEvent, renderHook } from '@testing-library/react'
+
+import { useResizableSidebar } from './useResizableSidebar'
+
+const baseOptions = {
+    defaultWidth: 300,
+    minWidth: 180,
+    maxWidth: 480
+}
+
+/** Synthesizes a real `MouseEvent` since renderHook calls outside the DOM. */
+function dispatchMouseMove(clientX: number) {
+    const evt = new MouseEvent('mousemove', { clientX, bubbles: true })
+    document.dispatchEvent(evt)
+}
+
+function dispatchMouseUp() {
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+}
+
+describe('useResizableSidebar', () => {
+    it('initializes width to defaultWidth', () => {
+        const { result } = renderHook(() => useResizableSidebar(baseOptions))
+        expect(result.current.width).toBe(300)
+    })
+
+    it('follows defaultWidth changes until the user drags the handle', () => {
+        const { result, rerender } = renderHook((opts: typeof baseOptions) => useResizableSidebar(opts), { initialProps: baseOptions })
+        expect(result.current.width).toBe(300)
+
+        // Viewport breakpoint flipped to narrow — width should track the new default.
+        rerender({ ...baseOptions, defaultWidth: 220 })
+        expect(result.current.width).toBe(220)
+
+        // Back to wide — same.
+        rerender(baseOptions)
+        expect(result.current.width).toBe(300)
+    })
+
+    it('locks to the dragged width and ignores subsequent defaultWidth changes', () => {
+        const { result, rerender } = renderHook((opts: typeof baseOptions) => useResizableSidebar(opts), { initialProps: baseOptions })
+
+        // Drag the handle from x=500 to x=600 (delta +100). Width should jump to 400.
+        act(() => {
+            result.current.onMouseDown({ clientX: 500 } as unknown as React.MouseEvent)
+        })
+        act(() => dispatchMouseMove(600))
+        act(() => dispatchMouseUp())
+        expect(result.current.width).toBe(400)
+
+        // Now flip the viewport-driven default — the user-locked width must persist.
+        rerender({ ...baseOptions, defaultWidth: 220 })
+        expect(result.current.width).toBe(400)
+    })
+
+    it('clamps the dragged width to [minWidth, maxWidth]', () => {
+        const { result } = renderHook(() => useResizableSidebar(baseOptions))
+
+        // Drag way too far right (delta +1000) — should clamp to maxWidth (480).
+        act(() => {
+            result.current.onMouseDown({ clientX: 0 } as unknown as React.MouseEvent)
+        })
+        act(() => dispatchMouseMove(1000))
+        expect(result.current.width).toBe(480)
+
+        // Drag way too far left (delta -10000) — should clamp to minWidth (180).
+        act(() => dispatchMouseMove(-10000))
+        expect(result.current.width).toBe(180)
+
+        act(() => dispatchMouseUp())
+    })
+
+    it('stops responding to mousemove after mouseup', () => {
+        const { result } = renderHook(() => useResizableSidebar(baseOptions))
+
+        act(() => {
+            result.current.onMouseDown({ clientX: 100 } as unknown as React.MouseEvent)
+        })
+        act(() => dispatchMouseMove(200))
+        expect(result.current.width).toBe(400)
+
+        act(() => dispatchMouseUp())
+
+        // Subsequent mousemove (without a fresh mousedown) must be ignored.
+        act(() => dispatchMouseMove(900))
+        expect(result.current.width).toBe(400)
+    })
+
+    it('removes document-level listeners on unmount', () => {
+        const removeSpy = jest.spyOn(document, 'removeEventListener')
+        const { unmount } = renderHook(() => useResizableSidebar(baseOptions))
+        unmount()
+        const removed = removeSpy.mock.calls.map(([type]) => type)
+        expect(removed).toEqual(expect.arrayContaining(['mousemove', 'mouseup']))
+        removeSpy.mockRestore()
+    })
+
+    it('does not update width when mousemove fires without a prior mousedown', () => {
+        // Edge case: a stray document-level mousemove (e.g. another component
+        // dispatched it) must not move the sidebar before the user drags.
+        const { result } = renderHook(() => useResizableSidebar(baseOptions))
+        // No onMouseDown — handler exits early via the isDragging ref guard.
+        // (Listeners aren't attached anyway, but we exercise the guard for safety.)
+        act(() => dispatchMouseMove(900))
+        expect(result.current.width).toBe(300)
+
+        // Sanity: fireEvent works the same way.
+        act(() => {
+            fireEvent.mouseMove(document, { clientX: 900 })
+        })
+        expect(result.current.width).toBe(300)
+    })
+})

--- a/packages/observe/src/features/executions/hooks/useResizableSidebar.ts
+++ b/packages/observe/src/features/executions/hooks/useResizableSidebar.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface UseResizableSidebarOptions {
+    /** Width to use when the user has not yet dragged the handle. */
+    defaultWidth: number
+    /** Minimum width (in px) the user can drag the sidebar to. */
+    minWidth: number
+    /** Maximum width (in px) the user can drag the sidebar to. */
+    maxWidth: number
+}
+
+interface UseResizableSidebarResult {
+    width: number
+    onMouseDown: (e: React.MouseEvent) => void
+}
+
+/**
+ * Drag-to-resize behavior for a horizontally-resizable sidebar. The width
+ * follows `defaultWidth` (i.e., the viewport breakpoint) until the user drags
+ * the handle, after which the width sticks to their choice and stops
+ * reacting to viewport changes.
+ *
+ * Encapsulates: width state, drag-state refs, document-level mousemove /
+ * mouseup listeners, and cleanup on unmount.
+ */
+export function useResizableSidebar({ defaultWidth, minWidth, maxWidth }: UseResizableSidebarOptions): UseResizableSidebarResult {
+    const [width, setWidth] = useState(defaultWidth)
+    const [hasUserResized, setHasUserResized] = useState(false)
+    const isDragging = useRef(false)
+    const dragStartX = useRef(0)
+    const dragStartWidth = useRef(defaultWidth)
+
+    useEffect(() => {
+        if (hasUserResized) return
+        setWidth(defaultWidth)
+    }, [defaultWidth, hasUserResized])
+
+    const handleMouseMove = useCallback(
+        (e: MouseEvent) => {
+            if (!isDragging.current) return
+            const delta = e.clientX - dragStartX.current
+            const next = Math.min(maxWidth, Math.max(minWidth, dragStartWidth.current + delta))
+            setWidth(next)
+        },
+        [maxWidth, minWidth]
+    )
+
+    const handleMouseUp = useCallback(() => {
+        isDragging.current = false
+        document.removeEventListener('mousemove', handleMouseMove)
+        document.removeEventListener('mouseup', handleMouseUp)
+    }, [handleMouseMove])
+
+    const onMouseDown = useCallback(
+        (e: React.MouseEvent) => {
+            isDragging.current = true
+            dragStartX.current = e.clientX
+            dragStartWidth.current = width
+            setHasUserResized(true)
+            document.addEventListener('mousemove', handleMouseMove)
+            document.addEventListener('mouseup', handleMouseUp)
+        },
+        [width, handleMouseMove, handleMouseUp]
+    )
+
+    useEffect(() => {
+        return () => {
+            document.removeEventListener('mousemove', handleMouseMove)
+            document.removeEventListener('mouseup', handleMouseUp)
+        }
+    }, [handleMouseMove, handleMouseUp])
+
+    return { width, onMouseDown }
+}

--- a/packages/observe/src/infrastructure/store/ObserveContext.test.tsx
+++ b/packages/observe/src/infrastructure/store/ObserveContext.test.tsx
@@ -45,5 +45,10 @@ describe('ObserveContext', () => {
             const { result } = renderHook(() => useObserveConfig(), { wrapper: wrapper(true) })
             expect(result.current.isDarkMode).toBe(true)
         })
+
+        it('exposes apiBaseUrl from the provider', () => {
+            const { result } = renderHook(() => useObserveConfig(), { wrapper: wrapper() })
+            expect(result.current.apiBaseUrl).toBe('http://localhost:3000')
+        })
     })
 })

--- a/packages/observe/src/infrastructure/store/ObserveContext.tsx
+++ b/packages/observe/src/infrastructure/store/ObserveContext.tsx
@@ -28,9 +28,10 @@ export function useObserveApi(): ObserveApiContextValue {
 
 interface ObserveConfigContextValue {
     isDarkMode: boolean
+    apiBaseUrl: string
 }
 
-const ObserveConfigContext = createContext<ObserveConfigContextValue>({ isDarkMode: false })
+const ObserveConfigContext = createContext<ObserveConfigContextValue>({ isDarkMode: false, apiBaseUrl: '' })
 
 export function useObserveConfig(): ObserveConfigContextValue {
     return useContext(ObserveConfigContext)
@@ -56,7 +57,7 @@ export function ObserveProvider({ apiBaseUrl, token, requestInterceptor, isDarkM
         return { executions: createExecutionsApi(client) }
     }, [apiBaseUrl, token, requestInterceptor])
 
-    const config = useMemo(() => ({ isDarkMode }), [isDarkMode])
+    const config = useMemo(() => ({ isDarkMode, apiBaseUrl }), [isDarkMode, apiBaseUrl])
 
     return (
         <ThemeProvider theme={theme}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,9 +840,9 @@ importers:
       react-markdown:
         specifier: ^9.0.1
         version: 9.1.0(@types/react@18.2.65)(react@18.2.0)
-      rehype-raw:
-        specifier: ^7.0.0
-        version: 7.0.0
+      react-syntax-highlighter:
+        specifier: 15.5.0
+        version: 15.5.0(react@18.2.0)
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
@@ -868,6 +868,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.2.21
+      '@types/react-syntax-highlighter':
+        specifier: 15.5.13
+        version: 15.5.13
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.18.2
         version: 8.55.0(@typescript-eslint/parser@8.55.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
@@ -4545,79 +4548,67 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -6426,35 +6417,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.73':
     resolution: {integrity: sha512-lX0z2bNmnk1PGZ+0a9OZwI2lPPvWjRYzPqvEitXX7lspyLFrOzh2kcQiLL7bhyODN23QvfriqwYqp5GreSzVvA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.73':
     resolution: {integrity: sha512-QDQgMElwxAoADsSR3UYvdTTQk5XOyD9J5kq15Z8XpGwpZOZsSE0zZ/X1JaOtS2x+HEZL6z1S6MF/1uhZFZb5ig==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.73':
     resolution: {integrity: sha512-wbzLJrTalQrpyrU1YRrO6w6pdr5vcebbJa+Aut5QfTaW9eEmMb1WFG6l1V+cCa5LdHmRr8bsvl0nJDU/IYDsmw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.73':
     resolution: {integrity: sha512-xbfhYrUufoTAKvsEx2ZUN4jvACabIF0h1F5Ik1Rk4e/kQq6c+Dwa5QF0bGrfLhceLpzHT0pCMGMDeQKQrcUIyA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/canvas-win32-x64-msvc@0.1.73':
     resolution: {integrity: sha512-YQmHXBufFBdWqhx+ympeTPkMfs3RNxaOgWm59vyjpsub7Us07BwCcmu1N5kildhO8Fm0syoI2kHnzGkJBLSvsg==}
@@ -7319,67 +7305,56 @@ packages:
     resolution: {integrity: sha512-hLrmRl53prCcD+YXTfNvXd776HTxNh8wPAMllusQ+amcQmtgo3V5i/nkhPN6FakW+QVLoUUr2AsbtIRPFU3xIA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.0':
     resolution: {integrity: sha512-XBKGSYcrkdiRRjl+8XvrUR3AosXU0NvF7VuqMsm7s5nRy+nt58ZMB19Jdp1RdqewLcaYnpk8zeVs/4MlLZEJxw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.0':
     resolution: {integrity: sha512-fRvZZPUiBz7NztBE/2QnCS5AtqLVhXmUOPj9IHlfGEXkapgImf4W9+FSkL8cWqoAjozyUzqFmSc4zh2ooaeF6g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.0':
     resolution: {integrity: sha512-Btv2WRZOcUGi8XU80XwIvzTg4U6+l6D0V6sZTrZx214nrwxw5nAi8hysaXj/mctyClWgesyuxbeLylCBNauimg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.0':
     resolution: {integrity: sha512-Li0emNnwtUZdLwHjQPBxn4VWztcrw/h7mgLyHiEI5Z0MhpeFGlzaiBHpSNVOMB/xucjXTTcO+dhv469Djr16KA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.0':
     resolution: {integrity: sha512-sB8+pfkYx2kvpDCfd63d5ScYT0Fz1LO6jIb2zLZvmK9ob2D8DeVqrmBDE0iDK8KlBVmsTNzrjr3G1xV4eUZhSw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.0':
     resolution: {integrity: sha512-5GQ6PFhh7E6jQm70p1aW05G2cap5zMOvO0se5JMecHeAdj5ZhWEHbJ4hiKpfi1nnnEdTauDXxPgXae/mqjow9w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.0':
     resolution: {integrity: sha512-N/euLsBd1rekWcuduakTo/dJw6U6sBP3eUq+RXM9RNfPuWTvG2w/WObDkIvJ2KChy6oxZmOSC08Ak2OJA0UiAA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.0':
     resolution: {integrity: sha512-2l9sA7d7QdikL0xQwNMO3xURBUNEWyHVHfAsHsUdq+E/pgLTUcCE+gih5PCdmyHmfTDeXUWVhqL0WZzg0nua3g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.0':
     resolution: {integrity: sha512-XZdD3fEEQcwG2KrJDdEQu7NrHonPxxaV0/w2HpvINBdcqebz1aL+0vM2WFJq4DeiAVT6F5SUQas65HY5JDqoPw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.0':
     resolution: {integrity: sha512-7ayfgvtmmWgKWBkCGg5+xTQ0r5V1owVm67zTrsEY1008L5ro7mCyGYORomARt/OquB9KY7LpxVBZes+oSniAAQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.45.0':
     resolution: {integrity: sha512-B+IJgcBnE2bm93jEW5kHisqvPITs4ddLOROAcOc/diBgrEiQJJ6Qcjby75rFSmH5eMGrqJryUgJDhrfj942apQ==}
@@ -8363,28 +8338,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.4.6':
     resolution: {integrity: sha512-LGQsKJ8MA9zZ8xHCkbGkcPSmpkZL2O7drvwsGKynyCttHhpwVjj9lguhD4DWU3+FWIsjvho5Vu0Ggei8OYi/Lw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.4.6':
     resolution: {integrity: sha512-10JL2nLIreMQDKvq2TECnQe5fCuoqBHu1yW8aChqgHUyg9d7gfZX/kppUsuimqcgRBnS0AjTDAA+JF6UsG/2Yg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.4.6':
     resolution: {integrity: sha512-EGyjFVzVY6Do89x8sfah7I3cuP4MwtwzmA6OlfD/KASqfCFf5eIaEBMbajgR41bVfMV7lK72lwAIea5xEyq1AQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.4.6':
     resolution: {integrity: sha512-gfW9AuXvwSyK07Vb8Y8E9m2oJZk21WqcD+X4BZhkbKB0TCZK0zk1j/HpS2UFlr1JB2zPKPpSWLU3ll0GEHRG2A==}
@@ -9114,6 +9085,9 @@ packages:
   '@types/react-dom@18.2.21':
     resolution: {integrity: sha512-gnvBA/21SA4xxqNXEwNiVcP0xSGHh/gi1VhWv9Bl46a0ItbTT5nFY+G9VSQpaG/8N/qdJpJ+vftQ4zflTtnjLw==}
 
+  '@types/react-syntax-highlighter@15.5.13':
+    resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
+
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
@@ -9478,49 +9452,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -10720,14 +10686,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   chromadb-js-bindings-linux-x64-gnu@1.1.1:
     resolution: {integrity: sha512-RcvBcECbUcFXlFM2httdGc+3wmkI76tD9iGS0H9npEhz4LyLvdXKBK8CZtw67hsHCH09KklKw4ITkSS85pHVbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   chromadb-js-bindings-win32-x64-msvc@1.1.1:
     resolution: {integrity: sha512-296SxWNwsmvP+1Ggkl72norTFLOivoXhGu0t5mXNIbd7yd2UodntvAvG2cheTHDCL/ILbox4u+6KHNvRxHgm6A==}
@@ -31817,6 +31781,10 @@ snapshots:
     dependencies:
       '@types/react': 18.2.65
 
+  '@types/react-syntax-highlighter@15.5.13':
+    dependencies:
+      '@types/react': 18.2.65
+
   '@types/react-transition-group@4.4.12(@types/react@18.2.65)':
     dependencies:
       '@types/react': 18.2.65
@@ -43306,7 +43274,7 @@ snapshots:
 
   react-syntax-highlighter@15.5.0(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.26.10
       highlight.js: 10.7.3
       lowlight: 1.20.0
       prismjs: 1.29.0


### PR DESCRIPTION
FLOWISE-575

## Summary

- Ports legacy `NodeExecutionDetails.jsx` (~1,285 LOC) to `@flowiseai/observe`
- Renders rendered/raw views for a node's input / output / error / state, with metrics, HITL controls, tools, and condition outputs
- 265 tests pass; coverage thresholds met

## In scope

- Rendered / Raw toggle
- Markdown, JSON, code-fence, and fallback renderers
- Token / cost / time metrics (legacy parity formatting)
- HITL Approve / Reject with optional feedback dialog
- Curated Input / Output / Error / State sections
- Available-tools list, used-tools chips, condition output

## Out of scope (deferred per ticket)

- File uploads, file annotations, artifacts (image / html)
- CodeEditor for `data.input.code`
- Source-doc dialog

## Architecture

- Domain types lifted to `core/types/nodeDetail.ts`; predicates and `resolveTool` / `extractToolCalls` to `core/utils/` per the new type-location rule documented in `ARCHITECTURE.md`
- `useResizableSidebar` extracted from `ExecutionDetail`
- `HitlPanel` merges the prior `HitlActionBar` + `HitlFeedbackDialog`
- `ToolAccordionList` consolidates two near-twin lists via a discriminated `variant` union
- Legacy-comparison comments tagged `// PARITY:` for a single cleanup sweep when legacy is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

Demos:

https://github.com/user-attachments/assets/54de591d-d77a-4ac0-9b78-c8292c010d4c

https://github.com/user-attachments/assets/712928cc-fe50-42f9-9ceb-41ba3ae26a3a

https://github.com/user-attachments/assets/d5e809a2-0e96-4fa6-9370-0c7fce464952

https://github.com/user-attachments/assets/c1f44dbe-28a5-46bd-99d6-4487b8e6d8c4

https://github.com/user-attachments/assets/643f6b7d-9520-4056-83f4-0f62c2af4b8b