### PR TITLE
feat(observe): ExecutionDetail with tree view, headers, and resizable drawer

### DIFF
--- a/packages/observe/ARCHITECTURE.md
+++ b/packages/observe/ARCHITECTURE.md
@@ -24,10 +24,14 @@ src/
 
 **"What it looks like."** Tiny, irreducible UI components with no business logic. Shared building blocks used across features.
 
+Example layout (illustrative — not exhaustive; check the directory for the current set):
+
 ```
 atoms/
-├── StatusIcon.tsx          # Execution / node status icon (INPROGRESS, FINISHED, ERROR…)
+├── StatusIndicator.tsx     # Execution / node status icon (INPROGRESS, FINISHED, ERROR…)
 ├── MetricsDisplay.tsx      # Token / cost / time metrics row
+├── NodeIcon.tsx            # AGENTFLOW_ICONS-driven avatar for a node type
+├── …                       # Other primitives as the SDK grows
 └── index.ts                # Central export
 ```
 
@@ -47,17 +51,23 @@ atoms/
 
 **"What it does."** Self-contained domain modules. Each feature owns its components, hooks, and feature-local utilities. Adding a new observability feature (evaluations, chat history, MALT) means adding a new directory here — it does not touch existing feature exports.
 
+Example layout (illustrative — not exhaustive; the `executions` feature currently has more sub-components and hooks than shown here):
+
 ```
 features/
 ├── executions/             # Execution viewer
 │   ├── components/
-│   │   ├── ExecutionsViewer.tsx      # Filterable list + pagination (global or scoped via agentflowId)
-│   │   ├── ExecutionDetail.tsx       # Resizable split-pane: tree + node detail
+│   │   ├── ExecutionsViewer.tsx      # Filterable list + pagination + resizable detail drawer
+│   │   ├── ExecutionDetail.tsx       # Resizable split-pane: tree sidebar + node detail
+│   │   ├── ExecutionTreeSidebar.tsx  # @mui/x-tree-view RichTreeView with custom slot
 │   │   ├── NodeExecutionDetail.tsx   # Step viewer: markdown/JSON/code/HTML renderers, HITL
-│   │   └── ExecutionsListTable.tsx   # Sortable/selectable MUI table
+│   │   ├── ExecutionsListTable.tsx   # Sortable/selectable MUI table
+│   │   └── …                         # Other components (chat bubbles, panels) as the feature grows
 │   ├── hooks/
 │   │   ├── useExecutionPoll.ts       # Auto-poll while INPROGRESS, stop on terminal state
-│   │   └── useExecutionTree.ts       # Build ExecutionTreeNode[] from flat NodeExecutionData[]
+│   │   ├── useExecutionTree.ts       # Build ExecutionTreeNode[] from flat NodeExecutionData[]
+│   │   ├── useResizableSidebar.ts    # Drag-to-resize width state (left- or right-anchored panels)
+│   │   └── …                         # Other feature-local hooks
 │   └── index.ts                      # Public API for this feature
 │
 └── (evaluations/)          # Future — GA
@@ -79,16 +89,26 @@ features/
 
 **"The Brain."** Framework-agnostic types, utilities, and the MUI theme factory. No React components, no API calls.
 
+Example layout (illustrative — not exhaustive; new sub-files land under `types/`, `primitives/`, and `utils/` as the SDK grows):
+
 ```
 core/
 ├── types/
 │   ├── execution.ts        # Execution, ExecutionState, NodeExecutionData,
 │   │                       # ExecutionTreeNode, HumanInputParams
-│   ├── observe.ts          # ObserveBaseProps (provider props), ExecutionsViewerProps,
+│   ├── observe.ts          # ObserveBaseProps, ExecutionsViewerProps,
 │   │                       # ExecutionDetailProps, ExecutionFilters
+│   ├── nodeDetail.ts       # ChatMessage, ConditionEntry, AvailableToolEntry, …
 │   └── index.ts
 │
 ├── primitives/             # Domain-free, safe to import from atoms/
+│   ├── agentflowIcons.ts   # AGENTFLOW_ICONS registry (icon + color per node type)
+│   ├── json.ts             # JSON tokenizer / safe parser
+│   └── index.ts
+│
+├── utils/                  # Domain-aware helpers — not importable from atoms/
+│   ├── guards.ts           # Type predicates over core/types/* shapes
+│   ├── tools.ts            # Tool-call extraction / resolution
 │   └── index.ts
 │
 └── theme/
@@ -118,6 +138,8 @@ When adding a utility, ask: _"Does this function need to know what an Execution 
 ### `infrastructure/` - External Services
 
 **"The Outside World."** API client factory and React context providers.
+
+Example layout (illustrative — not exhaustive; new API modules land under `api/` as features grow):
 
 ```
 infrastructure/
@@ -257,14 +279,12 @@ FINISHED | ERROR | TERMINATED | TIMEOUT | STOPPED → interval cleared immediate
 
 ### Execution Tree (`useExecutionTree`)
 
-`useExecutionTree` converts the flat `NodeExecutionData[]` stored as JSON in `execution.executionData` into a hierarchical `ExecutionTreeNode[]`:
+`useExecutionTree` converts the flat `NodeExecutionData[]` stored as JSON in `execution.executionData` into a hierarchical `ExecutionTreeNode[]`. Two parenting mechanisms run in sequence (mirrors legacy `ExecutionDetails.jsx` `buildTreeData`):
 
-1. Parse `executionData` JSON
-2. Separate top-level nodes (no `parentNodeId`) from iteration children
-3. Group children by `(parentNodeId, iterationIndex)`
-4. Insert virtual container nodes labeled `Iteration #N` with `isVirtualNode: true`
+1. **`previousNodeIds` parent→child** — each non-iteration node attaches to the most-recent prior instance of any node listed in its `previousNodeIds`. Nodes with empty / unmatched `previousNodeIds` become roots. The "most recent" rule disambiguates when the same `nodeId` runs more than once (e.g. inside a loop).
+2. **Iteration grouping** — children with `parentNodeId` + `iterationIndex` are bundled into virtual `Iteration #N` container nodes (`isVirtualNode: true`) under the iteration agent's most-recent instance, then linked to one another inside the iteration via the same `previousNodeIds` rule (restricted to same-iteration siblings).
 
-The tree is used by `ExecutionDetail` to render the sidebar node list.
+Tree-node ids are `${nodeId}_${arrayIndex}` so duplicate `nodeId`s remain addressable. The tree is consumed by `ExecutionTreeSidebar` (a `RichTreeView` slot) inside `ExecutionDetail`.
 
 ### HITL Callback — Opaque Consumer Contract
 
@@ -292,15 +312,15 @@ Tenant isolation is handled server-side by Flowise's `ExtendRequestContextMiddle
 Each module exposes only what's needed via its `index.ts`:
 
 ```typescript
-// features/executions/index.ts
-// ✅ Public API — components and types needed by index.ts
+// features/executions/index.ts (illustrative — re-export only what consumers need)
+// ✅ Public API
 export { ExecutionsViewer } from './components/ExecutionsViewer'
 export { ExecutionDetail } from './components/ExecutionDetail'
 export { NodeExecutionDetail } from './components/NodeExecutionDetail'
 export { useExecutionPoll } from './hooks/useExecutionPoll'
 export { useExecutionTree } from './hooks/useExecutionTree'
 
-// ❌ Internal sub-components and helpers stay private
+// ❌ Internal sub-components (e.g. ExecutionTreeSidebar, ChatMessageBubble) and helpers stay private
 ```
 
 ---
@@ -346,18 +366,20 @@ Adding evaluations, chat history, or MALT follows the same pattern:
 
 ## Root Files (`src/index.ts`)
 
-The barrel export exposes only the public surface:
+The barrel export exposes only the public surface. Example shape (illustrative — refer to `src/index.ts` for the current set):
 
 ```typescript
 // Components
-export { ExecutionsViewer } from './features/executions'
-export { ExecutionDetail } from './features/executions'
-export { NodeExecutionDetail } from './features/executions'
+export { ExecutionsViewer, ExecutionDetail, NodeExecutionDetail } from './features/executions'
 export { ObserveProvider } from './infrastructure/store'
+
+// Hooks (for consumers building custom UIs on top of observe infrastructure)
+export { useExecutionPoll, useExecutionTree } from './features/executions'
+export { useObserveApi, useObserveConfig } from './infrastructure/store'
 
 // Types
 export type { ExecutionsViewerProps, ExecutionDetailProps, ExecutionFilters } from './core/types'
-export type { Execution, ExecutionState, NodeExecutionData, HumanInputParams } from './core/types'
+export type { Execution, ExecutionState, NodeExecutionData, HumanInputParams, AgentflowRef } from './core/types'
 ```
 
 Everything else is internal implementation detail.

--- a/packages/observe/TESTS.md
+++ b/packages/observe/TESTS.md
@@ -30,9 +30,9 @@ Presentational components that are mostly JSX. Only add tests if the component c
 
 **Currently classified as Tier 3 (no `coverageThreshold` entry):**
 
--   `ExecutionDetail.tsx` — orchestration shell wiring `useExecutionPoll` + `useExecutionTree` + `useResizableSidebar` + `<ExecutionTreeSidebar>` + `<NodeExecutionDetail>`. The drag-resize logic was lifted to `useResizableSidebar` (testable in isolation); the recursive tree renderer was lifted to `<ExecutionTreeSidebar>`. What remains is composition.
--   `ExecutionTreeSidebar.tsx` — recursive list rendering with one click branch (skip-on-virtual-node). Add tests if the tree gains filtering, search, or non-trivial expand/collapse behavior.
 -   `ExecutionsListTable.tsx`, `ExecutionsViewer.tsx` — data-table + outer composition shells.
+
+`ExecutionDetail.tsx` was promoted to Tier 2 once it grew real branching (initial-selection rule, copy-id flow, error/loading/empty states). Drag-resize lives in `useResizableSidebar` and the recursive tree renderer in `<ExecutionTreeSidebar>`, both tested in isolation; the orchestrator's own tests cover composition + the auto-select branches.
 
 If any of these grows real branching logic (filter predicates, sort comparators, debounced handlers), promote it to Tier 2 by adding a `coverageThreshold` entry in `jest.config.js` and writing the corresponding tests.
 

--- a/packages/observe/examples/.env.example
+++ b/packages/observe/examples/.env.example
@@ -15,3 +15,11 @@ VITE_FLOW_ID=
 # Execution ID (UUID) — used for the standalone ExecutionDetail example
 # Get this from: any execution row in the Flowise executions view
 VITE_EXECUTION_ID=
+
+# Base URL of the agentflow canvas (optional). Independent of VITE_API_BASE_URL
+# because the canvas can live on a different host than the Flowise API.
+# When set, the example wires `onAgentflowClick` to open
+# `${VITE_AGENTFLOW_CANVAS_URL}/<agentflowId>` in a new tab.
+# When unset, the agentflow chip in the SDK renders non-clickable.
+# Example: http://localhost:3000/v2/agentcanvas
+VITE_AGENTFLOW_CANVAS_URL=

--- a/packages/observe/examples/README.md
+++ b/packages/observe/examples/README.md
@@ -10,23 +10,25 @@ A Vite + React dev app for exploring and testing `@flowiseai/observe` components
 cp .env.example .env
 ```
 
-| Variable            | Description                                                                                                                                                                                                                                                    |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `VITE_API_BASE_URL` | Base URL of your Flowise instance (default: `http://localhost:3000`)                                                                                                                                                                                           |
-| `VITE_API_TOKEN`    | API key for authentication — get this from **Flowise UI → Settings → API Keys → Create New Key**. This is an API key, not a user session token. Ensure the key has the necessary permissions for any features you want to exercise (e.g. deleting executions). |
-| `VITE_FLOW_ID`      | _(optional)_ UUID of an agentflow — scopes the Executions Viewer to that flow only. When unset, all executions across every agentflow are shown. Get it from the URL or settings of your agentflow in Flowise UI.                                              |
-| `VITE_EXECUTION_ID` | UUID of a specific execution — used by the Standalone Detail demo. Get it from any execution row in the executions view.                                                                                                                                       |
+<!-- prettier-ignore -->
+| Variable | Description |
+| --- | --- |
+| `VITE_API_BASE_URL` | Base URL of your Flowise instance (default: `http://localhost:3000`) |
+| `VITE_API_TOKEN` | API key for authentication — get this from **Flowise UI → Settings → API Keys → Create New Key**. This is an API key, not a user session token. Ensure the key has the necessary permissions for any features you want to exercise (e.g. deleting executions). |
+| `VITE_FLOW_ID` | _(optional)_ UUID of an agentflow — scopes the Executions Viewer to that flow only. When unset, all executions across every agentflow are shown. Get it from the URL or settings of your agentflow in Flowise UI. |
+| `VITE_EXECUTION_ID` | UUID of a specific execution — used by the Standalone Detail demo. Get it from any execution row in the executions view. |
+| `VITE_AGENTFLOW_CANVAS_URL` | _(optional)_ Base URL of the agentflow canvas — when set, the demos wire `onAgentflowClick` to open `${VITE_AGENTFLOW_CANVAS_URL}/<agentflowId>` in a new tab. When unset, the agentflow chip in the SDK header renders non-clickable. Example: `http://localhost:3000/v2/agentcanvas`. |
 
 **2. Install dependencies (from this directory):**
 
 ```bash
-pnpm install
+npm install
 ```
 
 **3. Start the dev server:**
 
 ```bash
-pnpm dev
+npm run dev
 ```
 
 The app opens at `http://localhost:5174` (or the next available port).
@@ -45,10 +47,11 @@ Features exercised:
 
 -   Execution list with state and session ID filters
 -   Pagination
--   Clicking a row opens `ExecutionDetail` in a side drawer
+-   Clicking a row opens `ExecutionDetail` in a side drawer (drag the left edge of the drawer to resize)
 -   Single-row delete (`allowDelete={true}`)
 -   Auto-poll while a run is INPROGRESS
 -   HITL Approve/Reject buttons (logs to console — no real prediction call)
+-   Clicking the agentflow name chip opens `${VITE_AGENTFLOW_CANVAS_URL}/<agentflowId>` in a new tab when the env var is set; renders non-clickable when unset
 
 ### Standalone Detail (`StandaloneDetailExample`)
 
@@ -60,11 +63,12 @@ The execution ID can be pre-filled via `VITE_EXECUTION_ID` or pasted into the te
 
 Features exercised:
 
--   Resizable split-pane layout
+-   Resizable split-pane layout (drag the divider between tree and detail)
 -   Node tree sidebar with iteration grouping
 -   `NodeExecutionDetail` — all renderers (markdown, JSON, raw/rendered toggle)
 -   Token / cost / time metrics per node
 -   Auto-poll while INPROGRESS
+-   Clicking the agentflow name chip opens `${VITE_AGENTFLOW_CANVAS_URL}/<agentflowId>` in a new tab when the env var is set; renders non-clickable when unset
 
 ---
 

--- a/packages/observe/examples/package-lock.json
+++ b/packages/observe/examples/package-lock.json
@@ -20,7 +20,7 @@
                 "@types/react-dom": "^18.2.0",
                 "@vitejs/plugin-react": "^4.0.0",
                 "typescript": "^5.0.0",
-                "vite": "8.0.9"
+                "vite": "^5.0.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -38,9 +38,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/compat-data/-/compat-data-7.29.3.tgz",
+            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -211,9 +211,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@babel/parser/-/parser-7.29.3.tgz",
+            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -309,40 +309,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@emnapi/core": {
-            "version": "1.9.2",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emnapi/core/-/core-1.9.2.tgz",
-            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.9.2",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emnapi/runtime/-/runtime-1.9.2.tgz",
-            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
             }
         },
         "node_modules/@emotion/babel-plugin": {
@@ -490,6 +456,397 @@
             "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
             "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
             "license": "MIT"
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
@@ -762,35 +1119,6 @@
                 }
             }
         },
-        "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@oxc-project/types": {
-            "version": "0.126.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@oxc-project/types/-/types-0.126.0.tgz",
-            "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
-            }
-        },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
             "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@popperjs/core/-/core-2.11.8.tgz",
@@ -801,10 +1129,31 @@
                 "url": "https://opencollective.com/popperjs"
             }
         },
-        "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.27",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+            "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+            "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
             "cpu": [
                 "arm64"
             ],
@@ -813,15 +1162,12 @@
             "optional": true,
             "os": [
                 "android"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+            "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
             "cpu": [
                 "arm64"
             ],
@@ -830,15 +1176,12 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+            "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
             "cpu": [
                 "x64"
             ],
@@ -847,15 +1190,26 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+            "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+            "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
             "cpu": [
                 "x64"
             ],
@@ -864,15 +1218,12 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-            "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+            "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
             "cpu": [
                 "arm"
             ],
@@ -881,15 +1232,26 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+            "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+            "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
             "cpu": [
                 "arm64"
             ],
@@ -898,15 +1260,12 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-            "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+            "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
             "cpu": [
                 "arm64"
             ],
@@ -915,15 +1274,40 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+            "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+            "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+            "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
             "cpu": [
                 "ppc64"
             ],
@@ -932,15 +1316,54 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+            "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+            "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+            "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+            "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
             "cpu": [
                 "s390x"
             ],
@@ -949,15 +1372,12 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+            "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
             "cpu": [
                 "x64"
             ],
@@ -966,15 +1386,12 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-            "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+            "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
             "cpu": [
                 "x64"
             ],
@@ -983,15 +1400,26 @@
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+            "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+            "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1000,34 +1428,12 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-            "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.9.2",
-                "@emnapi/runtime": "1.9.2",
-                "@napi-rs/wasm-runtime": "^1.1.4"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-            "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+            "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1036,15 +1442,26 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
+            ]
         },
-        "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-            "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+            "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+            "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
             "cpu": [
                 "x64"
             ],
@@ -1053,28 +1470,21 @@
             "optional": true,
             "os": [
                 "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+            "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+            "cpu": [
+                "x64"
             ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-beta.27",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -1120,6 +1530,13 @@
             "dependencies": {
                 "@babel/types": "^7.28.2"
             }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
@@ -1199,9 +1616,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.20",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-            "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+            "version": "2.10.24",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+            "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -1255,9 +1672,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001788",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-            "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+            "version": "1.0.30001791",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+            "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
             "dev": true,
             "funding": [
                 {
@@ -1306,15 +1723,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/cosmiconfig/node_modules/yaml": {
-            "version": "1.10.3",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/yaml/-/yaml-1.10.3.tgz",
-            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/csstype": {
             "version": "3.2.3",
             "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/csstype/-/csstype-3.2.3.tgz",
@@ -1338,16 +1746,6 @@
                 }
             }
         },
-        "node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
             "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -1359,9 +1757,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.340",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-            "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+            "version": "1.5.346",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/electron-to-chromium/-/electron-to-chromium-1.5.346.tgz",
+            "integrity": "sha512-3PGbvVwt9AppQsta0Kuq5DIcSj7aQfDfCVS7KnV3nhXEDtuJVRS7kK28Q+qy5KRkQ4bICV4xOaXNeUaXe78dDg==",
             "dev": true,
             "license": "ISC"
         },
@@ -1381,6 +1779,45 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.21.5",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
             }
         },
         "node_modules/escalade": {
@@ -1403,24 +1840,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
             }
         },
         "node_modules/find-root": {
@@ -1564,267 +1983,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/lightningcss": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-            "dev": true,
-            "license": "MPL-2.0",
-            "dependencies": {
-                "detect-libc": "^2.0.3"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            },
-            "optionalDependencies": {
-                "lightningcss-android-arm64": "1.32.0",
-                "lightningcss-darwin-arm64": "1.32.0",
-                "lightningcss-darwin-x64": "1.32.0",
-                "lightningcss-freebsd-x64": "1.32.0",
-                "lightningcss-linux-arm-gnueabihf": "1.32.0",
-                "lightningcss-linux-arm64-gnu": "1.32.0",
-                "lightningcss-linux-arm64-musl": "1.32.0",
-                "lightningcss-linux-x64-gnu": "1.32.0",
-                "lightningcss-linux-x64-musl": "1.32.0",
-                "lightningcss-win32-arm64-msvc": "1.32.0",
-                "lightningcss-win32-x64-msvc": "1.32.0"
-            }
-        },
-        "node_modules/lightningcss-android-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-x64": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -1860,9 +2018,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -1879,9 +2037,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.37",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/node-releases/-/node-releases-2.0.37.tgz",
-            "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+            "version": "2.0.38",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/node-releases/-/node-releases-2.0.38.tgz",
+            "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1945,23 +2103,10 @@
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
         },
