### PR TITLE
fix: FLOWISE-599 Adding Shahdow and elevation to dropdown list

### DIFF
--- a/packages/agentflow/src/core/theme/createAgentflowTheme.ts
+++ b/packages/agentflow/src/core/theme/createAgentflowTheme.ts
@@ -100,6 +100,11 @@ export function createAgentflowTheme(isDarkMode: boolean): Theme {
             },
             MuiAutocomplete: {
                 styleOverrides: {
+                    paper: {
+                        boxShadow:
+                            '0px 8px 10px -5px rgb(0 0 0 / 20%), 0px 16px 24px 2px rgb(0 0 0 / 14%), 0px 6px 30px 5px rgb(0 0 0 / 12%)',
+                        borderRadius: '10px'
+                    },
                     option: {
                         '&:hover': {
                             background: isDarkMode ? `${tokens.colors.background.optionHover.dark} !important` : undefined


### PR DESCRIPTION
The dropdown component in Agentflow was missing a box shadow. This PR adds Box Shawdow to dropdown list in Agentflow.

**Before:**
<img width="681" height="536" alt="screenshot-1 (1)" src="https://github.com/user-attachments/assets/12fd0cbc-32e3-49a6-9a51-aca62d29847b" />

**After:**
<img width="1728" height="1117" alt="Screenshot 2026-04-30 at 2 17 30 PM" src="https://github.com/user-attachments/assets/a94cda97-0fa7-4bd8-8b2c-905f5bceee05" />

Dark Mode:
<img width="1728" height="1117" alt="Screenshot 2026-05-01 at 9 50 10 AM" src="https://github.com/user-attachments/assets/145a6668-b33f-43c4-bbbe-ba8f74ffe23c" />