-        "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/postcss": {
-            "version": "8.5.10",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/postcss/-/postcss-8.5.10.tgz",
-            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+            "version": "8.5.13",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/postcss/-/postcss-8.5.13.tgz",
+            "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
             "dev": true,
             "funding": [
                 {
@@ -2091,46 +2236,50 @@
                 "node": ">=4"
             }
         },
-        "node_modules/rolldown": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+        "node_modules/rollup": {
+            "version": "4.60.2",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/rollup/-/rollup-4.60.2.tgz",
+            "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.126.0",
-                "@rolldown/pluginutils": "1.0.0-rc.16"
+                "@types/estree": "1.0.8"
             },
             "bin": {
-                "rolldown": "bin/cli.mjs"
+                "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+                "@rollup/rollup-android-arm-eabi": "4.60.2",
+                "@rollup/rollup-android-arm64": "4.60.2",
+                "@rollup/rollup-darwin-arm64": "4.60.2",
+                "@rollup/rollup-darwin-x64": "4.60.2",
+                "@rollup/rollup-freebsd-arm64": "4.60.2",
+                "@rollup/rollup-freebsd-x64": "4.60.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+                "@rollup/rollup-linux-arm64-musl": "4.60.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+                "@rollup/rollup-linux-loong64-musl": "4.60.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+                "@rollup/rollup-linux-x64-gnu": "4.60.2",
+                "@rollup/rollup-linux-x64-musl": "4.60.2",
+                "@rollup/rollup-openbsd-x64": "4.60.2",
+                "@rollup/rollup-openharmony-arm64": "4.60.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+                "@rollup/rollup-win32-x64-gnu": "4.60.2",
+                "@rollup/rollup-win32-x64-msvc": "4.60.2",
+                "fsevents": "~2.3.2"
             }
-        },
-        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-            "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
@@ -2188,31 +2337,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
-        },
         "node_modules/typescript": {
             "version": "5.9.3",
             "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/typescript/-/typescript-5.9.3.tgz",
@@ -2259,23 +2383,21 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.9",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/vite/-/vite-8.0.9.tgz",
-            "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+            "version": "5.4.21",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/vite/-/vite-5.4.21.tgz",
+            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.10",
-                "rolldown": "1.0.0-rc.16",
-                "tinyglobby": "^0.2.16"
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": "^18.0.0 || >=20.0.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -2284,33 +2406,23 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.0",
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
             },
             "peerDependenciesMeta": {
                 "@types/node": {
                     "optional": true
                 },
-                "@vitejs/devtools": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
                 "less": {
+                    "optional": true
+                },
+                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -2327,12 +2439,6 @@
                 },
                 "terser": {
                     "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
                 }
             }
         },
@@ -2344,21 +2450,12 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-            "dev": true,
+            "version": "1.10.3",
+            "resolved": "https://artifactory.workday.com/artifactory/api/npm/npm-virtual/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
             "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
             "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
+                "node": ">= 6"
             }
         }
     }

--- a/packages/observe/examples/package.json
+++ b/packages/observe/examples/package.json
@@ -21,6 +21,6 @@
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.0.0",
         "typescript": "^5.0.0",
-        "vite": "8.0.9"
+        "vite": "^5.0.2"
     }
 }

--- a/packages/observe/examples/src/config.ts
+++ b/packages/observe/examples/src/config.ts
@@ -2,3 +2,8 @@ export const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost
 export const token = import.meta.env.VITE_API_TOKEN || undefined
 export const flowId = import.meta.env.VITE_FLOW_ID || undefined
 export const executionId = import.meta.env.VITE_EXECUTION_ID || undefined
+
+// Base URL of the agentflow canvas (optional). Independent of `apiBaseUrl`
+// because the canvas can live on a different host than the Flowise API.
+// Demos that consume this append `/<agentflowId>` to navigate.
+export const agentflowCanvasUrl = import.meta.env.VITE_AGENTFLOW_CANVAS_URL || undefined

--- a/packages/observe/examples/src/demos/ExecutionsViewerExample.tsx
+++ b/packages/observe/examples/src/demos/ExecutionsViewerExample.tsx
@@ -1,7 +1,14 @@
 import { ExecutionsViewer, HumanInputParams } from '@flowiseai/observe'
 import { Box, Typography } from '@mui/material'
 
-import { flowId } from '../config'
+import { agentflowCanvasUrl, flowId } from '../config'
+
+// Build the navigation handler only when a canvas URL is configured. When
+// unset, `onAgentflowClick` stays undefined and the SDK renders the chip
+// non-clickable.
+const onAgentflowClick: ((agentflowId: string) => void) | undefined = agentflowCanvasUrl
+    ? (agentflowId) => window.open(`${agentflowCanvasUrl}/${agentflowId}`, '_blank', 'noopener,noreferrer')
+    : undefined
 
 export default function ExecutionsViewerExample() {
     return (
@@ -25,9 +32,7 @@ export default function ExecutionsViewerExample() {
                     onHumanInput={async (agentflowId: string, params: HumanInputParams) => {
                         console.info('[Example] onHumanInput', agentflowId, params)
                     }}
-                    onAgentflowClick={(agentflowId: string) => {
-                        console.info('[Example] onAgentflowClick', agentflowId)
-                    }}
+                    onAgentflowClick={onAgentflowClick}
                 />
             </Box>
         </Box>

--- a/packages/observe/examples/src/demos/StandaloneDetailExample.tsx
+++ b/packages/observe/examples/src/demos/StandaloneDetailExample.tsx
@@ -3,7 +3,11 @@ import { useState } from 'react'
 import { ExecutionDetail } from '@flowiseai/observe'
 import { Box, TextField, Typography } from '@mui/material'
 
-import { executionId as defaultExecutionId } from '../config'
+import { agentflowCanvasUrl, executionId as defaultExecutionId } from '../config'
+
+const onAgentflowClick: ((agentflowId: string) => void) | undefined = agentflowCanvasUrl
+    ? (agentflowId) => window.open(`${agentflowCanvasUrl}/${agentflowId}`, '_blank', 'noopener,noreferrer')
+    : undefined
 
 export default function StandaloneDetailExample() {
     const [executionId, setExecutionId] = useState(defaultExecutionId ?? '')
@@ -20,13 +24,7 @@ export default function StandaloneDetailExample() {
             />
             {executionId ? (
                 <Box sx={{ height: 600, border: '1px solid', borderColor: 'divider', borderRadius: 1, overflow: 'hidden' }}>
-                    <ExecutionDetail
-                        executionId={executionId}
-                        pollInterval={3000}
-                        onAgentflowClick={(agentflowId: string) => {
-                            console.info('[Example] onAgentflowClick', agentflowId)
-                        }}
-                    />
+                    <ExecutionDetail executionId={executionId} pollInterval={3000} onAgentflowClick={onAgentflowClick} />
                 </Box>
             ) : (
                 <Typography variant='body2' color='text.secondary'>

--- a/packages/observe/examples/vite.config.ts
+++ b/packages/observe/examples/vite.config.ts
@@ -14,8 +14,6 @@ export default defineConfig({
         // our theme's #673ab7).
         dedupe: ['react', 'react-dom', '@mui/material', '@mui/system', '@emotion/react', '@emotion/styled'],
         alias: {
-            react: resolve(__dirname, 'node_modules/react'),
-            'react-dom': resolve(__dirname, 'node_modules/react-dom'),
             '@flowiseai/observe/observe.css': resolve(__dirname, '../src/observe.css'),
             '@flowiseai/observe': resolve(__dirname, '../src/index.ts'),
             '@': resolve(__dirname, '../src')

--- a/packages/observe/jest.config.js
+++ b/packages/observe/jest.config.js
@@ -45,10 +45,9 @@ module.exports = {
             './src/infrastructure/store/': FLOOR,
 
             // Tested subset of components — extglob excludes the untested
-            // orchestrators (ExecutionDetail / ExecutionsListTable /
-            // ExecutionsViewer). Promote this to the folder level once those
-            // land tests.
-            './src/features/executions/components/!(ExecutionDetail|ExecutionsListTable|ExecutionsViewer).{ts,tsx}': FLOOR,
+            // orchestrators (ExecutionsListTable / ExecutionsViewer). Promote
+            // this to the folder level once those land tests.
+            './src/features/executions/components/!(ExecutionsListTable|ExecutionsViewer).{ts,tsx}': FLOOR,
 
             // executions.ts has direct tests; client.ts is exercised only
             // indirectly through executions.ts so it's not threshold-gated.

--- a/packages/observe/package.json
+++ b/packages/observe/package.json
@@ -68,6 +68,7 @@
         "react-dom": "^18.2.0"
     },
     "dependencies": {
+        "@mui/x-tree-view": "^7.25.0",
         "@tabler/icons-react": "^3.7.0",
         "axios": "1.15.0",
         "date-fns": "^3.6.0",

--- a/packages/observe/src/atoms/NodeIcon.tsx
+++ b/packages/observe/src/atoms/NodeIcon.tsx
@@ -1,51 +1,6 @@
-// AGENTFLOW_ICONS registry below is duplicated in
-// packages/agentflow/src/core/node-config/nodeIcons.ts — keep in sync until
-// extracted to packages/shared-ui in FLOWISE-628.
-
 import { Box } from '@mui/material'
-import {
-    type Icon,
-    IconArrowsSplit,
-    IconFunctionFilled,
-    IconLibrary,
-    IconMessageCircleFilled,
-    IconNote,
-    IconPlayerPlayFilled,
-    IconRelationOneToManyFilled,
-    IconRepeat,
-    IconReplaceUser,
-    IconRobot,
-    IconSparkles,
-    IconSubtask,
-    IconTools,
-    IconVectorBezier2,
-    IconWorld
-} from '@tabler/icons-react'
 
-import { tokens } from '@/core/theme'
-
-interface AgentflowIconEntry {
-    icon: Icon
-    color: string
-}
-
-const AGENTFLOW_ICONS: Record<string, AgentflowIconEntry> = {
-    conditionAgentflow: { icon: IconArrowsSplit, color: tokens.colors.nodes.condition },
-    startAgentflow: { icon: IconPlayerPlayFilled, color: tokens.colors.nodes.start },
-    llmAgentflow: { icon: IconSparkles, color: tokens.colors.nodes.llm },
-    agentAgentflow: { icon: IconRobot, color: tokens.colors.nodes.agent },
-    humanInputAgentflow: { icon: IconReplaceUser, color: tokens.colors.nodes.humanInput },
-    loopAgentflow: { icon: IconRepeat, color: tokens.colors.nodes.loop },
-    directReplyAgentflow: { icon: IconMessageCircleFilled, color: tokens.colors.nodes.directReply },
-    customFunctionAgentflow: { icon: IconFunctionFilled, color: tokens.colors.nodes.customFunction },
-    toolAgentflow: { icon: IconTools, color: tokens.colors.nodes.tool },
-    retrieverAgentflow: { icon: IconLibrary, color: tokens.colors.nodes.retriever },
-    conditionAgentAgentflow: { icon: IconSubtask, color: tokens.colors.nodes.conditionAgent },
-    stickyNoteAgentflow: { icon: IconNote, color: tokens.colors.nodes.stickyNote },
-    httpAgentflow: { icon: IconWorld, color: tokens.colors.nodes.http },
-    iterationAgentflow: { icon: IconRelationOneToManyFilled, color: tokens.colors.nodes.iteration },
-    executeFlowAgentflow: { icon: IconVectorBezier2, color: tokens.colors.nodes.executeFlow }
-}
+import { AGENTFLOW_ICONS } from '@/core/primitives'
 
 interface NodeIconProps {
     /** Node type name, e.g. "startAgentflow", "agentAgentflow". */

--- a/packages/observe/src/core/primitives/agentflowIcons.ts
+++ b/packages/observe/src/core/primitives/agentflowIcons.ts
@@ -1,0 +1,47 @@
+// AGENTFLOW_ICONS registry below is duplicated in
+// packages/agentflow/src/core/node-config/nodeIcons.ts — keep in sync until
+// extracted to packages/shared-ui in FLOWISE-628.
+
+import {
+    type Icon,
+    IconArrowsSplit,
+    IconFunctionFilled,
+    IconLibrary,
+    IconMessageCircleFilled,
+    IconNote,
+    IconPlayerPlayFilled,
+    IconRelationOneToManyFilled,
+    IconRepeat,
+    IconReplaceUser,
+    IconRobot,
+    IconSparkles,
+    IconSubtask,
+    IconTools,
+    IconVectorBezier2,
+    IconWorld
+} from '@tabler/icons-react'
+
+import { tokens } from '@/core/theme'
+
+export interface AgentflowIconEntry {
+    icon: Icon
+    color: string
+}
+
+export const AGENTFLOW_ICONS: Record<string, AgentflowIconEntry> = {
+    conditionAgentflow: { icon: IconArrowsSplit, color: tokens.colors.nodes.condition },
+    startAgentflow: { icon: IconPlayerPlayFilled, color: tokens.colors.nodes.start },
+    llmAgentflow: { icon: IconSparkles, color: tokens.colors.nodes.llm },
+    agentAgentflow: { icon: IconRobot, color: tokens.colors.nodes.agent },
+    humanInputAgentflow: { icon: IconReplaceUser, color: tokens.colors.nodes.humanInput },
+    loopAgentflow: { icon: IconRepeat, color: tokens.colors.nodes.loop },
+    directReplyAgentflow: { icon: IconMessageCircleFilled, color: tokens.colors.nodes.directReply },
+    customFunctionAgentflow: { icon: IconFunctionFilled, color: tokens.colors.nodes.customFunction },
+    toolAgentflow: { icon: IconTools, color: tokens.colors.nodes.tool },
+    retrieverAgentflow: { icon: IconLibrary, color: tokens.colors.nodes.retriever },
+    conditionAgentAgentflow: { icon: IconSubtask, color: tokens.colors.nodes.conditionAgent },
+    stickyNoteAgentflow: { icon: IconNote, color: tokens.colors.nodes.stickyNote },
+    httpAgentflow: { icon: IconWorld, color: tokens.colors.nodes.http },
+    iterationAgentflow: { icon: IconRelationOneToManyFilled, color: tokens.colors.nodes.iteration },
+    executeFlowAgentflow: { icon: IconVectorBezier2, color: tokens.colors.nodes.executeFlow }
+}

--- a/packages/observe/src/core/primitives/index.ts
+++ b/packages/observe/src/core/primitives/index.ts
@@ -1,2 +1,4 @@
+export type { AgentflowIconEntry } from './agentflowIcons'
+export { AGENTFLOW_ICONS } from './agentflowIcons'
 export type { JsonToken, JsonTokenType, ParseResult } from './json'
 export { tokenizeJson, tryParseJson } from './json'

--- a/packages/observe/src/core/types/execution.ts
+++ b/packages/observe/src/core/types/execution.ts
@@ -48,24 +48,25 @@ export interface NodeExecutionOutput {
     [key: string]: unknown
 }
 
+// Iteration metadata (`parentNodeId`, `iterationIndex`, `iterationContext`) is
+// nested in `data`, not at the top level — matches the runtime emission in
+// `packages/server/src/utils/buildAgentflow.ts`.
+export interface NodeExecutionDataPayload {
+    name?: string
+    parentNodeId?: string
+    /** 0-based */
+    iterationIndex?: number
+    iterationContext?: Record<string, unknown>
+    [key: string]: unknown
+}
+
 export interface NodeExecutionData {
     nodeLabel: string
     nodeId: string
-    /**
-     * Node payload — the runtime emits this as `{ input, output, state, error, ... }`.
-     * `data.output` carries `content`, `timeMetadata`, `usageMetadata`, etc.
-     * Shape varies by node type, hence `Record<string, unknown>`.
-     */
-    data: Record<string, unknown>
+    data: NodeExecutionDataPayload
     previousNodeIds: string[]
     status: ExecutionState
-    /** Node type name — used for icon lookup */
     name?: string
-    /** Index within an iteration group (0-based) */
-    iterationIndex?: number
-    iterationContext?: Record<string, unknown>
-    /** Parent node ID for iteration child nodes */
-    parentNodeId?: string
 }
 
 // ============================================================================

--- a/packages/observe/src/core/types/execution.ts
+++ b/packages/observe/src/core/types/execution.ts
@@ -76,7 +76,12 @@ export interface ExecutionTreeNode {
     id: string
     nodeId: string
     nodeLabel: string
-    status: ExecutionState
+    /**
+     * `ExecutionState` for real nodes; virtual iteration nodes additionally
+     * surface `'UNKNOWN'` when the rollup over their children falls through
+     * (legacy ExecutionDetails.jsx:438-446 parity).
+     */
+    status: ExecutionState | 'UNKNOWN'
     /**
      * Resolved node type name — `useExecutionTree` always populates this for
      * non-virtual nodes (falling back to `data.name` then `nodeId.split('_')[0]`).

--- a/packages/observe/src/core/types/observe.ts
+++ b/packages/observe/src/core/types/observe.ts
@@ -4,7 +4,7 @@
 
 import type { InternalAxiosRequestConfig } from 'axios'
 
-import type { ExecutionFilters, HumanInputParams } from './execution'
+import type { AgentflowRef, ExecutionFilters, HumanInputParams } from './execution'
 
 /**
  * Callback to customize outgoing Axios requests.
@@ -65,6 +65,18 @@ export interface ExecutionsViewerProps {
     initialFilters?: Partial<ExecutionFilters>
     /** See ExecutionDetailProps.onAgentflowClick — threaded through to the detail drawer */
     onAgentflowClick?: (agentflowId: string) => void
+    /**
+     * Detail-drawer sizing overrides. Each key is independent — supply only
+     * the values you want to override. Defaults (legacy parity):
+     * `defaultWidth = max(minWidth, window.innerWidth - 400)`,
+     * `minWidth = 400`, `maxWidth = window.innerWidth`. The resolved default
+     * is clamped into `[minWidth, maxWidth]` if you pass inconsistent values.
+     */
+    drawer?: {
+        defaultWidth?: number
+        minWidth?: number
+        maxWidth?: number
+    }
 }
 
 // ============================================================================
@@ -86,4 +98,11 @@ export interface ExecutionDetailProps {
      * When absent, the name is rendered as plain text (or omitted if no name is available).
      */
     onAgentflowClick?: (agentflowId: string) => void
+    /**
+     * Optional agentflow info to seed the header chip while the detail endpoint
+     * loads (or when the server's `getExecutionById` doesn't perform the
+     * `agentflow` join — only the list endpoint does today). When the API
+     * response carries `execution.agentflow`, it takes precedence.
+     */
+    agentflow?: AgentflowRef
 }

--- a/packages/observe/src/features/executions/components/ExecutionDetail.test.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.test.tsx
@@ -273,7 +273,10 @@ describe('ExecutionDetail', () => {
             renderWithTheme(<ExecutionDetail executionId='exec-1' />)
             expect(screen.getByText('Copy ID')).toBeInTheDocument()
             await userEvent.click(screen.getByText('Copy ID'))
-            expect(screen.getByText('Copied!')).toBeInTheDocument()
+            // Scoped to the chip's role; `userEvent.click` opens the Tooltip
+            // popper (role='tooltip', also "Copied!"), so a plain `getByText`
+            // would match both elements.
+            expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument()
         })
 
         it('logs a warning when the clipboard write rejects', async () => {

--- a/packages/observe/src/features/executions/components/ExecutionDetail.test.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.test.tsx
@@ -1,0 +1,320 @@
+import React from 'react'
+
+import { ThemeProvider } from '@mui/material/styles'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { createObserveTheme } from '@/core/theme'
+import type { Execution, ExecutionState, NodeExecutionData } from '@/core/types'
+
+import { ExecutionDetail } from './ExecutionDetail'
+
+// ============================================================================
+// Mocks — keep the orchestrator under test, stub the heavy children.
+// useExecutionPoll is mocked so we control loading/error/data without timers.
+// ============================================================================
+
+const mockUseExecutionPoll = jest.fn()
+const mockRefresh = jest.fn()
+
+jest.mock('../hooks/useExecutionPoll', () => ({
+    useExecutionPoll: (opts: unknown) => mockUseExecutionPoll(opts)
+}))
+
+jest.mock('./NodeExecutionDetail', () => ({
+    NodeExecutionDetail: ({ node }: { node: { nodeLabel: string } }) => <div data-testid='node-execution-detail'>{node.nodeLabel}</div>
+}))
+
+// Atoms transitively pull in react-syntax-highlighter (ESM-only) — stub it.
+jest.mock('react-syntax-highlighter', () => ({ Prism: () => null }))
+jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
+
+jest.mock('@/infrastructure/store', () => ({
+    useObserveConfig: () => ({ isDarkMode: false, apiBaseUrl: 'http://localhost:3000' })
+}))
+
+// ============================================================================
+// Factories
+// ============================================================================
+
+function makeNode(overrides: Partial<NodeExecutionData> = {}): NodeExecutionData {
+    return {
+        nodeId: 'node-1',
+        nodeLabel: 'Step 1',
+        status: 'FINISHED',
+        data: {},
+        previousNodeIds: [],
+        ...overrides
+    }
+}
+
+function makeExecution(overrides: Partial<Execution> = {}, nodes: NodeExecutionData[] = [makeNode()]): Execution {
+    return {
+        id: 'exec-1',
+        executionData: JSON.stringify(nodes),
+        state: 'FINISHED' as ExecutionState,
+        agentflowId: 'flow-1',
+        sessionId: 'sess-1',
+        isPublic: false,
+        createdDate: '2026-01-01T00:00:00Z',
+        updatedDate: '2026-01-01T00:00:00Z',
+        ...overrides
+    }
+}
+
+interface PollResultOverrides {
+    execution?: Execution | null
+    isLoading?: boolean
+    error?: string | null
+    refresh?: () => void
+}
+
+function setPollResult(partial: PollResultOverrides = {}) {
+    mockUseExecutionPoll.mockReturnValue({
+        execution: makeExecution(),
+        isLoading: false,
+        error: null,
+        refresh: mockRefresh,
+        ...partial
+    })
+}
+
+function renderWithTheme(ui: React.ReactElement) {
+    return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+// ============================================================================
+
+describe('ExecutionDetail', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('async states', () => {
+        it('renders a loading spinner while the execution is loading', () => {
+            setPollResult({ execution: null, isLoading: true })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByRole('progressbar')).toBeInTheDocument()
+        })
+
+        it('renders the error message when the API fails', () => {
+            setPollResult({ execution: null, isLoading: false, error: 'Network error' })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByText('Network error')).toBeInTheDocument()
+        })
+
+        it('renders "Execution not found" when execution is null without an explicit error', () => {
+            setPollResult({ execution: null, isLoading: false })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByText('Execution not found')).toBeInTheDocument()
+        })
+    })
+
+    describe('initial selection', () => {
+        it('auto-selects the first top-level node on initial tree build', () => {
+            const nodes = [makeNode({ nodeId: 'a', nodeLabel: 'First' }), makeNode({ nodeId: 'b', nodeLabel: 'Second' })]
+            setPollResult({ execution: makeExecution({}, nodes) })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByTestId('node-execution-detail')).toHaveTextContent('First')
+        })
+
+        it('auto-selects the first STOPPED node when state is STOPPED', () => {
+            const nodes = [
+                makeNode({ nodeId: 'a', nodeLabel: 'Ran', status: 'FINISHED' }),
+                makeNode({ nodeId: 'b', nodeLabel: 'Halted', status: 'STOPPED' }),
+                makeNode({ nodeId: 'c', nodeLabel: 'NeverRan', status: 'STOPPED' })
+            ]
+            setPollResult({ execution: makeExecution({ state: 'STOPPED' }, nodes) })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByTestId('node-execution-detail')).toHaveTextContent('Halted')
+        })
+
+        it('falls back to the first top-level node when state is STOPPED but no node is STOPPED', () => {
+            const nodes = [makeNode({ nodeId: 'a', nodeLabel: 'OnlyOne', status: 'FINISHED' })]
+            setPollResult({ execution: makeExecution({ state: 'STOPPED' }, nodes) })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByTestId('node-execution-detail')).toHaveTextContent('OnlyOne')
+        })
+
+        it('shows the placeholder when the tree is empty', () => {
+            setPollResult({ execution: makeExecution({ executionData: '[]' }, []) })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByText(/Select a step to view details/i)).toBeInTheDocument()
+            expect(screen.queryByTestId('node-execution-detail')).not.toBeInTheDocument()
+        })
+
+        it('does not re-select when the execution re-polls', () => {
+            const nodes = [makeNode({ nodeId: 'a', nodeLabel: 'First' }), makeNode({ nodeId: 'b', nodeLabel: 'Second' })]
+            setPollResult({ execution: makeExecution({}, nodes) })
+            const { rerender } = renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByTestId('node-execution-detail')).toHaveTextContent('First')
+
+            // Simulate a re-poll where the execution data is replaced — the selection ref must hold.
+            const nextNodes = [makeNode({ nodeId: 'x', nodeLabel: 'Different' })]
+            setPollResult({ execution: makeExecution({}, nextNodes) })
+            rerender(
+                <ThemeProvider theme={createObserveTheme(false)}>
+                    <ExecutionDetail executionId='exec-1' />
+                </ThemeProvider>
+            )
+
+            expect(screen.getByTestId('node-execution-detail')).toHaveTextContent('First')
+        })
+    })
+
+    describe('sidebar header', () => {
+        it('renders the agentflow name as a clickable chip with the external-link icon when onAgentflowClick is provided', async () => {
+            setPollResult({
+                execution: makeExecution({ agentflow: { id: 'flow-1', name: 'My Flow' } })
+            })
+            const onAgentflowClick = jest.fn()
+            renderWithTheme(<ExecutionDetail executionId='exec-1' onAgentflowClick={onAgentflowClick} />)
+
+            const chip = screen.getByRole('button', { name: 'My Flow' })
+            // Visual distinction: clickable variant carries the IconExternalLink affordance.
+            expect(chip.querySelector('.tabler-icon-external-link')).not.toBeNull()
+
+            await userEvent.click(chip)
+            expect(onAgentflowClick).toHaveBeenCalledWith('flow-1')
+        })
+
+        it('renders the agentflow name as a non-clickable, icon-less chip when onAgentflowClick is absent', () => {
+            setPollResult({
+                execution: makeExecution({ agentflow: { id: 'flow-1', name: 'My Flow' } })
+            })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            // Label still shows…
+            expect(screen.getByText('My Flow')).toBeInTheDocument()
+            // …but the chip is not a button (no role) and carries no external-link affordance.
+            expect(screen.queryByRole('button', { name: 'My Flow' })).not.toBeInTheDocument()
+            expect(document.querySelector('.tabler-icon-external-link')).toBeNull()
+        })
+
+        it('renders a non-clickable "Go to AgentFlow" fallback chip when neither agentflow info nor onAgentflowClick is provided', () => {
+            // PARITY: legacy renders the chip unconditionally (gated only on `!isPublic`).
+            // Mirroring that, the non-clickable variant always renders with the trailing label fallback.
+            setPollResult({ execution: makeExecution({ agentflow: undefined }) })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByText(/Go to AgentFlow/i)).toBeInTheDocument()
+            // Still non-clickable — no role=button on the fallback chip.
+            expect(screen.queryByRole('button', { name: /Go to AgentFlow/i })).not.toBeInTheDocument()
+        })
+
+        it('falls back to "Go to AgentFlow" when onAgentflowClick is provided but the execution has no agentflow info', () => {
+            // PARITY: legacy renders the chip whenever a navigation target exists, falling back to "Go to AgentFlow" when no name/id is available on the execution.
+            setPollResult({ execution: makeExecution({ agentflow: undefined }) })
+            const onAgentflowClick = jest.fn()
+            renderWithTheme(<ExecutionDetail executionId='exec-1' onAgentflowClick={onAgentflowClick} />)
+
+            const chip = screen.getByRole('button', { name: /Go to AgentFlow/i })
+            expect(chip).toBeInTheDocument()
+        })
+
+        it('falls back to the `agentflow` prop when the detail endpoint does not return the join', () => {
+            // The server's getExecutionById doesn't perform the agentflow join — only
+            // getAllExecutions does. ExecutionsViewer threads the row's agentflow
+            // info into ExecutionDetail via this prop so the chip can render the real name.
+            setPollResult({ execution: makeExecution({ agentflow: undefined }) })
+            const onAgentflowClick = jest.fn()
+            renderWithTheme(
+                <ExecutionDetail
+                    executionId='exec-1'
+                    onAgentflowClick={onAgentflowClick}
+                    agentflow={{ id: 'flow-99', name: 'Seeded Flow' }}
+                />
+            )
+            expect(screen.getByRole('button', { name: 'Seeded Flow' })).toBeInTheDocument()
+        })
+
+        it('prefers execution.agentflow from the API over the `agentflow` prop fallback', () => {
+            // Once the server adds the join, the API response wins.
+            setPollResult({ execution: makeExecution({ agentflow: { id: 'flow-real', name: 'From API' } }) })
+            const onAgentflowClick = jest.fn()
+            renderWithTheme(
+                <ExecutionDetail
+                    executionId='exec-1'
+                    onAgentflowClick={onAgentflowClick}
+                    agentflow={{ id: 'flow-stale', name: 'Stale Prop' }}
+                />
+            )
+            expect(screen.getByRole('button', { name: 'From API' })).toBeInTheDocument()
+            expect(screen.queryByText('Stale Prop')).not.toBeInTheDocument()
+        })
+
+        it('falls back to agentflow.id when name is missing', () => {
+            setPollResult({ execution: makeExecution({ agentflow: { id: 'flow-1', name: '' as unknown as string } }) })
+            const onAgentflowClick = jest.fn()
+            renderWithTheme(<ExecutionDetail executionId='exec-1' onAgentflowClick={onAgentflowClick} />)
+            expect(screen.getByText('flow-1')).toBeInTheDocument()
+        })
+
+        it('calls refresh when the refresh button is clicked', async () => {
+            setPollResult({})
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            await userEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+            expect(mockRefresh).toHaveBeenCalledTimes(1)
+        })
+
+        it('writes the execution id to the clipboard when the Copy ID chip is clicked', async () => {
+            const writeText = jest.fn().mockResolvedValue(undefined)
+            Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+            setPollResult({})
+
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            await userEvent.click(screen.getByText('Copy ID'))
+            expect(writeText).toHaveBeenCalledWith('exec-1')
+        })
+
+        it('flips the Copy ID label to "Copied!" after click', async () => {
+            const writeText = jest.fn().mockResolvedValue(undefined)
+            Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+            setPollResult({})
+
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByText('Copy ID')).toBeInTheDocument()
+            await userEvent.click(screen.getByText('Copy ID'))
+            expect(screen.getByText('Copied!')).toBeInTheDocument()
+        })
+
+        it('logs a warning when the clipboard write rejects', async () => {
+            const writeText = jest.fn().mockRejectedValue(new Error('denied'))
+            Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+            const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+            setPollResult({})
+
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            await userEvent.click(screen.getByText('Copy ID'))
+
+            // Wait a microtask for the rejected promise to flush.
+            await act(async () => {})
+            expect(consoleWarn).toHaveBeenCalledWith('[Observe] Clipboard copy failed:', expect.any(Error))
+            consoleWarn.mockRestore()
+        })
+
+        it('does nothing when navigator.clipboard is undefined', async () => {
+            Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined })
+            setPollResult({})
+
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            // Should not throw.
+            await userEvent.click(screen.getByText('Copy ID'))
+        })
+
+        it('renders the formatted updated date', () => {
+            setPollResult({
+                execution: makeExecution({ updatedDate: '2026-04-29T15:30:00Z' })
+            })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            // Format: 'MMM d, yyyy h:mm a'. Time-zone-dependent — assert the date prefix and an h:mm a clock-time substring.
+            const datePrefix = screen.getByText(/Apr 29, 2026/i)
+            expect(datePrefix).toBeInTheDocument()
+            expect(datePrefix.textContent).toMatch(/\d{1,2}:\d{2} (AM|PM)/)
+        })
+
+        it('renders "N/A" when the execution has no updated date', () => {
+            setPollResult({ execution: makeExecution({ updatedDate: undefined as unknown as string }) })
+            renderWithTheme(<ExecutionDetail executionId='exec-1' />)
+            expect(screen.getByText('N/A')).toBeInTheDocument()
+        })
+    })
+})

--- a/packages/observe/src/features/executions/components/ExecutionDetail.test.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.test.tsx
@@ -279,7 +279,7 @@ describe('ExecutionDetail', () => {
             expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument()
         })
 
-        it('logs a warning when the clipboard write rejects', async () => {
+        it('logs a warning and leaves the chip on "Copy ID" when the clipboard write rejects', async () => {
             const writeText = jest.fn().mockRejectedValue(new Error('denied'))
             Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
             const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
@@ -291,6 +291,9 @@ describe('ExecutionDetail', () => {
             // Wait a microtask for the rejected promise to flush.
             await act(async () => {})
             expect(consoleWarn).toHaveBeenCalledWith('[Observe] Clipboard copy failed:', expect.any(Error))
+            // The chip must NOT flash "Copied!" when the write fails.
+            expect(screen.queryByRole('button', { name: 'Copied!' })).not.toBeInTheDocument()
+            expect(screen.getByText('Copy ID')).toBeInTheDocument()
             consoleWarn.mockRestore()
         })
 

--- a/packages/observe/src/features/executions/components/ExecutionDetail.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.tsx
@@ -91,13 +91,18 @@ export function ExecutionDetail({
 
     const formattedUpdatedDate = useMemo(() => formatUpdatedDate(execution?.updatedDate), [execution?.updatedDate])
 
+    useEffect(() => {
+        if (!copied) return
+        const timer = setTimeout(() => setCopied(false), 2000)
+        return () => clearTimeout(timer)
+    }, [copied])
+
     const copyId = () => {
         if (navigator.clipboard) {
             navigator.clipboard.writeText(executionId).catch((err) => {
                 console.warn('[Observe] Clipboard copy failed:', err)
             })
             setCopied(true)
-            setTimeout(() => setCopied(false), 2000)
         }
     }
 

--- a/packages/observe/src/features/executions/components/ExecutionDetail.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.tsx
@@ -98,12 +98,13 @@ export function ExecutionDetail({
     }, [copied])
 
     const copyId = () => {
-        if (navigator.clipboard) {
-            navigator.clipboard.writeText(executionId).catch((err) => {
+        if (!navigator.clipboard) return
+        navigator.clipboard
+            .writeText(executionId)
+            .then(() => setCopied(true))
+            .catch((err) => {
                 console.warn('[Observe] Clipboard copy failed:', err)
             })
-            setCopied(true)
-        }
     }
 
     if (isLoading) {

--- a/packages/observe/src/features/executions/components/ExecutionDetail.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionDetail.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { Box, Chip, CircularProgress, IconButton, Stack, Tooltip, Typography, useMediaQuery } from '@mui/material'
+import { Box, Chip, CircularProgress, IconButton, Tooltip, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
-import { IconCopy, IconRefresh } from '@tabler/icons-react'
+import { IconCopy, IconExternalLink, IconRefresh } from '@tabler/icons-react'
+import { format as formatDate, parseISO } from 'date-fns'
 
-import { StatusIndicator } from '@/atoms'
-import type { ExecutionDetailProps, ExecutionState, ExecutionTreeNode } from '@/core/types'
+import type { ExecutionDetailProps, ExecutionTreeNode } from '@/core/types'
 
 import { useExecutionPoll } from '../hooks/useExecutionPoll'
 import { useExecutionTree } from '../hooks/useExecutionTree'
@@ -14,34 +14,82 @@ import { useResizableSidebar } from '../hooks/useResizableSidebar'
 import { ExecutionTreeSidebar } from './ExecutionTreeSidebar'
 import { NodeExecutionDetail } from './NodeExecutionDetail'
 
-const MIN_SIDEBAR_WIDTH = 180
+const MIN_SIDEBAR_WIDTH = 240
 const MAX_SIDEBAR_WIDTH = 480
-const DEFAULT_SIDEBAR_WIDTH_WIDE = 300
-const DEFAULT_SIDEBAR_WIDTH_NARROW = 220
+const DEFAULT_SIDEBAR_WIDTH = 300
 
-/**
- * Full execution detail view: resizable tree sidebar (left) + node detail panel (right).
- * Fetches the execution by ID and auto-polls while INPROGRESS.
- */
+function findFirstStoppedNode(nodes: ExecutionTreeNode[]): ExecutionTreeNode | null {
+    for (const node of nodes) {
+        if (!node.isVirtualNode && node.status === 'STOPPED') return node
+        const found = findFirstStoppedNode(node.children)
+        if (found) return found
+    }
+    return null
+}
+
+function findFirstSelectableNode(nodes: ExecutionTreeNode[]): ExecutionTreeNode | null {
+    for (const node of nodes) {
+        if (!node.isVirtualNode) return node
+        const found = findFirstSelectableNode(node.children)
+        if (found) return found
+    }
+    return null
+}
+
+function collectAllIds(nodes: ExecutionTreeNode[]): string[] {
+    const ids: string[] = []
+    for (const node of nodes) {
+        ids.push(node.id)
+        if (node.children.length > 0) ids.push(...collectAllIds(node.children))
+    }
+    return ids
+}
+
+// PARITY: legacy uses moment(d).format('MMM D, YYYY h:mm A'). date-fns 'MMM d, yyyy h:mm a' produces the same en-US output.
+function formatUpdatedDate(iso: string | undefined): string {
+    if (!iso) return 'N/A'
+    try {
+        return formatDate(parseISO(iso), 'MMM d, yyyy h:mm a')
+    } catch {
+        return 'N/A'
+    }
+}
+
 export function ExecutionDetail({
     executionId,
     pollInterval = 3000,
     onHumanInput,
     onClose: _onClose,
-    onAgentflowClick
+    onAgentflowClick,
+    agentflow: agentflowProp
 }: ExecutionDetailProps) {
     const theme = useTheme()
-    const isNarrowViewport = useMediaQuery(theme.breakpoints.down('lg'))
-    const defaultSidebarWidth = isNarrowViewport ? DEFAULT_SIDEBAR_WIDTH_NARROW : DEFAULT_SIDEBAR_WIDTH_WIDE
     const { execution, isLoading, error, refresh } = useExecutionPoll({ executionId, pollInterval })
     const tree = useExecutionTree(execution?.executionData ?? null)
     const [selectedNode, setSelectedNode] = useState<ExecutionTreeNode | null>(null)
+    const [expandedIds, setExpandedIds] = useState<string[]>([])
     const { width: sidebarWidth, onMouseDown: onSidebarHandleMouseDown } = useResizableSidebar({
-        defaultWidth: defaultSidebarWidth,
+        defaultWidth: DEFAULT_SIDEBAR_WIDTH,
         minWidth: MIN_SIDEBAR_WIDTH,
         maxWidth: MAX_SIDEBAR_WIDTH
     })
     const [copied, setCopied] = useState(false)
+    const hasInitializedRef = useRef(false)
+
+    // PARITY: legacy ExecutionDetails opens with all nodes expanded and selects the first STOPPED node when state==='STOPPED', else the first top-level node — only on initial tree build so re-polls don't yank the selection.
+    useEffect(() => {
+        if (hasInitializedRef.current) return
+        if (tree.length === 0) return
+        const initial =
+            execution?.state === 'STOPPED' ? findFirstStoppedNode(tree) ?? findFirstSelectableNode(tree) : findFirstSelectableNode(tree)
+        if (initial) {
+            setSelectedNode(initial)
+            setExpandedIds(collectAllIds(tree))
+            hasInitializedRef.current = true
+        }
+    }, [tree, execution?.state])
+
+    const formattedUpdatedDate = useMemo(() => formatUpdatedDate(execution?.updatedDate), [execution?.updatedDate])
 
     const copyId = () => {
         if (navigator.clipboard) {
@@ -69,80 +117,108 @@ export function ExecutionDetail({
         )
     }
 
+    // The detail endpoint doesn't perform the agentflow join; fall back to the
+    // optional prop (typically passed from ExecutionsViewer's list response).
+    const agentflow = execution.agentflow ?? agentflowProp
+    // PARITY: chained `||` (not `??`) so empty strings fall through to the next option, matching legacy.
+    const agentflowChipLabel = agentflow?.name || agentflow?.id || 'Go to AgentFlow'
+
     return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-            {/* Toolbar */}
-            <Stack
-                direction='row'
-                spacing={1}
-                alignItems='center'
-                sx={{ px: 2, py: 1, borderBottom: `1px solid ${theme.palette.divider}`, flexShrink: 0 }}
-            >
-                <StatusIndicator state={execution.state as ExecutionState} size={16} />
-                <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>
-                    {execution.state}
-                </Typography>
-                <Tooltip title={copied ? 'Copied!' : `ID: ${execution.id}`}>
-                    <IconButton size='small' onClick={copyId}>
-                        <IconCopy size={14} />
-                    </IconButton>
-                </Tooltip>
-                {execution.agentflow &&
-                    (onAgentflowClick ? (
-                        <Chip
-                            label={execution.agentflow.name}
-                            size='small'
-                            clickable
-                            onClick={() => onAgentflowClick(execution.agentflowId)}
-                        />
-                    ) : (
-                        <Typography variant='body2' color='text.secondary'>
-                            {execution.agentflow.name}
-                        </Typography>
-                    ))}
-                <Box sx={{ flex: 1 }} />
-                <Tooltip title='Refresh'>
-                    <IconButton size='small' onClick={refresh}>
-                        <IconRefresh size={14} />
-                    </IconButton>
-                </Tooltip>
-            </Stack>
-
-            {/* Split pane */}
-            <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
-                <Box sx={{ width: sidebarWidth, flexShrink: 0, overflow: 'auto', borderRight: `1px solid ${theme.palette.divider}` }}>
-                    <ExecutionTreeSidebar tree={tree} selectedId={selectedNode?.id ?? null} onSelect={setSelectedNode} />
-                </Box>
-
-                {/* Drag handle */}
+        <Box sx={{ display: 'flex', flex: 1, height: '100%', overflow: 'hidden' }}>
+            <Box sx={{ width: sidebarWidth, flexShrink: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                {/* Header — chips + date/refresh row, rendered above the tree (parity with legacy). */}
                 <Box
-                    onMouseDown={onSidebarHandleMouseDown}
                     sx={{
-                        width: 4,
-                        cursor: 'col-resize',
-                        flexShrink: 0,
-                        backgroundColor: 'transparent',
-                        '&:hover': { backgroundColor: theme.palette.primary.main }
+                        p: 2,
+                        pb: 1,
+                        backgroundColor: theme.palette.background.paper,
+                        borderBottom: `1px solid ${theme.palette.divider}`,
+                        flexShrink: 0
                     }}
-                />
+                >
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                        {onAgentflowClick ? (
+                            <Chip
+                                sx={{ pl: 1 }}
+                                icon={<IconExternalLink size={15} />}
+                                variant='outlined'
+                                label={agentflowChipLabel}
+                                clickable
+                                onClick={() => onAgentflowClick(execution.agentflowId)}
+                            />
+                        ) : (
+                            <Chip variant='outlined' label={agentflowChipLabel} />
+                        )}
 
-                {/* Node detail panel */}
-                <Box sx={{ flex: 1, overflow: 'hidden' }}>
-                    {selectedNode ? (
-                        <NodeExecutionDetail
-                            node={selectedNode}
-                            agentflowId={execution.agentflowId}
-                            sessionId={execution.sessionId}
-                            onHumanInput={onHumanInput}
-                        />
-                    ) : (
-                        <Box sx={{ p: 3 }}>
-                            <Typography variant='body2' color='text.secondary'>
-                                Select a step to view details.
-                            </Typography>
-                        </Box>
-                    )}
+                        <Tooltip
+                            title={copied ? 'Copied!' : `Execution ID: ${execution.id}`}
+                            placement='top'
+                            disableHoverListener={!execution.id}
+                        >
+                            <Chip
+                                sx={{ pl: 1 }}
+                                icon={<IconCopy size={15} />}
+                                variant='outlined'
+                                label={copied ? 'Copied!' : 'Copy ID'}
+                                clickable
+                                onClick={copyId}
+                            />
+                        </Tooltip>
+                    </Box>
+
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 1 }}>
+                        <Typography sx={{ flex: 1 }} color='text.primary'>
+                            {formattedUpdatedDate}
+                        </Typography>
+                        <Tooltip title='Refresh'>
+                            <IconButton onClick={refresh} size='small'>
+                                <IconRefresh size={20} />
+                            </IconButton>
+                        </Tooltip>
+                    </Box>
                 </Box>
+
+                {/* Tree — fills remaining sidebar height, scrolls independently. */}
+                <Box sx={{ flex: 1, overflow: 'auto', p: 1 }}>
+                    <ExecutionTreeSidebar
+                        tree={tree}
+                        selectedId={selectedNode?.id ?? null}
+                        onSelect={setSelectedNode}
+                        expandedIds={expandedIds}
+                        onExpandedChange={setExpandedIds}
+                    />
+                </Box>
+            </Box>
+
+            {/* Drag handle */}
+            <Box
+                onMouseDown={onSidebarHandleMouseDown}
+                sx={{
+                    width: 4,
+                    cursor: 'col-resize',
+                    flexShrink: 0,
+                    backgroundColor: 'transparent',
+                    borderRight: `1px solid ${theme.palette.divider}`,
+                    '&:hover': { backgroundColor: theme.palette.primary.main }
+                }}
+            />
+
+            {/* Detail panel */}
+            <Box sx={{ flex: 1, overflow: 'auto' }}>
+                {selectedNode ? (
+                    <NodeExecutionDetail
+                        node={selectedNode}
+                        agentflowId={execution.agentflowId}
+                        sessionId={execution.sessionId}
+                        onHumanInput={onHumanInput}
+                    />
+                ) : (
+                    <Box sx={{ p: 3 }}>
+                        <Typography variant='body2' color='text.secondary'>
+                            Select a step to view details.
+                        </Typography>
+                    </Box>
+                )}
             </Box>
         </Box>
     )

--- a/packages/observe/src/features/executions/components/ExecutionTreeSidebar.test.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionTreeSidebar.test.tsx
@@ -191,7 +191,7 @@ describe('ExecutionTreeSidebar', () => {
     })
 
     describe('selection', () => {
-        it('fires onSelect with the clicked node (skipping virtual nodes)', async () => {
+        it('fires onSelect for real and virtual nodes — legacy parity', async () => {
             const onSelect = jest.fn()
             const tree = [
                 makeNode({ id: 'real', nodeId: 'real', nodeLabel: 'Real' }),
@@ -211,9 +211,9 @@ describe('ExecutionTreeSidebar', () => {
             expect(onSelect).toHaveBeenCalledTimes(1)
             expect(onSelect.mock.calls[0][0].nodeId).toBe('real')
 
-            // Clicking the virtual row must NOT call onSelect.
             await userEvent.click(screen.getByText('Iteration #0'))
-            expect(onSelect).toHaveBeenCalledTimes(1)
+            expect(onSelect).toHaveBeenCalledTimes(2)
+            expect(onSelect.mock.calls[1][0].nodeId).toBe('iter-0')
         })
     })
 

--- a/packages/observe/src/features/executions/components/ExecutionTreeSidebar.test.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionTreeSidebar.test.tsx
@@ -1,15 +1,16 @@
-import type { ReactElement } from 'react'
+import { type ReactElement, useState } from 'react'
 
 import { ThemeProvider } from '@mui/material/styles'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
+import { AGENTFLOW_ICONS } from '@/core/primitives'
 import { createObserveTheme } from '@/core/theme'
 import type { ExecutionTreeNode } from '@/core/types'
 
 import { ExecutionTreeSidebar } from './ExecutionTreeSidebar'
 
-// Stub the syntax highlighter pulled in transitively via @/atoms
-// (CodeFenceBlock → react-syntax-highlighter, ESM-only).
+// Stub the syntax highlighter pulled in transitively via @/atoms.
 jest.mock('react-syntax-highlighter', () => ({ Prism: () => null }))
 jest.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({ oneDark: {} }))
 
@@ -19,6 +20,43 @@ jest.mock('@/infrastructure/store', () => ({
 
 function renderWithTheme(ui: ReactElement) {
     return render(<ThemeProvider theme={createObserveTheme(false)}>{ui}</ThemeProvider>)
+}
+
+function collectAllIds(nodes: ExecutionTreeNode[]): string[] {
+    const ids: string[] = []
+    for (const node of nodes) {
+        ids.push(node.id)
+        if (node.children.length > 0) ids.push(...collectAllIds(node.children))
+    }
+    return ids
+}
+
+interface HarnessProps {
+    tree: ExecutionTreeNode[]
+    onSelect?: (node: ExecutionTreeNode) => void
+    initialExpanded?: string[]
+}
+
+/**
+ * Wrapper that owns the controlled selectedId/expandedIds state, mirroring
+ * the contract `ExecutionDetail` provides in production. Tests assert against
+ * what reaches the DOM through this contract.
+ */
+function Harness({ tree, onSelect, initialExpanded }: HarnessProps) {
+    const [selectedId, setSelectedId] = useState<string | null>(null)
+    const [expandedIds, setExpandedIds] = useState<string[]>(initialExpanded ?? collectAllIds(tree))
+    return (
+        <ExecutionTreeSidebar
+            tree={tree}
+            selectedId={selectedId}
+            onSelect={(node) => {
+                setSelectedId(node.id)
+                onSelect?.(node)
+            }}
+            expandedIds={expandedIds}
+            onExpandedChange={setExpandedIds}
+        />
+    )
 }
 
 function makeNode(overrides: Partial<ExecutionTreeNode> = {}): ExecutionTreeNode {
@@ -36,7 +74,7 @@ function makeNode(overrides: Partial<ExecutionTreeNode> = {}): ExecutionTreeNode
 describe('ExecutionTreeSidebar', () => {
     describe('empty state', () => {
         it('renders the empty placeholder when tree is []', () => {
-            renderWithTheme(<ExecutionTreeSidebar tree={[]} selectedId={null} onSelect={jest.fn()} />)
+            renderWithTheme(<Harness tree={[]} />)
             expect(screen.getByText(/No execution steps recorded/i)).toBeInTheDocument()
         })
     })
@@ -47,12 +85,12 @@ describe('ExecutionTreeSidebar', () => {
                 makeNode({ id: 'a', nodeId: 'a', nodeLabel: 'Start' }),
                 makeNode({ id: 'b', nodeId: 'b', nodeLabel: 'Agent', name: 'agentAgentflow' })
             ]
-            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={jest.fn()} />)
+            renderWithTheme(<Harness tree={tree} />)
             expect(screen.getByText('Start')).toBeInTheDocument()
             expect(screen.getByText('Agent')).toBeInTheDocument()
         })
 
-        it('recursively renders child rows under their parent', () => {
+        it('recursively renders child rows when the parent is expanded', () => {
             const tree = [
                 makeNode({
                     id: 'parent',
@@ -62,73 +100,125 @@ describe('ExecutionTreeSidebar', () => {
                     children: [makeNode({ id: 'child', nodeId: 'child', nodeLabel: 'Inner Step' })]
                 })
             ]
-            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={jest.fn()} />)
+            renderWithTheme(<Harness tree={tree} />)
             expect(screen.getByText('Loop')).toBeInTheDocument()
             expect(screen.getByText('Inner Step')).toBeInTheDocument()
         })
 
-        it('renders virtual iteration container nodes as italic captions instead of clickable rows', () => {
+        it('renders the iteration icon for virtual iteration container nodes', () => {
             const tree: ExecutionTreeNode[] = [
                 {
                     id: 'iter-0',
                     nodeId: 'iter-0',
-                    nodeLabel: 'Iteration #1',
+                    nodeLabel: 'Iteration #0',
                     status: 'FINISHED',
                     isVirtualNode: true,
-                    name: '',
+                    name: 'iterationAgentflow',
                     children: []
                 }
             ]
-            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={jest.fn()} />)
-            const label = screen.getByText('Iteration #1')
-            expect(label).toBeInTheDocument()
-            // Virtual labels render as a Typography caption with italic style;
-            // not wrapped in the clickable Box's role-pointer cursor.
-            expect(label.tagName.toLowerCase()).toBe('span')
+            renderWithTheme(<Harness tree={tree} />)
+            // Iteration row shows its label …
+            expect(screen.getByText('Iteration #0')).toBeInTheDocument()
+            // … and the AGENTFLOW_ICONS lookup renders the iteration icon
+            // (`IconRelationOneToManyFilled`). The DOM only locks the icon
+            // identity; the registry assertion below locks its color.
+            const treeitem = screen.getByRole('treeitem')
+            expect(treeitem.querySelector('.tabler-icon-relation-one-to-many-filled')).not.toBeNull()
+            expect(AGENTFLOW_ICONS.iterationAgentflow.icon).toBeDefined()
+            expect(AGENTFLOW_ICONS.iterationAgentflow.color).toMatch(/^#[0-9a-fA-F]{6}$/)
+        })
+
+        it.each([
+            ['FINISHED', 'CheckCircleIcon'],
+            ['ERROR', 'ErrorIcon'],
+            ['TIMEOUT', 'ErrorIcon'],
+            ['STOPPED', 'StopCircleIcon']
+        ] as const)('renders the %s status icon as MUI %s', (state, testId) => {
+            const tree = [makeNode({ id: 'a', nodeId: 'a', status: state })]
+            renderWithTheme(<Harness tree={tree} />)
+            expect(screen.getByTestId(testId)).toBeInTheDocument()
+        })
+
+        it('renders TERMINATED with the tabler IconCircleXFilled (no MUI icon test-id)', () => {
+            const tree = [makeNode({ id: 'a', nodeId: 'a', status: 'TERMINATED' })]
+            renderWithTheme(<Harness tree={tree} />)
+            // Tabler icons don't expose data-testid; assert via class.
+            expect(document.querySelector('.tabler-icon-circle-x-filled')).not.toBeNull()
+            // No MUI status icon should be rendered for TERMINATED.
+            expect(screen.queryByTestId('CheckCircleIcon')).not.toBeInTheDocument()
+        })
+
+        it('renders INPROGRESS with the tabler IconLoader spin animation', () => {
+            const tree = [makeNode({ id: 'a', nodeId: 'a', status: 'INPROGRESS' })]
+            renderWithTheme(<Harness tree={tree} />)
+            expect(document.querySelector('.tabler-icon-loader')).not.toBeNull()
+        })
+
+        it('renders the rolled-up status icon on virtual iteration rows (legacy parity)', () => {
+            const tree: ExecutionTreeNode[] = [
+                {
+                    id: 'iter-0',
+                    nodeId: 'iter-0',
+                    nodeLabel: 'Iteration #0',
+                    status: 'FINISHED',
+                    isVirtualNode: true,
+                    name: 'iterationAgentflow',
+                    children: []
+                }
+            ]
+            renderWithTheme(<Harness tree={tree} />)
+            expect(screen.getByTestId('CheckCircleIcon')).toBeInTheDocument()
+        })
+
+        it('omits the status icon when virtual iteration status is UNKNOWN', () => {
+            const tree: ExecutionTreeNode[] = [
+                {
+                    id: 'iter-0',
+                    nodeId: 'iter-0',
+                    nodeLabel: 'Iteration #0',
+                    status: 'UNKNOWN',
+                    isVirtualNode: true,
+                    name: 'iterationAgentflow',
+                    children: []
+                }
+            ]
+            renderWithTheme(<Harness tree={tree} />)
+            expect(screen.queryByTestId('CheckCircleIcon')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('ErrorIcon')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('StopCircleIcon')).not.toBeInTheDocument()
         })
     })
 
     describe('selection', () => {
-        it('fires onSelect with the clicked node (skipping virtual nodes)', () => {
+        it('fires onSelect with the clicked node (skipping virtual nodes)', async () => {
             const onSelect = jest.fn()
             const tree = [
                 makeNode({ id: 'real', nodeId: 'real', nodeLabel: 'Real' }),
                 {
                     id: 'iter-0',
                     nodeId: 'iter-0',
-                    nodeLabel: 'Iteration #1',
+                    nodeLabel: 'Iteration #0',
                     status: 'FINISHED' as const,
                     isVirtualNode: true,
-                    name: '',
+                    name: 'iterationAgentflow',
                     children: []
                 }
             ]
-            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={onSelect} />)
+            renderWithTheme(<Harness tree={tree} onSelect={onSelect} />)
 
-            fireEvent.click(screen.getByText('Real'))
+            await userEvent.click(screen.getByText('Real'))
             expect(onSelect).toHaveBeenCalledTimes(1)
             expect(onSelect.mock.calls[0][0].nodeId).toBe('real')
 
             // Clicking the virtual row must NOT call onSelect.
-            fireEvent.click(screen.getByText('Iteration #1'))
+            await userEvent.click(screen.getByText('Iteration #0'))
             expect(onSelect).toHaveBeenCalledTimes(1)
-        })
-
-        it('still calls onSelect on a row even when it matches selectedId (idempotent re-click)', () => {
-            // Sanity: passing selectedId doesn't disable the row's click target.
-            // (MUI's `sx` background highlight isn't observable from jsdom's
-            // computed style, so we anchor on the click behavior here.)
-            const onSelect = jest.fn()
-            const tree = [makeNode({ id: 'a', nodeId: 'a', nodeLabel: 'First' })]
-            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId='a' onSelect={onSelect} />)
-            fireEvent.click(screen.getByText('First'))
-            expect(onSelect).toHaveBeenCalledTimes(1)
-            expect(onSelect.mock.calls[0][0].nodeId).toBe('a')
         })
     })
 
     describe('expand/collapse', () => {
-        it('renders children expanded by default', () => {
+        it('renders children when initialExpanded includes the parent id', () => {
             const tree = [
                 makeNode({
                     id: 'parent',
@@ -137,12 +227,11 @@ describe('ExecutionTreeSidebar', () => {
                     children: [makeNode({ id: 'child', nodeId: 'child', nodeLabel: 'Child' })]
                 })
             ]
-            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={jest.fn()} />)
+            renderWithTheme(<Harness tree={tree} initialExpanded={['parent']} />)
             expect(screen.getByText('Child')).toBeInTheDocument()
         })
 
-        it('toggles children visibility when a parent row with children is clicked', () => {
-            const onSelect = jest.fn()
+        it('omits children when initialExpanded is empty', () => {
             const tree = [
                 makeNode({
                     id: 'parent',
@@ -151,14 +240,8 @@ describe('ExecutionTreeSidebar', () => {
                     children: [makeNode({ id: 'child', nodeId: 'child', nodeLabel: 'Child' })]
                 })
             ]
-            renderWithTheme(<ExecutionTreeSidebar tree={tree} selectedId={null} onSelect={onSelect} />)
-            expect(screen.getByText('Child')).toBeInTheDocument()
-
-            fireEvent.click(screen.getByText('Parent'))
+            renderWithTheme(<Harness tree={tree} initialExpanded={[]} />)
             expect(screen.queryByText('Child')).not.toBeInTheDocument()
-
-            fireEvent.click(screen.getByText('Parent'))
-            expect(screen.getByText('Child')).toBeInTheDocument()
         })
     })
 })

--- a/packages/observe/src/features/executions/components/ExecutionTreeSidebar.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionTreeSidebar.tsx
@@ -71,11 +71,10 @@ export function ExecutionTreeSidebar({ tree, selectedId, onSelect, expandedIds, 
         )
     }
 
-    // PARITY: virtual iteration container nodes are not selectable in legacy.
     const handleSelect = (_: unknown, itemId: string | null) => {
         if (!itemId) return
         const node = indexed.get(itemId)
-        if (!node || node.isVirtualNode) return
+        if (!node) return
         onSelect(node)
     }
 

--- a/packages/observe/src/features/executions/components/ExecutionTreeSidebar.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionTreeSidebar.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useMemo } from 'react'
 
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import ErrorIcon from '@mui/icons-material/Error'
@@ -58,6 +58,9 @@ function indexTree(nodes: ExecutionTreeNode[], out: Map<string, ExecutionTreeNod
  * icons on the right, virtual iteration nodes use the iteration icon.
  */
 export function ExecutionTreeSidebar({ tree, selectedId, onSelect, expandedIds, onExpandedChange }: ExecutionTreeSidebarProps) {
+    // Declared before the early return so the hook count stays stable across renders.
+    const indexed = useMemo(() => indexTree(tree), [tree])
+
     if (tree.length === 0) {
         return (
             <Box sx={{ p: 2 }}>
@@ -68,7 +71,6 @@ export function ExecutionTreeSidebar({ tree, selectedId, onSelect, expandedIds, 
         )
     }
 
-    const indexed = indexTree(tree)
     // PARITY: virtual iteration container nodes are not selectable in legacy.
     const handleSelect = (_: unknown, itemId: string | null) => {
         if (!itemId) return

--- a/packages/observe/src/features/executions/components/ExecutionTreeSidebar.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionTreeSidebar.tsx
@@ -1,23 +1,63 @@
-import { useState } from 'react'
+import { forwardRef } from 'react'
 
-import { Box, Divider, Typography } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ErrorIcon from '@mui/icons-material/Error'
+import StopCircleIcon from '@mui/icons-material/StopCircle'
+import { Box, Typography } from '@mui/material'
+import { alpha, keyframes, styled, useTheme } from '@mui/material/styles'
+import { RichTreeView } from '@mui/x-tree-view/RichTreeView'
+import {
+    TreeItem2Checkbox,
+    TreeItem2Content,
+    TreeItem2GroupTransition,
+    TreeItem2IconContainer,
+    TreeItem2Label,
+    TreeItem2Root
+} from '@mui/x-tree-view/TreeItem2'
+import { TreeItem2DragAndDropOverlay } from '@mui/x-tree-view/TreeItem2DragAndDropOverlay'
+import { TreeItem2Icon } from '@mui/x-tree-view/TreeItem2Icon'
+import { TreeItem2Provider } from '@mui/x-tree-view/TreeItem2Provider'
+import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2'
+import { IconCircleXFilled, IconLoader } from '@tabler/icons-react'
 
-import { NodeIcon, StatusIndicator } from '@/atoms'
+import { AGENTFLOW_ICONS } from '@/core/primitives'
 import type { ExecutionState, ExecutionTreeNode } from '@/core/types'
-import { useObserveConfig } from '@/infrastructure/store'
 
 interface ExecutionTreeSidebarProps {
     tree: ExecutionTreeNode[]
     selectedId: string | null
     onSelect: (node: ExecutionTreeNode) => void
+    expandedIds: string[]
+    onExpandedChange: (ids: string[]) => void
+}
+
+// `RichTreeView` is typed against a structural item shape; we hand it our
+// ExecutionTreeNode tree and project id/label via `getItemId` / `getItemLabel`.
+// This narrowed view exposes the only fields the tree code reads through the
+// `items` prop, so the cast is centralized in one place instead of leaking
+// `as unknown as …` into every callback.
+type RichTreeViewItem = { id: string; nodeLabel: string; children?: RichTreeViewItem[] }
+
+function toRichItems(nodes: ExecutionTreeNode[]): RichTreeViewItem[] {
+    return nodes as unknown as RichTreeViewItem[]
+}
+
+/** Recursive map indexed by item id — used inside the slot to resolve raw node fields. */
+function indexTree(nodes: ExecutionTreeNode[], out: Map<string, ExecutionTreeNode> = new Map()): Map<string, ExecutionTreeNode> {
+    for (const node of nodes) {
+        out.set(node.id, node)
+        if (node.children.length > 0) indexTree(node.children, out)
+    }
+    return out
 }
 
 /**
- * Recursive tree of nodes for the left pane of `ExecutionDetail`. Virtual
- * iteration container nodes render as italic captions and are not selectable.
+ * Sidebar tree built on `@mui/x-tree-view`'s `RichTreeView`. Visual parity with
+ * legacy `ExecutionDetails.jsx`: per-branch border (3px solid when the parent
+ * is selected, 1px dashed otherwise) colored from `AGENTFLOW_ICONS`, status
+ * icons on the right, virtual iteration nodes use the iteration icon.
  */
-export function ExecutionTreeSidebar({ tree, selectedId, onSelect }: ExecutionTreeSidebarProps) {
+export function ExecutionTreeSidebar({ tree, selectedId, onSelect, expandedIds, onExpandedChange }: ExecutionTreeSidebarProps) {
     if (tree.length === 0) {
         return (
             <Box sx={{ p: 2 }}>
@@ -28,80 +68,182 @@ export function ExecutionTreeSidebar({ tree, selectedId, onSelect }: ExecutionTr
         )
     }
 
-    return <TreeNodeList nodes={tree} selectedId={selectedId} onSelect={onSelect} depth={0} />
-}
+    const indexed = indexTree(tree)
+    // PARITY: virtual iteration container nodes are not selectable in legacy.
+    const handleSelect = (_: unknown, itemId: string | null) => {
+        if (!itemId) return
+        const node = indexed.get(itemId)
+        if (!node || node.isVirtualNode) return
+        onSelect(node)
+    }
 
-interface TreeNodeListProps {
-    nodes: ExecutionTreeNode[]
-    selectedId: string | null
-    onSelect: (node: ExecutionTreeNode) => void
-    depth: number
-}
+    const handleExpandedChange = (_: unknown, ids: string[]) => onExpandedChange(ids)
 
-function TreeNodeList({ nodes, selectedId, onSelect, depth }: TreeNodeListProps) {
     return (
-        <>
-            {nodes.map((node) => (
-                <TreeNodeItem key={node.id} node={node} selectedId={selectedId} onSelect={onSelect} depth={depth} />
-            ))}
-        </>
+        <RichTreeView
+            items={toRichItems(tree)}
+            getItemId={(item) => item.id}
+            getItemLabel={(item) => item.nodeLabel}
+            expandedItems={expandedIds}
+            onExpandedItemsChange={handleExpandedChange}
+            selectedItems={selectedId ?? null}
+            onSelectedItemsChange={handleSelect}
+            slots={{ item: CustomTreeItem }}
+        />
     )
 }
 
-interface TreeNodeItemProps {
-    node: ExecutionTreeNode
-    selectedId: string | null
-    onSelect: (node: ExecutionTreeNode) => void
-    depth: number
+// ---------------------------------------------------------------------------
+// Slot: custom tree item with status icon, branch border, DnD overlay
+// ---------------------------------------------------------------------------
+
+const StyledTreeItemRoot = styled(TreeItem2Root)(({ theme }) => ({
+    color: theme.palette.grey[400]
+}))
+
+const CustomTreeItemContent = styled(TreeItem2Content)(({ theme }) => ({
+    flexDirection: 'row-reverse',
+    borderRadius: theme.spacing(0.7),
+    marginBottom: theme.spacing(0.5),
+    marginTop: theme.spacing(0.5),
+    padding: theme.spacing(0.5),
+    paddingRight: theme.spacing(1),
+    fontWeight: 500,
+    '&.Mui-expanded': {
+        '&::before': {
+            content: '""',
+            display: 'block',
+            position: 'absolute',
+            left: '16px',
+            top: '44px',
+            height: 'calc(100% - 48px)',
+            width: '1.5px',
+            backgroundColor: theme.palette.grey[700],
+            ...theme.applyStyles?.('light', { backgroundColor: theme.palette.grey[300] })
+        }
+    },
+    '&:hover': {
+        backgroundColor: alpha(theme.palette.primary.main, 0.1)
+    },
+    '&.Mui-focused, &.Mui-selected, &.Mui-selected.Mui-focused': {
+        backgroundColor: theme.palette.primary.dark,
+        color: theme.palette.primary.contrastText,
+        ...theme.applyStyles?.('light', { backgroundColor: theme.palette.primary.main })
+    }
+}))
+
+const spin = keyframes({
+    from: { transform: 'rotate(0deg)' },
+    to: { transform: 'rotate(360deg)' }
+})
+
+interface StatusIconProps {
+    state: ExecutionState | 'UNKNOWN'
 }
 
-function TreeNodeItem({ node, selectedId, onSelect, depth }: TreeNodeItemProps) {
+function StatusIcon({ state }: StatusIconProps) {
     const theme = useTheme()
-    const { apiBaseUrl } = useObserveConfig()
-    const [expanded, setExpanded] = useState(true)
-    const isSelected = node.id === selectedId
-    const hasChildren = node.children.length > 0
+    const baseSx = { ml: 1, fontSize: '1.2rem' } as const
+
+    switch (state) {
+        case 'FINISHED':
+            return <CheckCircleIcon sx={{ ...baseSx, color: 'success.dark' }} />
+        case 'ERROR':
+        case 'TIMEOUT':
+            return <ErrorIcon sx={{ ...baseSx, color: 'error.main' }} />
+        case 'STOPPED':
+            return <StopCircleIcon sx={{ ...baseSx, color: 'error.main' }} />
+        case 'TERMINATED':
+            return (
+                <Box sx={{ ml: 1, display: 'flex' }}>
+                    <IconCircleXFilled size={18} color={theme.palette.error.main} />
+                </Box>
+            )
+        case 'INPROGRESS':
+            return (
+                <Box sx={{ ml: 1, display: 'flex', animation: `${spin} 1s linear infinite` }}>
+                    <IconLoader size={18} color={theme.palette.warning.dark} />
+                </Box>
+            )
+        default:
+            return null
+    }
+}
+
+interface CustomTreeItemProps {
+    id?: string
+    itemId: string
+    label?: React.ReactNode
+    disabled?: boolean
+    children?: React.ReactNode
+}
+
+const CustomTreeItem = forwardRef<HTMLLIElement, CustomTreeItemProps>(function CustomTreeItem(props, ref) {
+    const { id, itemId, label, disabled, children, ...other } = props
+    const theme = useTheme()
+
+    const {
+        getRootProps,
+        getContentProps,
+        getIconContainerProps,
+        getCheckboxProps,
+        getLabelProps,
+        getGroupTransitionProps,
+        getDragAndDropOverlayProps,
+        status,
+        publicAPI
+    } = useTreeItem2({ id, itemId, children, label, disabled, rootRef: ref })
+
+    const item = publicAPI.getItem(itemId) as unknown as ExecutionTreeNode | undefined
+    if (!item) return null
+
+    // PARITY: branch color follows the parent node type's AGENTFLOW_ICONS color, falling back to theme primary.
+    const branchColor = AGENTFLOW_ICONS[item.name]?.color ?? theme.palette.primary.main
 
     return (
-        <>
-            <Box
-                onClick={() => {
-                    if (!node.isVirtualNode) onSelect(node)
-                    if (hasChildren) setExpanded((v) => !v)
-                }}
-                sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    pl: 1.5 + depth * 1.5,
-                    pr: 1.5,
-                    py: 0.75,
-                    cursor: node.isVirtualNode ? 'default' : 'pointer',
-                    backgroundColor: isSelected ? theme.palette.action.selected : 'transparent',
-                    '&:hover': { backgroundColor: theme.palette.action.hover },
-                    borderBottom: `1px solid ${theme.palette.divider}`
-                }}
-            >
-                {node.isVirtualNode ? (
-                    <Typography variant='caption' color='text.secondary' sx={{ fontStyle: 'italic' }}>
-                        {node.nodeLabel}
-                    </Typography>
-                ) : (
-                    <>
-                        <NodeIcon name={node.name} size={22} apiBaseUrl={apiBaseUrl} />
-                        <Typography variant='body2' sx={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                            {node.nodeLabel}
-                        </Typography>
-                        <StatusIndicator state={node.status as ExecutionState} size={14} />
-                    </>
+        <TreeItem2Provider itemId={itemId}>
+            <StyledTreeItemRoot {...getRootProps(other)}>
+                <CustomTreeItemContent {...getContentProps()}>
+                    <TreeItem2IconContainer {...getIconContainerProps()}>
+                        <TreeItem2Icon status={status} />
+                    </TreeItem2IconContainer>
+                    <TreeItem2Checkbox {...getCheckboxProps()} />
+                    <CustomLabel {...getLabelProps()} item={item} />
+                    <TreeItem2DragAndDropOverlay {...getDragAndDropOverlayProps()} />
+                </CustomTreeItemContent>
+                {children && (
+                    <TreeItem2GroupTransition
+                        {...getGroupTransitionProps()}
+                        style={{
+                            borderLeft: `${status.selected ? '3px solid' : '1px dashed'} ${branchColor}`,
+                            marginLeft: '13px',
+                            paddingLeft: '8px'
+                        }}
+                    />
                 )}
-            </Box>
-            {hasChildren && expanded && (
-                <>
-                    <Divider />
-                    <TreeNodeList nodes={node.children} selectedId={selectedId} onSelect={onSelect} depth={depth + 1} />
-                </>
+            </StyledTreeItemRoot>
+        </TreeItem2Provider>
+    )
+})
+
+interface CustomLabelProps {
+    children?: React.ReactNode
+    item: ExecutionTreeNode
+}
+
+function CustomLabel({ item, children, ...other }: CustomLabelProps) {
+    const entry = AGENTFLOW_ICONS[item.name]
+    const NodeTypeIcon = entry?.icon
+
+    return (
+        <TreeItem2Label {...other} sx={{ display: 'flex', alignItems: 'center' }}>
+            {NodeTypeIcon && (
+                <Box sx={{ mr: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <NodeTypeIcon size={20} color={entry.color} />
+                </Box>
             )}
-        </>
+            <Typography sx={{ flex: 1, color: 'text.primary' }}>{children}</Typography>
+            <StatusIcon state={item.status} />
+        </TreeItem2Label>
     )
 }

--- a/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
@@ -286,6 +286,8 @@ export function ExecutionsViewer({
 
                 {drawerExecution && (
                     <ExecutionDetail
+                        // Reset internal state when the user switches rows without closing the drawer.
+                        key={drawerExecution.id}
                         executionId={drawerExecution.id}
                         pollInterval={pollInterval}
                         onHumanInput={onHumanInput}

--- a/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import DragHandleIcon from '@mui/icons-material/DragHandle'
 import {
     Box,
     Button,
@@ -20,15 +21,19 @@ import {
     TextField,
     Typography
 } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { alpha, useTheme } from '@mui/material/styles'
 
 import type { Execution, ExecutionFilters, ExecutionState, ExecutionsViewerProps } from '@/core/types'
 import { useObserveApi } from '@/infrastructure/store'
+
+import { useDrawerWidths } from '../hooks/useDrawerWidths'
+import { useResizableSidebar } from '../hooks/useResizableSidebar'
 
 import { ExecutionDetail } from './ExecutionDetail'
 import { ExecutionsListTable } from './ExecutionsListTable'
 
 const DEFAULT_PAGE_SIZE = 12
+
 const EXECUTION_STATES: Array<ExecutionState | ''> = ['', 'INPROGRESS', 'FINISHED', 'ERROR', 'TERMINATED', 'TIMEOUT', 'STOPPED']
 
 /**
@@ -42,7 +47,8 @@ export function ExecutionsViewer({
     pollInterval = 3000,
     onHumanInput,
     onAgentflowClick,
-    initialFilters
+    initialFilters,
+    drawer
 }: ExecutionsViewerProps) {
     const theme = useTheme()
     const { executions: api } = useObserveApi()
@@ -72,6 +78,12 @@ export function ExecutionsViewer({
 
     // Detail drawer
     const [drawerExecution, setDrawerExecution] = useState<Execution | null>(null)
+    const drawerWidths = useDrawerWidths(drawer)
+    const { width: drawerWidth, onMouseDown: onDrawerHandleMouseDown } = useResizableSidebar({
+        ...drawerWidths,
+        // Right-anchored drawer: handle on the LEFT edge, drag-left grows.
+        inverted: true
+    })
 
     // Delete confirmation
     const [deleteTarget, setDeleteTarget] = useState<Execution | null>(null)
@@ -247,8 +259,31 @@ export function ExecutionsViewer({
                 anchor='right'
                 open={!!drawerExecution}
                 onClose={() => setDrawerExecution(null)}
-                PaperProps={{ sx: { width: { xs: '100vw', sm: '90vw', md: '85vw', lg: '80vw' } } }}
+                PaperProps={{ sx: { width: drawerWidth, overflow: 'hidden' } }}
             >
+                {/* Drag-handle on the LEFT edge — resizes the drawer (parity with legacy ExecutionDetails resizeHandle). */}
+                {/* No `role="button"` / `aria-label`: drag-only widgets can't be operated by keyboard, so screen readers shouldn't announce one. */}
+                <Box
+                    role='separator'
+                    aria-orientation='vertical'
+                    onMouseDown={onDrawerHandleMouseDown}
+                    sx={{
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: 8,
+                        cursor: 'ew-resize',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        zIndex: 1,
+                        '&:hover': { background: alpha(theme.palette.text.primary, 0.05) }
+                    }}
+                >
+                    <DragHandleIcon sx={{ transform: 'rotate(90deg)', fontSize: 20, color: 'action.disabled' }} />
+                </Box>
+
                 {drawerExecution && (
                     <ExecutionDetail
                         executionId={drawerExecution.id}
@@ -256,6 +291,9 @@ export function ExecutionsViewer({
                         onHumanInput={onHumanInput}
                         onAgentflowClick={onAgentflowClick}
                         onClose={() => setDrawerExecution(null)}
+                        // Seed the header chip with the agentflow info already on the row —
+                        // the server's getExecutionById doesn't perform the join, only getAllExecutions does.
+                        agentflow={drawerExecution.agentflow}
                     />
                 )}
             </Drawer>

--- a/packages/observe/src/features/executions/hooks/useDrawerWidths.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useDrawerWidths.test.tsx
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react'
+
+import { useDrawerWidths } from './useDrawerWidths'
+
+const originalInnerWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth')
+
+function setViewport(value: number | undefined) {
+    Object.defineProperty(window, 'innerWidth', { value, writable: true, configurable: true })
+}
+
+afterEach(() => {
+    if (originalInnerWidth) Object.defineProperty(window, 'innerWidth', originalInnerWidth)
+})
+
+describe('useDrawerWidths', () => {
+    describe('without overrides', () => {
+        it('uses the legacy 400-floor and the viewport width as max', () => {
+            setViewport(1600)
+            const { result } = renderHook(() => useDrawerWidths(undefined))
+            expect(result.current.minWidth).toBe(400)
+            expect(result.current.maxWidth).toBe(1600)
+        })
+
+        it('computes defaultWidth as `viewport - 400` when there is room', () => {
+            setViewport(1600)
+            const { result } = renderHook(() => useDrawerWidths(undefined))
+            expect(result.current.defaultWidth).toBe(1200)
+        })
+
+        it('floors defaultWidth to minWidth when the viewport is narrower than the legacy gap', () => {
+            // viewportWidth (500) - 400 = 100, well below the 400 floor.
+            setViewport(500)
+            const { result } = renderHook(() => useDrawerWidths(undefined))
+            expect(result.current.defaultWidth).toBe(400)
+        })
+    })
+
+    describe('with consumer overrides', () => {
+        it('uses minWidth override', () => {
+            setViewport(1600)
+            const { result } = renderHook(() => useDrawerWidths({ minWidth: 250 }))
+            expect(result.current.minWidth).toBe(250)
+        })
+
+        it('uses maxWidth override (overrides the viewport-derived max)', () => {
+            setViewport(1600)
+            const { result } = renderHook(() => useDrawerWidths({ maxWidth: 800 }))
+            expect(result.current.maxWidth).toBe(800)
+        })
+
+        it('uses defaultWidth override when consistent with min/max', () => {
+            setViewport(1600)
+            const { result } = renderHook(() => useDrawerWidths({ defaultWidth: 600 }))
+            expect(result.current.defaultWidth).toBe(600)
+        })
+
+        it('clamps defaultWidth UP to minWidth when the override is below the floor', () => {
+            // PARITY: the override is honored as a hint, but the resolved value
+            // never initializes below `minWidth` — the drawer would otherwise
+            // appear at a width the user can't shrink it back to.
+            setViewport(1600)
+            const { result } = renderHook(() => useDrawerWidths({ defaultWidth: 200, minWidth: 400 }))
+            expect(result.current.defaultWidth).toBe(400)
+        })
+
+        it('clamps defaultWidth DOWN to maxWidth when the override exceeds the ceiling', () => {
+            setViewport(1600)
+            const { result } = renderHook(() => useDrawerWidths({ defaultWidth: 5000, maxWidth: 800 }))
+            expect(result.current.defaultWidth).toBe(800)
+        })
+
+        it('respects all three overrides simultaneously', () => {
+            setViewport(1600)
+            const { result } = renderHook(() => useDrawerWidths({ defaultWidth: 700, minWidth: 300, maxWidth: 900 }))
+            expect(result.current).toEqual({ defaultWidth: 700, minWidth: 300, maxWidth: 900 })
+        })
+    })
+
+    describe('SSR-style fallback (window.innerWidth=undefined)', () => {
+        // Jsdom always defines `window`, so the `typeof window === 'undefined'`
+        // guard branch can't be hit directly. Setting `innerWidth=undefined`
+        // exercises the same downstream `??` fallback math (viewportWidth is
+        // undefined either way), which is the consumer-visible behavior.
+        it('falls back to a 1920 ceiling and a 1024 raw default when viewport is unknown', () => {
+            setViewport(undefined)
+            const { result } = renderHook(() => useDrawerWidths(undefined))
+            expect(result.current.minWidth).toBe(400)
+            expect(result.current.maxWidth).toBe(1920)
+            expect(result.current.defaultWidth).toBe(1024)
+        })
+
+        it('still honors consumer overrides when viewport is unknown', () => {
+            setViewport(undefined)
+            const { result } = renderHook(() => useDrawerWidths({ minWidth: 300, maxWidth: 1200, defaultWidth: 800 }))
+            expect(result.current).toEqual({ minWidth: 300, maxWidth: 1200, defaultWidth: 800 })
+        })
+
+        it('clamps the SSR raw default into [min, max] when overrides are tight', () => {
+            // SSR raw=1024, but maxWidth override=900 → clamps down to 900.
+            setViewport(undefined)
+            const { result } = renderHook(() => useDrawerWidths({ maxWidth: 900 }))
+            expect(result.current.defaultWidth).toBe(900)
+        })
+    })
+
+    describe('memoization', () => {
+        it('returns the same reference when called with the same override fields', () => {
+            setViewport(1600)
+            const { result, rerender } = renderHook((overrides) => useDrawerWidths(overrides), {
+                initialProps: { defaultWidth: 600 } as { defaultWidth?: number; minWidth?: number; maxWidth?: number }
+            })
+            const first = result.current
+            // A fresh object literal with identical fields must NOT recompute.
+            rerender({ defaultWidth: 600 })
+            expect(result.current).toBe(first)
+        })
+
+        it('recomputes when an override field changes', () => {
+            setViewport(1600)
+            const { result, rerender } = renderHook((overrides) => useDrawerWidths(overrides), {
+                initialProps: { defaultWidth: 600 } as { defaultWidth?: number; minWidth?: number; maxWidth?: number }
+            })
+            const first = result.current
+            rerender({ defaultWidth: 700 })
+            expect(result.current).not.toBe(first)
+            expect(result.current.defaultWidth).toBe(700)
+        })
+    })
+})

--- a/packages/observe/src/features/executions/hooks/useDrawerWidths.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useDrawerWidths.test.tsx
@@ -33,6 +33,16 @@ describe('useDrawerWidths', () => {
             const { result } = renderHook(() => useDrawerWidths(undefined))
             expect(result.current.defaultWidth).toBe(400)
         })
+
+        it('caps minWidth to maxWidth on tiny viewports so the drawer never exceeds the screen', () => {
+            // On a 300px wide viewport the 400px floor would otherwise produce
+            // minWidth > maxWidth, pushing the drawer past the right edge.
+            setViewport(300)
+            const { result } = renderHook(() => useDrawerWidths(undefined))
+            expect(result.current.maxWidth).toBe(300)
+            expect(result.current.minWidth).toBe(300)
+            expect(result.current.defaultWidth).toBe(300)
+        })
     })
 
     describe('with consumer overrides', () => {

--- a/packages/observe/src/features/executions/hooks/useDrawerWidths.ts
+++ b/packages/observe/src/features/executions/hooks/useDrawerWidths.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react'
+
+/**
+ * Drawer-width resolution for the right-anchored execution-detail drawer.
+ *
+ * `MIN_DRAWER_WIDTH_PX` and `DRAWER_LEFT_GAP_PX` come from legacy parity:
+ * the legacy view leaves ~400px of background visible to the LEFT of the
+ * drawer (`drawerWidth = window.innerWidth - 400`).
+ *
+ * `SSR_*_FALLBACK_PX` values are used when `window` is undefined (server-side
+ * render) — pinned to common desktop dimensions so the drawer has a reasonable
+ * size before hydration.
+ */
+const MIN_DRAWER_WIDTH_PX = 400
+const DRAWER_LEFT_GAP_PX = 400
+const SSR_MAX_WIDTH_FALLBACK_PX = 1920
+const SSR_DEFAULT_WIDTH_FALLBACK_PX = 1024
+
+export interface DrawerWidthOverrides {
+    defaultWidth?: number
+    minWidth?: number
+    maxWidth?: number
+}
+
+export interface ResolvedDrawerWidths {
+    minWidth: number
+    maxWidth: number
+    defaultWidth: number
+}
+
+/**
+ * Resolves the drawer width triple from optional consumer overrides + the
+ * current viewport. The returned `defaultWidth` is always clamped into
+ * `[minWidth, maxWidth]` so an inconsistent override (e.g.
+ * `defaultWidth=200, minWidth=400`) doesn't initialize below the floor.
+ *
+ * Memoized on the three override fields, so passing a fresh `drawer` object
+ * literal each render does NOT recompute (or shake the downstream
+ * `useResizableSidebar` width state).
+ */
+export function useDrawerWidths(overrides: DrawerWidthOverrides | undefined): ResolvedDrawerWidths {
+    const dwDefault = overrides?.defaultWidth
+    const dwMin = overrides?.minWidth
+    const dwMax = overrides?.maxWidth
+    return useMemo(() => {
+        const viewportWidth = typeof window === 'undefined' ? undefined : window.innerWidth
+        const minWidth = dwMin ?? MIN_DRAWER_WIDTH_PX
+        const maxWidth = dwMax ?? viewportWidth ?? SSR_MAX_WIDTH_FALLBACK_PX
+        const raw =
+            dwDefault ??
+            (viewportWidth !== undefined ? Math.max(minWidth, viewportWidth - DRAWER_LEFT_GAP_PX) : SSR_DEFAULT_WIDTH_FALLBACK_PX)
+        const defaultWidth = Math.min(maxWidth, Math.max(minWidth, raw))
+        return { minWidth, maxWidth, defaultWidth }
+    }, [dwDefault, dwMin, dwMax])
+}

--- a/packages/observe/src/features/executions/hooks/useDrawerWidths.ts
+++ b/packages/observe/src/features/executions/hooks/useDrawerWidths.ts
@@ -44,8 +44,9 @@ export function useDrawerWidths(overrides: DrawerWidthOverrides | undefined): Re
     const dwMax = overrides?.maxWidth
     return useMemo(() => {
         const viewportWidth = typeof window === 'undefined' ? undefined : window.innerWidth
-        const minWidth = dwMin ?? MIN_DRAWER_WIDTH_PX
         const maxWidth = dwMax ?? viewportWidth ?? SSR_MAX_WIDTH_FALLBACK_PX
+        // Cap min to max so a sub-400px viewport doesn't invert the bounds.
+        const minWidth = Math.min(dwMin ?? MIN_DRAWER_WIDTH_PX, maxWidth)
         const raw =
             dwDefault ??
             (viewportWidth !== undefined ? Math.max(minWidth, viewportWidth - DRAWER_LEFT_GAP_PX) : SSR_DEFAULT_WIDTH_FALLBACK_PX)

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
@@ -17,6 +17,14 @@ const baseNode = (overrides: Partial<NodeExecutionData> = {}): NodeExecutionData
     ...overrides
 })
 
+const iterChild = (overrides: Partial<NodeExecutionData> & { parentNodeId?: string; iterationIndex?: number } = {}): NodeExecutionData => {
+    const { parentNodeId, iterationIndex, data, ...rest } = overrides
+    return baseNode({
+        ...rest,
+        data: { ...(data ?? {}), parentNodeId, iterationIndex }
+    })
+}
+
 describe('useExecutionTree', () => {
     describe('degenerate inputs', () => {
         it('returns [] for null', () => {
@@ -134,7 +142,7 @@ describe('useExecutionTree', () => {
     describe('iteration grouping', () => {
         it('inserts a virtual container node for iteration children', () => {
             const parent = baseNode({ nodeId: 'loop', nodeLabel: 'Loop' })
-            const child = baseNode({ nodeId: 'step', nodeLabel: 'Step', parentNodeId: 'loop', iterationIndex: 0 })
+            const child = iterChild({ nodeId: 'step', nodeLabel: 'Step', parentNodeId: 'loop', iterationIndex: 0 })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, child])))
 
             expect(result.current).toHaveLength(1)
@@ -156,9 +164,9 @@ describe('useExecutionTree', () => {
 
         it('groups children by iterationIndex into separate virtual nodes', () => {
             const parent = baseNode({ nodeId: 'loop', nodeLabel: 'Loop' })
-            const iter0a = baseNode({ nodeId: 'step-a', parentNodeId: 'loop', iterationIndex: 0 })
-            const iter0b = baseNode({ nodeId: 'step-b', parentNodeId: 'loop', iterationIndex: 0 })
-            const iter1a = baseNode({ nodeId: 'step-c', parentNodeId: 'loop', iterationIndex: 1 })
+            const iter0a = iterChild({ nodeId: 'step-a', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter0b = iterChild({ nodeId: 'step-b', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter1a = iterChild({ nodeId: 'step-c', parentNodeId: 'loop', iterationIndex: 1 })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, iter0a, iter0b, iter1a])))
 
             const children = result.current[0].children
@@ -171,9 +179,9 @@ describe('useExecutionTree', () => {
 
         it('sorts virtual nodes by iterationIndex ascending', () => {
             const parent = baseNode({ nodeId: 'loop' })
-            const iter2 = baseNode({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 2 })
-            const iter0 = baseNode({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
-            const iter1 = baseNode({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 1 })
+            const iter2 = iterChild({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 2 })
+            const iter0 = iterChild({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter1 = iterChild({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 1 })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, iter2, iter0, iter1])))
 
             const indices = result.current[0].children.map((c) => c.iterationIndex)
@@ -182,8 +190,8 @@ describe('useExecutionTree', () => {
 
         it('rolls up virtual node status to ERROR when any child errored', () => {
             const parent = baseNode({ nodeId: 'loop' })
-            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
-            const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'ERROR' })
+            const child1 = iterChild({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
+            const child2 = iterChild({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'ERROR' })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
 
             expect(result.current[0].children[0].status).toBe('ERROR')
@@ -191,8 +199,8 @@ describe('useExecutionTree', () => {
 
         it('rolls up to INPROGRESS when any child is in-flight (and none errored)', () => {
             const parent = baseNode({ nodeId: 'loop' })
-            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'INPROGRESS' })
-            const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
+            const child1 = iterChild({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'INPROGRESS' })
+            const child2 = iterChild({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
 
             expect(result.current[0].children[0].status).toBe('INPROGRESS')
@@ -200,8 +208,8 @@ describe('useExecutionTree', () => {
 
         it('rolls up to FINISHED only when all children finished', () => {
             const parent = baseNode({ nodeId: 'loop' })
-            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
-            const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
+            const child1 = iterChild({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
+            const child2 = iterChild({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
 
             expect(result.current[0].children[0].status).toBe('FINISHED')
@@ -210,8 +218,8 @@ describe('useExecutionTree', () => {
         it('falls back to UNKNOWN when children mix non-error, non-in-flight, non-finished states (legacy parity)', () => {
             const parent = baseNode({ nodeId: 'loop' })
             // Mix STOPPED + TIMEOUT — neither triggers ERROR / INPROGRESS, and "every === FINISHED" is false.
-            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'STOPPED' })
-            const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'TIMEOUT' })
+            const child1 = iterChild({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'STOPPED' })
+            const child2 = iterChild({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'TIMEOUT' })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
 
             expect(result.current[0].children[0].status).toBe('UNKNOWN')
@@ -223,7 +231,7 @@ describe('useExecutionTree', () => {
             // Without iterationIndex, the node falls back to previousNodeIds
             // / root behavior — it does NOT join an iteration group.
             const parent = baseNode({ nodeId: 'loop' })
-            const orphan = baseNode({ nodeId: 'c1', parentNodeId: 'loop' })
+            const orphan = iterChild({ nodeId: 'c1', parentNodeId: 'loop' })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, orphan])))
 
             // Both are roots; no virtual iteration container is synthesized.
@@ -233,7 +241,7 @@ describe('useExecutionTree', () => {
 
         it('does not include iteration children as top-level nodes', () => {
             const parent = baseNode({ nodeId: 'loop' })
-            const child = baseNode({ nodeId: 'child', parentNodeId: 'loop', iterationIndex: 0 })
+            const child = iterChild({ nodeId: 'child', parentNodeId: 'loop', iterationIndex: 0 })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, child])))
 
             expect(result.current).toHaveLength(1)
@@ -249,9 +257,9 @@ describe('useExecutionTree', () => {
         // iteration entirely).
         it('chains iteration-internal siblings via previousNodeIds within the same iteration', () => {
             const loop = baseNode({ nodeId: 'loop' })
-            const a = baseNode({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
-            const b = baseNode({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['a'] })
-            const c = baseNode({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['b'] })
+            const a = iterChild({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
+            const b = iterChild({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['a'] })
+            const c = iterChild({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['b'] })
             const { result } = renderHook(() => useExecutionTree(toJson([loop, a, b, c])))
 
             // Tree: loop -> [iter#0]
@@ -275,10 +283,10 @@ describe('useExecutionTree', () => {
             // must restrict the match to iteration #1, otherwise iter#1's
             // node would dangle as a child of iter#0.
             const loop = baseNode({ nodeId: 'loop' })
-            const iter0a = baseNode({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
-            const iter0b = baseNode({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['a'] })
-            const iter1a = baseNode({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 1 })
-            const iter1b = baseNode({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 1, previousNodeIds: ['a'] })
+            const iter0a = iterChild({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter0b = iterChild({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['a'] })
+            const iter1a = iterChild({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 1 })
+            const iter1b = iterChild({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 1, previousNodeIds: ['a'] })
             const { result } = renderHook(() => useExecutionTree(toJson([loop, iter0a, iter0b, iter1a, iter1b])))
 
             const virtuals = result.current[0].children
@@ -307,13 +315,43 @@ describe('useExecutionTree', () => {
             // container directly — preserving legacy behavior.
             const loop = baseNode({ nodeId: 'loop' })
             const outside = baseNode({ nodeId: 'outside' })
-            const inside = baseNode({ nodeId: 'inside', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['outside'] })
+            const inside = iterChild({ nodeId: 'inside', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['outside'] })
             const { result } = renderHook(() => useExecutionTree(toJson([loop, outside, inside])))
 
             const virtualNode = result.current.find((n) => n.nodeId === 'loop')!.children[0]
             expect(virtualNode.isVirtualNode).toBe(true)
             expect(virtualNode.children).toHaveLength(1)
             expect(virtualNode.children[0].nodeId).toBe('inside')
+        })
+
+        it('reads parentNodeId/iterationIndex from data (runtime payload shape, not top-level)', () => {
+            const start = baseNode({ nodeId: 'start' })
+            const llm = baseNode({ nodeId: 'llm', previousNodeIds: ['start'] })
+            const loop = baseNode({ nodeId: 'loop', previousNodeIds: ['llm'] })
+            const iter0Agent = iterChild({ nodeId: 'agent', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter0Reply = iterChild({ nodeId: 'reply', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['agent'] })
+            const iter1Agent = iterChild({ nodeId: 'agent', parentNodeId: 'loop', iterationIndex: 1 })
+            const iter1Reply = iterChild({ nodeId: 'reply', parentNodeId: 'loop', iterationIndex: 1, previousNodeIds: ['agent'] })
+            const iter2Agent = iterChild({ nodeId: 'agent', parentNodeId: 'loop', iterationIndex: 2 })
+            const iter2Reply = iterChild({ nodeId: 'reply', parentNodeId: 'loop', iterationIndex: 2, previousNodeIds: ['agent'] })
+            const { result } = renderHook(() =>
+                useExecutionTree(toJson([start, llm, loop, iter0Agent, iter0Reply, iter1Agent, iter1Reply, iter2Agent, iter2Reply]))
+            )
+
+            expect(result.current).toHaveLength(1)
+            const llmNode = result.current[0].children[0]
+            const loopNode = llmNode.children[0]
+            expect(loopNode.nodeId).toBe('loop')
+            expect(loopNode.children).toHaveLength(3)
+
+            loopNode.children.forEach((virtual, i) => {
+                expect(virtual.isVirtualNode).toBe(true)
+                expect(virtual.iterationIndex).toBe(i)
+                expect(virtual.children).toHaveLength(1)
+                expect(virtual.children[0].nodeId).toBe('agent')
+                expect(virtual.children[0].children).toHaveLength(1)
+                expect(virtual.children[0].children[0].nodeId).toBe('reply')
+            })
         })
     })
 
@@ -349,7 +387,8 @@ describe('useExecutionTree', () => {
             // If the runtime payload is malformed (e.g. data.name accidentally
             // set to an object), we must not pass that through as a name —
             // the nodeId fallback must kick in instead.
-            const node = baseNode({ nodeId: 'fallback_0', data: { name: { nested: 'oops' } } })
+            // Cast through unknown — the test deliberately violates the typed contract.
+            const node = baseNode({ nodeId: 'fallback_0', data: { name: { nested: 'oops' } as unknown as string } })
             const { result } = renderHook(() => useExecutionTree(toJson([node])))
             expect(result.current[0].name).toBe('fallback')
         })
@@ -364,11 +403,11 @@ describe('useExecutionTree', () => {
             // An iteration-agent node hanging off `start` …
             const iterAgent = baseNode({ nodeId: 'loop', previousNodeIds: ['start'] })
             // … with one iteration child …
-            const iterChild = baseNode({ nodeId: 'inside', parentNodeId: 'loop', iterationIndex: 0 })
+            const iterationChild = iterChild({ nodeId: 'inside', parentNodeId: 'loop', iterationIndex: 0 })
             // … plus a plain sibling under `start` that records execution AFTER the iteration.
             // (`previousNodeIds: ['start']` means it would attach to start as a sibling of `loop`.)
             const sibling = baseNode({ nodeId: 'after', previousNodeIds: ['start'] })
-            const { result } = renderHook(() => useExecutionTree(toJson([start, iterAgent, iterChild, sibling])))
+            const { result } = renderHook(() => useExecutionTree(toJson([start, iterAgent, iterationChild, sibling])))
 
             const startNode = result.current[0]
             // Children of `start`: `loop` (which holds the virtual iteration node) and `after`.
@@ -428,7 +467,7 @@ describe('useExecutionTree', () => {
 
         it('does not set raw on virtual iteration container nodes', () => {
             const parent = baseNode({ nodeId: 'loop' })
-            const child = baseNode({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 0 })
+            const child = iterChild({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 0 })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, child])))
 
             const virtualNode = result.current[0].children[0]

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.test.tsx
@@ -68,10 +68,66 @@ describe('useExecutionTree', () => {
             expect(result.current.map((n) => n.nodeId)).toEqual(['n1', 'n2', 'n3'])
         })
 
-        it('builds node id as nodeId-iterationIndex', () => {
-            const node = baseNode({ nodeId: 'n1', iterationIndex: 0 })
+        it('builds node id as nodeId_<arrayIndex> so duplicate nodeIds stay addressable', () => {
+            const node = baseNode({ nodeId: 'n1' })
             const { result } = renderHook(() => useExecutionTree(toJson([node])))
-            expect(result.current[0].id).toBe('n1-0')
+            expect(result.current[0].id).toBe('n1_0')
+        })
+
+        it('uses array index in the id when the same nodeId appears twice (e.g., a re-run)', () => {
+            const a = baseNode({ nodeId: 'shared', nodeLabel: 'First' })
+            const b = baseNode({ nodeId: 'shared', nodeLabel: 'Second' })
+            const { result } = renderHook(() => useExecutionTree(toJson([a, b])))
+            // Both instances are distinct in the tree; ids are unique even though nodeId collides.
+            const ids = result.current.map((n) => n.id)
+            expect(ids).toEqual(['shared_0', 'shared_1'])
+        })
+    })
+
+    describe('previousNodeIds parenting', () => {
+        it('attaches a node to the most recent ancestor whose nodeId is in previousNodeIds', () => {
+            const start = baseNode({ nodeId: 'startAgentflow_0', nodeLabel: 'Start' })
+            const next = baseNode({ nodeId: 'executeFlowAgentflow_1', nodeLabel: 'Execute Flow 0', previousNodeIds: ['startAgentflow_0'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([start, next])))
+
+            expect(result.current).toHaveLength(1)
+            expect(result.current[0].nodeId).toBe('startAgentflow_0')
+            expect(result.current[0].children).toHaveLength(1)
+            expect(result.current[0].children[0].nodeId).toBe('executeFlowAgentflow_1')
+        })
+
+        it('chains A → B → C through previousNodeIds', () => {
+            const a = baseNode({ nodeId: 'a' })
+            const b = baseNode({ nodeId: 'b', previousNodeIds: ['a'] })
+            const c = baseNode({ nodeId: 'c', previousNodeIds: ['b'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([a, b, c])))
+
+            expect(result.current).toHaveLength(1)
+            expect(result.current[0].nodeId).toBe('a')
+            expect(result.current[0].children[0].nodeId).toBe('b')
+            expect(result.current[0].children[0].children[0].nodeId).toBe('c')
+        })
+
+        it('treats a node as root when previousNodeIds names something not yet executed', () => {
+            const orphan = baseNode({ nodeId: 'orphan', previousNodeIds: ['never-ran'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([orphan])))
+            expect(result.current).toHaveLength(1)
+            expect(result.current[0].nodeId).toBe('orphan')
+        })
+
+        it('picks the most recent instance when previousNodeIds resolves to a duplicate', () => {
+            // Two instances of "loop" appear; the next node points back to the loop.
+            // Only the most recent (latest array index) instance should adopt the child.
+            const first = baseNode({ nodeId: 'loop', nodeLabel: 'Loop pass 1' })
+            const middle = baseNode({ nodeId: 'mid' })
+            const second = baseNode({ nodeId: 'loop', nodeLabel: 'Loop pass 2' })
+            const child = baseNode({ nodeId: 'after', previousNodeIds: ['loop'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([first, middle, second, child])))
+
+            const second_loop = result.current.find((n) => n.id === 'loop_2')
+            expect(second_loop?.children[0]?.nodeId).toBe('after')
+            const first_loop = result.current.find((n) => n.id === 'loop_0')
+            expect(first_loop?.children).toHaveLength(0)
         })
     })
 
@@ -87,9 +143,15 @@ describe('useExecutionTree', () => {
 
             const virtualNode = parentNode.children[0]
             expect(virtualNode.isVirtualNode).toBe(true)
-            expect(virtualNode.nodeLabel).toBe('Iteration #1')
+            // PARITY: legacy uses the raw 0-based iterationIndex.
+            expect(virtualNode.nodeLabel).toBe('Iteration #0')
             expect(virtualNode.id).toBe('loop-iteration-0')
             expect(virtualNode.iterationIndex).toBe(0)
+            // PARITY: virtual containers must carry `name: 'iterationAgentflow'`
+            // so the AGENTFLOW_ICONS lookup in the sidebar resolves to the
+            // iteration icon. Asserted at the hook layer so the contract is
+            // independent of the rendered icon.
+            expect(virtualNode.name).toBe('iterationAgentflow')
         })
 
         it('groups children by iterationIndex into separate virtual nodes', () => {
@@ -118,23 +180,55 @@ describe('useExecutionTree', () => {
             expect(indices).toEqual([0, 1, 2])
         })
 
-        it('virtual node status matches last child in the iteration group', () => {
+        it('rolls up virtual node status to ERROR when any child errored', () => {
             const parent = baseNode({ nodeId: 'loop' })
-            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'INPROGRESS' })
+            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
             const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'ERROR' })
             const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
 
             expect(result.current[0].children[0].status).toBe('ERROR')
         })
 
-        it('defaults iterationIndex to 0 when absent', () => {
+        it('rolls up to INPROGRESS when any child is in-flight (and none errored)', () => {
             const parent = baseNode({ nodeId: 'loop' })
-            const child = baseNode({ nodeId: 'c1', parentNodeId: 'loop' })
-            // no iterationIndex set
-            const { result } = renderHook(() => useExecutionTree(toJson([parent, child])))
+            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'INPROGRESS' })
+            const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
 
-            expect(result.current[0].children).toHaveLength(1)
-            expect(result.current[0].children[0].iterationIndex).toBe(0)
+            expect(result.current[0].children[0].status).toBe('INPROGRESS')
+        })
+
+        it('rolls up to FINISHED only when all children finished', () => {
+            const parent = baseNode({ nodeId: 'loop' })
+            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
+            const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'FINISHED' })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
+
+            expect(result.current[0].children[0].status).toBe('FINISHED')
+        })
+
+        it('falls back to UNKNOWN when children mix non-error, non-in-flight, non-finished states (legacy parity)', () => {
+            const parent = baseNode({ nodeId: 'loop' })
+            // Mix STOPPED + TIMEOUT — neither triggers ERROR / INPROGRESS, and "every === FINISHED" is false.
+            const child1 = baseNode({ nodeId: 'c1', parentNodeId: 'loop', iterationIndex: 0, status: 'STOPPED' })
+            const child2 = baseNode({ nodeId: 'c2', parentNodeId: 'loop', iterationIndex: 0, status: 'TIMEOUT' })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, child1, child2])))
+
+            expect(result.current[0].children[0].status).toBe('UNKNOWN')
+        })
+
+        it('treats a node with parentNodeId but no iterationIndex as a non-iteration node (legacy parity)', () => {
+            // PARITY: legacy buildTreeData gates iteration grouping on
+            // `data.parentNodeId && data.iterationIndex !== undefined`.
+            // Without iterationIndex, the node falls back to previousNodeIds
+            // / root behavior — it does NOT join an iteration group.
+            const parent = baseNode({ nodeId: 'loop' })
+            const orphan = baseNode({ nodeId: 'c1', parentNodeId: 'loop' })
+            const { result } = renderHook(() => useExecutionTree(toJson([parent, orphan])))
+
+            // Both are roots; no virtual iteration container is synthesized.
+            expect(result.current).toHaveLength(2)
+            expect(result.current[0].children).toHaveLength(0)
         })
 
         it('does not include iteration children as top-level nodes', () => {
@@ -144,6 +238,82 @@ describe('useExecutionTree', () => {
 
             expect(result.current).toHaveLength(1)
             expect(result.current[0].nodeId).toBe('loop')
+        })
+    })
+
+    describe('iteration-internal previousNodeIds (third pass)', () => {
+        // PARITY: the trickiest part of the port — building the sub-tree
+        // INSIDE a virtual iteration container. Sibling chains within a
+        // single iteration must form, but the lookup must not adopt
+        // ancestors from a different iteration (or from outside the
+        // iteration entirely).
+        it('chains iteration-internal siblings via previousNodeIds within the same iteration', () => {
+            const loop = baseNode({ nodeId: 'loop' })
+            const a = baseNode({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
+            const b = baseNode({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['a'] })
+            const c = baseNode({ nodeId: 'c', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['b'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([loop, a, b, c])))
+
+            // Tree: loop -> [iter#0]
+            //                 └─ a
+            //                    └─ b
+            //                       └─ c
+            const virtualNode = result.current[0].children[0]
+            expect(virtualNode.isVirtualNode).toBe(true)
+            expect(virtualNode.children).toHaveLength(1)
+            expect(virtualNode.children[0].nodeId).toBe('a')
+            expect(virtualNode.children[0].children).toHaveLength(1)
+            expect(virtualNode.children[0].children[0].nodeId).toBe('b')
+            expect(virtualNode.children[0].children[0].children).toHaveLength(1)
+            expect(virtualNode.children[0].children[0].children[0].nodeId).toBe('c')
+        })
+
+        it('does not adopt ancestors from a different iteration when resolving previousNodeIds', () => {
+            // Two iterations of the same loop. Iteration #1 has a node whose
+            // previousNodeIds points at a nodeId that exists in BOTH
+            // iterations. The third-pass `findAncestor(sameIterationOnly=true)`
+            // must restrict the match to iteration #1, otherwise iter#1's
+            // node would dangle as a child of iter#0.
+            const loop = baseNode({ nodeId: 'loop' })
+            const iter0a = baseNode({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 0 })
+            const iter0b = baseNode({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['a'] })
+            const iter1a = baseNode({ nodeId: 'a', parentNodeId: 'loop', iterationIndex: 1 })
+            const iter1b = baseNode({ nodeId: 'b', parentNodeId: 'loop', iterationIndex: 1, previousNodeIds: ['a'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([loop, iter0a, iter0b, iter1a, iter1b])))
+
+            const virtuals = result.current[0].children
+            expect(virtuals).toHaveLength(2)
+
+            const iter0 = virtuals.find((v) => v.iterationIndex === 0)!
+            const iter1 = virtuals.find((v) => v.iterationIndex === 1)!
+
+            // Each iteration owns exactly one root child (`a`) with `b` underneath it.
+            expect(iter0.children).toHaveLength(1)
+            expect(iter0.children[0].nodeId).toBe('a')
+            expect(iter0.children[0].children).toHaveLength(1)
+            expect(iter0.children[0].children[0].nodeId).toBe('b')
+
+            expect(iter1.children).toHaveLength(1)
+            expect(iter1.children[0].nodeId).toBe('a')
+            expect(iter1.children[0].children).toHaveLength(1)
+            expect(iter1.children[0].children[0].nodeId).toBe('b')
+        })
+
+        it('falls back to virtual container when previousNodeIds points outside the iteration', () => {
+            // An iteration child references a nodeId that exists OUTSIDE the
+            // iteration (a top-level node). Because `findAncestor` with
+            // sameIterationOnly=true excludes non-iteration candidates, no
+            // ancestor is found and the node attaches to the virtual
+            // container directly — preserving legacy behavior.
+            const loop = baseNode({ nodeId: 'loop' })
+            const outside = baseNode({ nodeId: 'outside' })
+            const inside = baseNode({ nodeId: 'inside', parentNodeId: 'loop', iterationIndex: 0, previousNodeIds: ['outside'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([loop, outside, inside])))
+
+            const virtualNode = result.current.find((n) => n.nodeId === 'loop')!.children[0]
+            expect(virtualNode.isVirtualNode).toBe(true)
+            expect(virtualNode.children).toHaveLength(1)
+            expect(virtualNode.children[0].nodeId).toBe('inside')
         })
     })
 
@@ -182,6 +352,70 @@ describe('useExecutionTree', () => {
             const node = baseNode({ nodeId: 'fallback_0', data: { name: { nested: 'oops' } } })
             const { result } = renderHook(() => useExecutionTree(toJson([node])))
             expect(result.current[0].name).toBe('fallback')
+        })
+    })
+
+    describe('iterations-first sibling sort', () => {
+        // PARITY: legacy ExecutionDetails.jsx:589-614 sorts every node's
+        // children so virtual iteration nodes come first; non-iteration
+        // siblings preserve original execution order.
+        it('places virtual iteration siblings before non-iteration siblings of the same parent', () => {
+            const start = baseNode({ nodeId: 'start' })
+            // An iteration-agent node hanging off `start` …
+            const iterAgent = baseNode({ nodeId: 'loop', previousNodeIds: ['start'] })
+            // … with one iteration child …
+            const iterChild = baseNode({ nodeId: 'inside', parentNodeId: 'loop', iterationIndex: 0 })
+            // … plus a plain sibling under `start` that records execution AFTER the iteration.
+            // (`previousNodeIds: ['start']` means it would attach to start as a sibling of `loop`.)
+            const sibling = baseNode({ nodeId: 'after', previousNodeIds: ['start'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([start, iterAgent, iterChild, sibling])))
+
+            const startNode = result.current[0]
+            // Children of `start`: `loop` (which holds the virtual iteration node) and `after`.
+            // Within `loop`, the virtual iteration node should sort first vs any plain children.
+            // Within `start`, ordering preserves execution order between non-iteration siblings.
+            const loopNode = startNode.children.find((c) => c.nodeId === 'loop')!
+            expect(loopNode.children[0].isVirtualNode).toBe(true)
+        })
+
+        it('preserves original execution order between non-iteration siblings', () => {
+            const root = baseNode({ nodeId: 'root' })
+            const childA = baseNode({ nodeId: 'a', previousNodeIds: ['root'] })
+            const childB = baseNode({ nodeId: 'b', previousNodeIds: ['root'] })
+            const childC = baseNode({ nodeId: 'c', previousNodeIds: ['root'] })
+            const { result } = renderHook(() => useExecutionTree(toJson([root, childA, childB, childC])))
+
+            const ids = result.current[0].children.map((n) => n.nodeId)
+            expect(ids).toEqual(['a', 'b', 'c'])
+        })
+    })
+
+    describe('credential redaction', () => {
+        // PARITY: legacy buildTreeData (ExecutionDetails.jsx:371-383) recursively
+        // strips `FLOWISE_CREDENTIAL_ID` keys from each node's `data` because the
+        // server-side list/detail endpoints don't redact (only the public
+        // endpoint does). The hook does the scrubbing client-side.
+        it('removes top-level FLOWISE_CREDENTIAL_ID keys from raw.data', () => {
+            const node = baseNode({ nodeId: 'n1', data: { FLOWISE_CREDENTIAL_ID: 'secret', other: 'kept' } })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            const raw = result.current[0].raw!
+            expect((raw.data as Record<string, unknown>).FLOWISE_CREDENTIAL_ID).toBeUndefined()
+            expect((raw.data as Record<string, unknown>).other).toBe('kept')
+        })
+
+        it('removes nested FLOWISE_CREDENTIAL_ID keys recursively', () => {
+            const node = baseNode({
+                nodeId: 'n1',
+                data: { input: { credentials: { FLOWISE_CREDENTIAL_ID: 'secret', label: 'kept' } } }
+            })
+            const { result } = renderHook(() => useExecutionTree(toJson([node])))
+            const raw = result.current[0].raw!
+            const credentials = ((raw.data as Record<string, unknown>).input as Record<string, unknown>).credentials as Record<
+                string,
+                unknown
+            >
+            expect(credentials.FLOWISE_CREDENTIAL_ID).toBeUndefined()
+            expect(credentials.label).toBe('kept')
         })
     })
 

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.ts
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.ts
@@ -71,6 +71,9 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
         const uniqueId = (nodeId: string, index: number) => `${nodeId}_${index}`
         const isIterationChild = (n: NodeExecutionData) => Boolean(n.parentNodeId) && n.iterationIndex !== undefined
 
+        // `nodeId` → ascending array indices. Read in reverse to find the most-recent occurrence < currentIndex.
+        const indicesByNodeId = new Map<string, number[]>()
+
         nodes.forEach((n, index) => {
             // The runtime never emits `name` at the top level (per
             // `IAgentflowExecutedData`); Agent/LLM/etc. put their type
@@ -89,6 +92,8 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
                 raw: n
             })
             executionIndexById.set(id, index)
+            if (!indicesByNodeId.has(n.nodeId)) indicesByNodeId.set(n.nodeId, [])
+            indicesByNodeId.get(n.nodeId)!.push(index)
         })
 
         const iterationGroups = new Map<string, Map<number, number[]>>() // parentNodeId -> iterIdx -> [array index, ...]
@@ -125,9 +130,8 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
             })
         })
 
-        // Find the most recent ancestor among `previousNodeIds`. Optionally
-        // restrict the search to nodes within the same iteration (for sub-tree
-        // building inside virtual iteration containers).
+        // Most recent ancestor index whose nodeId is in `previousNodeIds`.
+        // With sameIterationOnly, restrict to nodes in the same iteration.
         const findAncestor = (
             n: NodeExecutionData,
             currentIndex: number,
@@ -137,10 +141,13 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
             let bestIndex = -1
             let bestNodeId: string | null = null
             for (const prevId of n.previousNodeIds) {
-                for (let i = 0; i < currentIndex; i++) {
-                    const candidate = nodes[i]
-                    if (candidate.nodeId !== prevId) continue
+                const indices = indicesByNodeId.get(prevId)
+                if (!indices) continue
+                for (let j = indices.length - 1; j >= 0; j--) {
+                    const i = indices[j]
+                    if (i >= currentIndex) continue
                     if (sameIterationOnly) {
+                        const candidate = nodes[i]
                         if (candidate.parentNodeId !== n.parentNodeId) continue
                         if (candidate.iterationIndex !== n.iterationIndex) continue
                     }
@@ -148,6 +155,7 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
                         bestIndex = i
                         bestNodeId = prevId
                     }
+                    break
                 }
             }
             return bestIndex >= 0 && bestNodeId ? { index: bestIndex, nodeId: bestNodeId } : null
@@ -173,14 +181,10 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
         // Second pass: attach virtual iteration nodes to the iteration agent's
         // most recent instance.
         iterationGroups.forEach((byIdx, parentNodeId) => {
-            let latestParentIndex = -1
-            for (let i = nodes.length - 1; i >= 0; i--) {
-                if (nodes[i].nodeId === parentNodeId) {
-                    latestParentIndex = i
-                    break
-                }
-            }
-            const parent = latestParentIndex >= 0 ? treeNodes.get(uniqueId(parentNodeId, latestParentIndex)) : undefined
+            const parentIndices = indicesByNodeId.get(parentNodeId)
+            if (!parentIndices || parentIndices.length === 0) return
+            const latestParentIndex = parentIndices[parentIndices.length - 1]
+            const parent = treeNodes.get(uniqueId(parentNodeId, latestParentIndex))
             if (!parent) return
             Array.from(byIdx.keys())
                 .sort((a, b) => a - b)

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.ts
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.ts
@@ -69,16 +69,15 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
         const executionIndexById = new Map<string, number>()
 
         const uniqueId = (nodeId: string, index: number) => `${nodeId}_${index}`
-        const isIterationChild = (n: NodeExecutionData) => Boolean(n.parentNodeId) && n.iterationIndex !== undefined
+        const isIterationChild = (n: NodeExecutionData) => Boolean(n.data.parentNodeId) && n.data.iterationIndex !== undefined
 
         // `nodeId` → ascending array indices. Read in reverse to find the most-recent occurrence < currentIndex.
         const indicesByNodeId = new Map<string, number[]>()
 
         nodes.forEach((n, index) => {
-            // The runtime never emits `name` at the top level (per
-            // `IAgentflowExecutedData`); Agent/LLM/etc. put their type
-            // identifier on `data.name`, so the fallback chain is required.
-            const dataName = n.data?.name
+            // The runtime emits the type identifier on `data.name`; `n.name` is
+            // a tolerated fallback for non-runtime producers (tests, wrappers).
+            const dataName = n.data.name
             const resolvedName = n.name ?? (typeof dataName === 'string' ? dataName : undefined) ?? n.nodeId.split('_')[0]
             const id = uniqueId(n.nodeId, index)
             treeNodes.set(id, {
@@ -87,7 +86,7 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
                 nodeLabel: n.nodeLabel,
                 status: n.status,
                 name: resolvedName,
-                iterationIndex: n.iterationIndex,
+                iterationIndex: n.data.iterationIndex,
                 children: [],
                 raw: n
             })
@@ -98,9 +97,8 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
 
         const iterationGroups = new Map<string, Map<number, number[]>>() // parentNodeId -> iterIdx -> [array index, ...]
         nodes.forEach((n, index) => {
-            if (!isIterationChild(n)) return
-            const parentNodeId = n.parentNodeId!
-            const iterIdx = n.iterationIndex!
+            const { parentNodeId, iterationIndex: iterIdx } = n.data
+            if (!parentNodeId || iterIdx === undefined) return
             if (!iterationGroups.has(parentNodeId)) iterationGroups.set(parentNodeId, new Map())
             const byIdx = iterationGroups.get(parentNodeId)!
             if (!byIdx.has(iterIdx)) byIdx.set(iterIdx, [])
@@ -148,8 +146,8 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
                     if (i >= currentIndex) continue
                     if (sameIterationOnly) {
                         const candidate = nodes[i]
-                        if (candidate.parentNodeId !== n.parentNodeId) continue
-                        if (candidate.iterationIndex !== n.iterationIndex) continue
+                        if (candidate.data.parentNodeId !== n.data.parentNodeId) continue
+                        if (candidate.data.iterationIndex !== n.data.iterationIndex) continue
                     }
                     if (i > bestIndex) {
                         bestIndex = i

--- a/packages/observe/src/features/executions/hooks/useExecutionTree.ts
+++ b/packages/observe/src/features/executions/hooks/useExecutionTree.ts
@@ -1,16 +1,46 @@
 import { useMemo } from 'react'
 
-import type { ExecutionTreeNode, NodeExecutionData } from '@/core/types'
+import type { ExecutionState, ExecutionTreeNode, NodeExecutionData } from '@/core/types'
+
+const FLOWISE_CREDENTIAL_ID = 'FLOWISE_CREDENTIAL_ID'
+
+/** Recursively delete `FLOWISE_CREDENTIAL_ID` keys from `data` (mutates in place). */
+function scrubCredentialIds(data: unknown): void {
+    if (!data || typeof data !== 'object') return
+    const obj = data as Record<string, unknown>
+    for (const key of Object.keys(obj)) {
+        if (key === FLOWISE_CREDENTIAL_ID) {
+            delete obj[key]
+            continue
+        }
+        const value = obj[key]
+        if (value && typeof value === 'object') scrubCredentialIds(value)
+    }
+}
+
+/** Legacy ExecutionDetails.jsx:438-446 rollup: ERROR > INPROGRESS > all-FINISHED > UNKNOWN. */
+function rollupIterationStatus(childStatuses: ExecutionState[]): ExecutionState | 'UNKNOWN' {
+    if (childStatuses.some((s) => s === 'ERROR')) return 'ERROR'
+    if (childStatuses.some((s) => s === 'INPROGRESS')) return 'INPROGRESS'
+    if (childStatuses.length > 0 && childStatuses.every((s) => s === 'FINISHED')) return 'FINISHED'
+    return 'UNKNOWN'
+}
 
 /**
- * Builds a hierarchical ExecutionTreeNode[] from the flat NodeExecutionData[] stored in
- * execution.executionData (JSON string). Handles:
+ * Builds a hierarchical `ExecutionTreeNode[]` from the flat `NodeExecutionData[]`
+ * stored in `execution.executionData` (JSON string). Two parenting mechanisms,
+ * mirroring the legacy `ExecutionDetails.jsx` `buildTreeData`:
  *
- * - Top-level nodes (no parentNodeId)
- * - Iteration child nodes (parentNodeId set, grouped by iterationIndex)
- * - Virtual iteration container nodes (synthesized to group iteration children)
+ * 1. **`previousNodeIds` parent→child** — each non-iteration node attaches to
+ *    the most recent prior instance of any node listed in its `previousNodeIds`.
+ *    A node with empty `previousNodeIds` becomes a root.
+ * 2. **Iteration grouping** — children with `parentNodeId` + `iterationIndex`
+ *    are grouped into virtual `Iteration #N` container nodes under the iteration
+ *    agent's most recent instance, then linked to one another inside the
+ *    iteration via the same `previousNodeIds` rule.
  *
- * Mirrors the tree-building logic in OSS ExecutionDetails.jsx.
+ * Tree node ids are `${nodeId}_${index}` (array position) so the same `nodeId`
+ * appearing multiple times (e.g. inside a loop) keeps each instance addressable.
  */
 export function useExecutionTree(executionDataJson: string | null): ExecutionTreeNode[] {
     return useMemo(() => {
@@ -26,35 +56,30 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
 
         if (!Array.isArray(nodes) || nodes.length === 0) return []
 
-        // Separate top-level nodes from iteration children
-        const topLevel = nodes.filter((n) => !n.parentNodeId)
-        const iterationChildren = nodes.filter((n) => !!n.parentNodeId)
+        // PARITY: legacy buildTreeData (ExecutionDetails.jsx:371-383) recursively
+        // strips `FLOWISE_CREDENTIAL_ID` keys from each node's `data`. The list
+        // and detail server endpoints don't redact (only the public endpoint
+        // does), so we scrub here before exposing `raw` on tree nodes.
+        nodes.forEach((n) => scrubCredentialIds(n.data))
 
-        // Group iteration children by parentNodeId, then by iterationIndex
-        const childrenByParent = new Map<string, Map<number, NodeExecutionData[]>>()
-        for (const child of iterationChildren) {
-            const parentId = child.parentNodeId!
-            const iterIdx = child.iterationIndex ?? 0
+        const treeNodes = new Map<string, ExecutionTreeNode>()
+        // Track each node's original array index — used by the final sibling
+        // sort to preserve original execution order between non-iteration
+        // siblings. Virtual iteration nodes use -1 so they sort first.
+        const executionIndexById = new Map<string, number>()
 
-            if (!childrenByParent.has(parentId)) {
-                childrenByParent.set(parentId, new Map())
-            }
-            const byIndex = childrenByParent.get(parentId)!
-            if (!byIndex.has(iterIdx)) {
-                byIndex.set(iterIdx, [])
-            }
-            byIndex.get(iterIdx)!.push(child)
-        }
+        const uniqueId = (nodeId: string, index: number) => `${nodeId}_${index}`
+        const isIterationChild = (n: NodeExecutionData) => Boolean(n.parentNodeId) && n.iterationIndex !== undefined
 
-        function buildNode(n: NodeExecutionData): ExecutionTreeNode {
+        nodes.forEach((n, index) => {
             // The runtime never emits `name` at the top level (per
             // `IAgentflowExecutedData`); Agent/LLM/etc. put their type
             // identifier on `data.name`, so the fallback chain is required.
             const dataName = n.data?.name
             const resolvedName = n.name ?? (typeof dataName === 'string' ? dataName : undefined) ?? n.nodeId.split('_')[0]
-
-            const treeNode: ExecutionTreeNode = {
-                id: `${n.nodeId}-${n.iterationIndex ?? 0}`,
+            const id = uniqueId(n.nodeId, index)
+            treeNodes.set(id, {
+                id,
                 nodeId: n.nodeId,
                 nodeLabel: n.nodeLabel,
                 status: n.status,
@@ -62,31 +87,144 @@ export function useExecutionTree(executionDataJson: string | null): ExecutionTre
                 iterationIndex: n.iterationIndex,
                 children: [],
                 raw: n
-            }
+            })
+            executionIndexById.set(id, index)
+        })
 
-            const childGroups = childrenByParent.get(n.nodeId)
-            if (childGroups && childGroups.size > 0) {
-                // Build a virtual container per iteration group
-                const sortedIterations = Array.from(childGroups.keys()).sort((a, b) => a - b)
-                treeNode.children = sortedIterations.map((iterIdx) => {
-                    const groupChildren = childGroups.get(iterIdx)!
-                    const virtualNode: ExecutionTreeNode = {
-                        id: `${n.nodeId}-iteration-${iterIdx}`,
-                        nodeId: `${n.nodeId}-iteration-${iterIdx}`,
-                        nodeLabel: `Iteration #${iterIdx + 1}`,
-                        status: groupChildren[groupChildren.length - 1]?.status ?? 'FINISHED',
-                        name: '',
-                        isVirtualNode: true,
-                        iterationIndex: iterIdx,
-                        children: groupChildren.map(buildNode)
-                    }
-                    return virtualNode
+        const iterationGroups = new Map<string, Map<number, number[]>>() // parentNodeId -> iterIdx -> [array index, ...]
+        nodes.forEach((n, index) => {
+            if (!isIterationChild(n)) return
+            const parentNodeId = n.parentNodeId!
+            const iterIdx = n.iterationIndex!
+            if (!iterationGroups.has(parentNodeId)) iterationGroups.set(parentNodeId, new Map())
+            const byIdx = iterationGroups.get(parentNodeId)!
+            if (!byIdx.has(iterIdx)) byIdx.set(iterIdx, [])
+            byIdx.get(iterIdx)!.push(index)
+        })
+
+        const virtualNodes = new Map<string, ExecutionTreeNode>() // virtualId -> ExecutionTreeNode
+        const childToVirtualParent = new Map<string, string>() // child uniqueId -> virtualId
+        iterationGroups.forEach((byIdx, parentNodeId) => {
+            byIdx.forEach((indices, iterIdx) => {
+                const virtualId = `${parentNodeId}-iteration-${iterIdx}`
+                const childStatuses = indices.map((i) => nodes[i].status)
+                virtualNodes.set(virtualId, {
+                    id: virtualId,
+                    nodeId: virtualId,
+                    // PARITY: legacy ExecutionDetails.jsx:436 uses the raw 0-based iterationIndex.
+                    nodeLabel: `Iteration #${iterIdx}`,
+                    status: rollupIterationStatus(childStatuses),
+                    // PARITY: drive the iteration container icon via AGENTFLOW_ICONS lookup, matching the legacy `iterationAgentflow` node-type signal.
+                    name: 'iterationAgentflow',
+                    isVirtualNode: true,
+                    iterationIndex: iterIdx,
+                    children: []
                 })
-            }
+                executionIndexById.set(virtualId, -1)
+                indices.forEach((i) => childToVirtualParent.set(uniqueId(nodes[i].nodeId, i), virtualId))
+            })
+        })
 
-            return treeNode
+        // Find the most recent ancestor among `previousNodeIds`. Optionally
+        // restrict the search to nodes within the same iteration (for sub-tree
+        // building inside virtual iteration containers).
+        const findAncestor = (
+            n: NodeExecutionData,
+            currentIndex: number,
+            sameIterationOnly = false
+        ): { index: number; nodeId: string } | null => {
+            if (!n.previousNodeIds || n.previousNodeIds.length === 0) return null
+            let bestIndex = -1
+            let bestNodeId: string | null = null
+            for (const prevId of n.previousNodeIds) {
+                for (let i = 0; i < currentIndex; i++) {
+                    const candidate = nodes[i]
+                    if (candidate.nodeId !== prevId) continue
+                    if (sameIterationOnly) {
+                        if (candidate.parentNodeId !== n.parentNodeId) continue
+                        if (candidate.iterationIndex !== n.iterationIndex) continue
+                    }
+                    if (i > bestIndex) {
+                        bestIndex = i
+                        bestNodeId = prevId
+                    }
+                }
+            }
+            return bestIndex >= 0 && bestNodeId ? { index: bestIndex, nodeId: bestNodeId } : null
         }
 
-        return topLevel.map(buildNode)
+        const rootNodes: ExecutionTreeNode[] = []
+
+        // First pass: link non-iteration nodes via previousNodeIds.
+        nodes.forEach((n, index) => {
+            if (isIterationChild(n)) return
+            const self = treeNodes.get(uniqueId(n.nodeId, index))!
+
+            const ancestor = findAncestor(n, index)
+            if (!ancestor) {
+                rootNodes.push(self)
+                return
+            }
+            // findAncestor returns indices we've already seeded into treeNodes — non-null.
+            const parent = treeNodes.get(uniqueId(ancestor.nodeId, ancestor.index))!
+            parent.children.push(self)
+        })
+
+        // Second pass: attach virtual iteration nodes to the iteration agent's
+        // most recent instance.
+        iterationGroups.forEach((byIdx, parentNodeId) => {
+            let latestParentIndex = -1
+            for (let i = nodes.length - 1; i >= 0; i--) {
+                if (nodes[i].nodeId === parentNodeId) {
+                    latestParentIndex = i
+                    break
+                }
+            }
+            const parent = latestParentIndex >= 0 ? treeNodes.get(uniqueId(parentNodeId, latestParentIndex)) : undefined
+            if (!parent) return
+            Array.from(byIdx.keys())
+                .sort((a, b) => a - b)
+                .forEach((iterIdx) => {
+                    const virtual = virtualNodes.get(`${parentNodeId}-iteration-${iterIdx}`)
+                    if (virtual) parent.children.push(virtual)
+                })
+        })
+
+        // Third pass: build sub-tree inside each virtual iteration container.
+        nodes.forEach((n, index) => {
+            if (!isIterationChild(n)) return
+            const self = treeNodes.get(uniqueId(n.nodeId, index))!
+            const virtualId = childToVirtualParent.get(self.id)
+            if (!virtualId) return
+            const virtualParent = virtualNodes.get(virtualId)
+            if (!virtualParent) return
+
+            const ancestor = findAncestor(n, index, true)
+            if (!ancestor) {
+                virtualParent.children.push(self)
+                return
+            }
+            // findAncestor returns indices we've already seeded into treeNodes — non-null.
+            const ancestorNode = treeNodes.get(uniqueId(ancestor.nodeId, ancestor.index))!
+            ancestorNode.children.push(self)
+        })
+
+        // PARITY: legacy ExecutionDetails.jsx:589-614 sorts every node's
+        // children so virtual iteration nodes appear before non-iteration
+        // siblings; non-iteration siblings preserve original execution order.
+        const sortChildren = (node: ExecutionTreeNode) => {
+            if (node.children.length === 0) return
+            node.children.sort((a, b) => {
+                const aVirtual = a.isVirtualNode === true
+                const bVirtual = b.isVirtualNode === true
+                if (aVirtual !== bVirtual) return aVirtual ? -1 : 1
+                // Every real and virtual node id is seeded into executionIndexById — non-null.
+                return executionIndexById.get(a.id)! - executionIndexById.get(b.id)!
+            })
+            node.children.forEach(sortChildren)
+        }
+        rootNodes.forEach(sortChildren)
+
+        return rootNodes
     }, [executionDataJson])
 }

--- a/packages/observe/src/features/executions/hooks/useHumanInput.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useHumanInput.test.tsx
@@ -36,10 +36,12 @@ describe('useHumanInput', () => {
             )
         })
 
-        it('does not open the feedback dialog when enableFeedback=false', () => {
+        it('does not open the feedback dialog when enableFeedback=false', async () => {
             const onHumanInput = jest.fn().mockResolvedValue(undefined)
             const { result } = renderHook(() => useHumanInput({ ...baseOpts, onHumanInput }))
-            act(() => {
+            // Async act so the post-await `setIsSubmitting(false)` in `submit`'s
+            // finally block flushes inside the boundary.
+            await act(async () => {
                 result.current.handleProceed()
             })
             expect(result.current.feedbackOpen).toBe(false)

--- a/packages/observe/src/features/executions/hooks/useNodeData.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useNodeData.test.tsx
@@ -79,6 +79,16 @@ describe('useNodeData', () => {
             const { result } = renderHook(() => useNodeData(makeNode({ data: { input: {} } })))
             expect(result.current.hasInput).toBe(false)
         })
+
+        it('suppresses iteration parent input — legacy renders "No data" for iterationAgentflow', () => {
+            const { result } = renderHook(() =>
+                useNodeData(
+                    makeNode({ name: 'iterationAgentflow', data: { name: 'iterationAgentflow', input: { iterationInput: [{}, {}, {}] } } })
+                )
+            )
+            expect(result.current.inputValue).toBeUndefined()
+            expect(result.current.hasInput).toBe(false)
+        })
     })
 
     describe('inputMessages (chat detection)', () => {
@@ -187,6 +197,11 @@ describe('useNodeData', () => {
 
             const no = renderHook(() => useNodeData(makeNode({ name: 'llmAgentflow', data: {} })))
             expect(no.result.current.isHumanInputNode).toBe(false)
+        })
+
+        it('isHumanInputNode resolves via data.name (runtime payload shape, no top-level name)', () => {
+            const { result } = renderHook(() => useNodeData(makeNode({ data: { name: 'humanInputAgentflow' } })))
+            expect(result.current.isHumanInputNode).toBe(true)
         })
 
         it('enableFeedback reads from data.input.humanInputEnableFeedback', () => {

--- a/packages/observe/src/features/executions/hooks/useNodeData.ts
+++ b/packages/observe/src/features/executions/hooks/useNodeData.ts
@@ -78,6 +78,9 @@ export function useNodeData(node: ExecutionTreeNode): DerivedNodeData {
             if (typeof input === 'object' && !Array.isArray(input) && 'question' in (input as Record<string, unknown>)) {
                 return (input as Record<string, unknown>).question
             }
+            // Iteration parent: legacy's fallback renders `data.input.question || '*No data*'`,
+            // and the runtime emits `data.input.iterationInput` (no `question`) → "No data".
+            if (payload.name === 'iterationAgentflow') return undefined
             return input
         })()
 
@@ -119,7 +122,11 @@ export function useNodeData(node: ExecutionTreeNode): DerivedNodeData {
             typeof stateValue === 'object' &&
             Object.keys(stateValue as Record<string, unknown>).length > 0
 
-        const isHumanInputNode = raw?.name === 'humanInputAgentflow'
+        // Same fallback chain as the tree builder: the runtime emits the type
+        // identifier on `data.name`, not at the top level.
+        const dataName = raw?.data?.name
+        const resolvedName = raw?.name ?? (typeof dataName === 'string' ? dataName : undefined)
+        const isHumanInputNode = resolvedName === 'humanInputAgentflow'
         const enableFeedback = dataInput?.humanInputEnableFeedback === true || payload.humanInputEnableFeedback === true
 
         return {

--- a/packages/observe/src/features/executions/hooks/useResizableSidebar.test.tsx
+++ b/packages/observe/src/features/executions/hooks/useResizableSidebar.test.tsx
@@ -95,6 +95,47 @@ describe('useResizableSidebar', () => {
         removeSpy.mockRestore()
     })
 
+    describe('inverted: true (right-anchored panel like a Drawer)', () => {
+        const invertedOptions = { ...baseOptions, inverted: true }
+
+        it('grows the width when the cursor moves left', () => {
+            const { result } = renderHook(() => useResizableSidebar(invertedOptions))
+            // Start drag at x=500 with width=300 (default).
+            act(() => {
+                result.current.onMouseDown({ clientX: 500 } as unknown as React.MouseEvent)
+            })
+            // Cursor moves to x=400 (delta = -100). Inverted: width grows by 100.
+            act(() => dispatchMouseMove(400))
+            expect(result.current.width).toBe(400)
+            act(() => dispatchMouseUp())
+        })
+
+        it('shrinks the width when the cursor moves right', () => {
+            const { result } = renderHook(() => useResizableSidebar({ ...invertedOptions, defaultWidth: 400 }))
+            act(() => {
+                result.current.onMouseDown({ clientX: 500 } as unknown as React.MouseEvent)
+            })
+            // Cursor moves to x=600 (delta = +100). Inverted: width shrinks by 100.
+            act(() => dispatchMouseMove(600))
+            expect(result.current.width).toBe(300)
+            act(() => dispatchMouseUp())
+        })
+
+        it('still clamps to [minWidth, maxWidth]', () => {
+            const { result } = renderHook(() => useResizableSidebar(invertedOptions))
+            act(() => {
+                result.current.onMouseDown({ clientX: 500 } as unknown as React.MouseEvent)
+            })
+            // Drag far left → would give a huge width; clamps to maxWidth (480).
+            act(() => dispatchMouseMove(-10000))
+            expect(result.current.width).toBe(480)
+            // Drag far right → would give a tiny/negative width; clamps to minWidth (180).
+            act(() => dispatchMouseMove(10000))
+            expect(result.current.width).toBe(180)
+            act(() => dispatchMouseUp())
+        })
+    })
+
     it('does not update width when mousemove fires without a prior mousedown', () => {
         // Edge case: a stray document-level mousemove (e.g. another component
         // dispatched it) must not move the sidebar before the user drags.

--- a/packages/observe/src/features/executions/hooks/useResizableSidebar.ts
+++ b/packages/observe/src/features/executions/hooks/useResizableSidebar.ts
@@ -7,6 +7,12 @@ interface UseResizableSidebarOptions {
     minWidth: number
     /** Maximum width (in px) the user can drag the sidebar to. */
     maxWidth: number
+    /**
+     * When true, dragging left grows the panel (and dragging right shrinks it).
+     * Use for right-anchored panels like a right-side `<Drawer>` whose handle
+     * sits on its LEFT edge. Defaults to false (left-anchored: drag right grows).
+     */
+    inverted?: boolean
 }
 
 interface UseResizableSidebarResult {
@@ -23,7 +29,12 @@ interface UseResizableSidebarResult {
  * Encapsulates: width state, drag-state refs, document-level mousemove /
  * mouseup listeners, and cleanup on unmount.
  */
-export function useResizableSidebar({ defaultWidth, minWidth, maxWidth }: UseResizableSidebarOptions): UseResizableSidebarResult {
+export function useResizableSidebar({
+    defaultWidth,
+    minWidth,
+    maxWidth,
+    inverted = false
+}: UseResizableSidebarOptions): UseResizableSidebarResult {
     const [width, setWidth] = useState(defaultWidth)
     const [hasUserResized, setHasUserResized] = useState(false)
     const isDragging = useRef(false)
@@ -39,10 +50,11 @@ export function useResizableSidebar({ defaultWidth, minWidth, maxWidth }: UseRes
         (e: MouseEvent) => {
             if (!isDragging.current) return
             const delta = e.clientX - dragStartX.current
-            const next = Math.min(maxWidth, Math.max(minWidth, dragStartWidth.current + delta))
+            const adjusted = inverted ? -delta : delta
+            const next = Math.min(maxWidth, Math.max(minWidth, dragStartWidth.current + adjusted))
             setWidth(next)
         },
-        [maxWidth, minWidth]
+        [maxWidth, minWidth, inverted]
     )
 
     const handleMouseUp = useCallback(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,6 +816,9 @@ importers:
       '@mui/material':
         specifier: ^5.15.0
         version: 5.15.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/x-tree-view':
+        specifier: ^7.25.0
+        version: 7.29.1(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react@18.2.0))(@mui/material@5.15.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@6.4.7(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.4(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react@18.2.0))(@types/react@18.2.65)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tabler/icons-react':
         specifier: ^3.7.0
         version: 3.31.0(react@18.2.0)
@@ -927,7 +930,7 @@ importers:
         version: 6.11.0
       '@google-cloud/logging-winston':
         specifier: ^6.0.0
-        version: 6.0.0(winston@3.12.0)
+        version: 6.0.0(encoding@0.1.13)(winston@3.12.0)
       '@keyv/redis':
         specifier: ^4.2.0
         version: 4.3.3
@@ -1101,7 +1104,7 @@ importers:
         version: 1.2.0
       multer-cloud-storage:
         specifier: ^4.0.0
-        version: 4.0.0
+        version: 4.0.0(encoding@0.1.13)
       multer-s3:
         specifier: ^3.0.1
         version: 3.0.1(@aws-sdk/client-s3@3.844.0)
@@ -1517,7 +1520,7 @@ importers:
         version: 29.7.0(@types/node@22.16.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2))
       pretty-quick:
         specifier: ^3.1.3
-        version: 3.3.1(prettier@3.2.5)
+        version: 3.3.1(prettier@2.8.8)
       react-scripts:
         specifier: ^5.0.1
         version: 5.0.1(@babel/plugin-syntax-flow@7.23.3(@babel/core@7.24.0))(@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.24.0))(@swc/core@1.4.6)(@types/babel__core@7.20.5)(bufferutil@4.0.8)(canvas@2.11.2(encoding@0.1.13))(eslint@8.57.0)(react@18.2.0)(sass@1.71.1)(ts-node@10.9.2(@swc/core@1.4.6)(@types/node@22.16.3)(typescript@5.5.2))(type-fest@4.40.1)(typescript@5.5.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)
@@ -20080,11 +20083,12 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuidv7@0.6.3:
@@ -26058,7 +26062,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/common@5.0.2':
+  '@google-cloud/common@5.0.2(encoding@0.1.13)':
     dependencies:
       '@google-cloud/projectify': 4.0.0
       '@google-cloud/promisify': 4.1.0
@@ -26073,9 +26077,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/logging-winston@6.0.0(winston@3.12.0)':
+  '@google-cloud/logging-winston@6.0.0(encoding@0.1.13)(winston@3.12.0)':
     dependencies:
-      '@google-cloud/logging': 11.2.0
+      '@google-cloud/logging': 11.2.0(encoding@0.1.13)
       google-auth-library: 9.15.1(encoding@0.1.13)
       lodash.mapvalues: 4.6.0
       winston: 3.12.0
@@ -26084,9 +26088,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/logging@11.2.0':
+  '@google-cloud/logging@11.2.0(encoding@0.1.13)':
     dependencies:
-      '@google-cloud/common': 5.0.2
+      '@google-cloud/common': 5.0.2(encoding@0.1.13)
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/projectify': 4.0.0
       '@google-cloud/promisify': 4.1.0
@@ -40947,7 +40951,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  multer-cloud-storage@4.0.0:
+  multer-cloud-storage@4.0.0(encoding@0.1.13):
     dependencies:
       '@google-cloud/storage': 7.16.0(encoding@0.1.13)
       '@types/express': 5.0.1
@@ -42564,17 +42568,6 @@ snapshots:
       picocolors: 1.0.0
       picomatch: 3.0.1
       prettier: 2.8.8
-      tslib: 2.6.2
-
-  pretty-quick@3.3.1(prettier@3.2.5):
-    dependencies:
-      execa: 4.1.0
-      find-up: 4.1.0
-      ignore: 5.3.1
-      mri: 1.2.0
-      picocolors: 1.0.0
-      picomatch: 3.0.1
-      prettier: 3.2.5
       tslib: 2.6.2
 
   prism-react-renderer@1.3.5(react@18.2.0):


### PR DESCRIPTION
## Summary

Ports the legacy `ExecutionDetails.jsx` (~984 lines) into the `@flowiseai/observe` SDK as a composable `ExecutionDetail` orchestrator.

- **`ExecutionDetail`**: split-pane (sidebar tree + node detail) with sidebar header that holds the agentflow chip, Copy-ID chip, formatted updated date, and refresh button. Auto-selects the first STOPPED node (or first top-level otherwise) on initial tree build.
- **`ExecutionTreeSidebar`**: `@mui/x-tree-view` `RichTreeView` with a custom `TreeItem2` slot — per-branch border colored from `AGENTFLOW_ICONS`, status-icon variants on each row, virtual `Iteration #N` containers, controlled expand/collapse defaulting to all-expanded.
- **`useExecutionTree`** rewritten to mirror the legacy three-pass `buildTreeData`: `previousNodeIds` parent→child with most-recent disambiguation, iteration grouping under the latest parent instance, sub-tree linking inside virtual containers, iterations-first sibling sort, and recursive `FLOWISE_CREDENTIAL_ID` scrub. Iteration container status is the legacy `ERROR > INPROGRESS > all-FINISHED > UNKNOWN` rollup.
- **`useDrawerWidths`** + `useResizableSidebar({ inverted })` extension drive a resizable `ExecutionsViewer` Drawer (parity with the legacy left-edge drag handle). Adds a public `ExecutionsViewerProps.drawer?: { defaultWidth?, minWidth?, maxWidth? }` override.
- **`AGENTFLOW_ICONS`** lifted from `atoms/NodeIcon.tsx` to `core/primitives/agentflowIcons.ts` so the tree slot can consume it without re-importing through `atoms`.
- **`ExecutionDetailProps.agentflow?: AgentflowRef`** seeds the header chip while the detail endpoint loads (server-side `getExecutionById` doesn't perform the agentflow join — only `getAllExecutions` does).
- Adds `@mui/x-tree-view` as a runtime dep.

## Test plan

- [x] `pnpm -C packages/observe test:coverage` — 331 tests pass, all `coverageThreshold` entries met (85.37% statements / 82.98% branches overall; `useExecutionTree` 96.5% / 85.18%, new `useDrawerWidths` 100% / 90.9%, `ExecutionDetail` 89.18% / 92.5%).
- [x] Manually verify in `packages/observe/examples` (`pnpm dev` after copying `.env.example` to `.env`):
  - List → row click opens the resizable Drawer; left-edge handle widens/narrows.
  - Tree shows status icons for each row plus rolled-up status on virtual iteration containers; `IconLoader` spins for INPROGRESS rows.
  - Agentflow chip is clickable and opens the canvas in a new tab when `VITE_AGENTFLOW_CANVAS_URL` is set; non-clickable otherwise.
  - Copy-ID chip flips inline to `Copied!` for 2s. **Behavior change from legacy**: legacy dispatched a Redux/notistack snackbar toast ("ID copied to clipboard") via the host app; the SDK can't assume a snackbar provider exists, so the confirmation is rendered on the chip itself.
  - Refresh button re-fetches; date formatted as `MMM d, yyyy h:mm a`.
  - Standalone `<ExecutionDetail>` demo by execution id renders the same surface without the list.

FLOWISE-576

### Demo

https://github.com/user-attachments/assets/3dfd7f03-9ade-4024-ba9b-6dbfd12e5251

https://github.com/user-attachments/assets/7d6a892d-a528-43a4-bbb0-9d5c453295fb
