### PR TITLE
feat:686 | smart agents - StateBackend

### DIFF
--- a/packages/components/nodes/agentflow/SmartAgent/SmartAgent.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/SmartAgent.ts
@@ -25,6 +25,7 @@ import { PlanningTool, Todo } from './planning/PlanningTool'
 import { buildSystemPrompt } from './context/SystemPromptBuilder'
 import { createBackend } from './sandbox/factory'
 import { buildFsTools } from './sandbox/tools/fs'
+import { FileData } from './sandbox/BackendProtocol'
 import { getErrorMessage } from '../../../src/error'
 import { DataSource } from 'typeorm'
 import { randomBytes } from 'crypto'
@@ -1037,8 +1038,28 @@ class SmartAgent_Agentflow implements INode {
                 toolNode: { label: 'Planning', name: 'write_todos' }
             })
 
-            const backend = await createBackend()
-            const fsTools = buildFsTools(backend)
+            // For StateBackend, runtimeState.files is the persisted snapshot — saved into executionData by the
+            // agentflow engine when startPersistState=true.
+            const runtimeState = options.agentflowRuntime?.state as ICommonObject | undefined
+            const initialFiles = (runtimeState?.files as Record<string, FileData> | undefined) ?? {}
+            const backend = await createBackend(initialFiles)
+            const fsTools = buildFsTools(backend, (update) => {
+                if (!runtimeState) return
+
+                // keep runtimeState.files in sync with the backend after each mutation
+                const existing = (runtimeState.files as Record<string, FileData> | undefined) ?? {}
+                const merged = { ...existing }
+                for (const [path, data] of Object.entries(update)) {
+                    if (data === null) {
+                        delete merged[path]
+                    } else {
+                        merged[path] = data
+                    }
+                }
+
+                runtimeState.files = merged
+            })
+
             toolsInstance.push(...(fsTools as unknown as Tool[]))
 
             if (llmNodeInstance && toolsInstance.length > 0) {

--- a/packages/components/nodes/agentflow/SmartAgent/context/SystemPromptBuilder.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/context/SystemPromptBuilder.ts
@@ -46,11 +46,18 @@ You have access to a sandbox filesystem. All paths must be absolute.
 - \`/workspace/\` — working area for files you create or process during this task
 - \`/artifacts/\` — outputs intended to be surfaced to the user (reports, generated files, etc.)
 
-// TODO: Temporary demo instructions for read_file + write_file only. Later stages will replace this with
-// complete tool coverage (ls, edit_file, glob, grep) and richer path/usage guidance.
 **Available tools:**
 - \`read_file\` — read a text file; supports \`offset\` and \`limit\` for pagination of large files
-- \`write_file\` — create a new text file; **create-only** — errors if the file already exists`
+- \`write_file\` — create a new text file; **create-only** — errors if the file already exists
+- \`edit_file\` — replace a specific string in an existing file; errors if the string appears more than once unless \`replace_all\` is true
+- \`list_files\` — list files and directories at a given path
+- \`glob_files\` — find files matching a glob pattern (e.g. \`**/*.ts\`) within a base directory
+- \`grep_files\` — search file contents for a regex pattern; returns matching lines with file path and line number
+
+**Usage guidance:**
+- Prefer \`edit_file\` over re-writing a whole file when making targeted changes — it's faster and less error-prone.
+- Use \`glob_files\` to discover files before reading them; use \`grep_files\` to locate specific content across many files.
+- Large files: use \`offset\` + \`limit\` on \`read_file\` to paginate rather than reading the entire file at once.`
 
 // Part 5: Subagent prompt
 const SUBAGENT_PROMPT = `## Subagent Delegation

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/BackendProtocol.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/BackendProtocol.ts
@@ -24,7 +24,10 @@ export interface GrepMatch {
 }
 
 export type LsResult = { files: FileInfo[] } | { error: string }
-export type ReadResult = { content: string; mimeType: string } | { content: Uint8Array; mimeType: string } | { error: string }
+export type ReadResult =
+    | { content: string; mimeType: string; truncated: boolean }
+    | { content: Uint8Array; mimeType: string }
+    | { error: string }
 export type ReadRawResult = { data: FileData } | { error: string }
 export type WriteResult = { path: string; filesUpdate: FilesUpdate | null } | { error: string }
 export type EditResult = { path: string; occurrences: number; filesUpdate: FilesUpdate | null } | { error: string }

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/backends/StateBackend.test.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/backends/StateBackend.test.ts
@@ -43,6 +43,19 @@ describe('StateBackend — write/read', () => {
         }
     })
 
+    it('write of Uint8Array to a text-mimeType path is decoded to a string on read', async () => {
+        const backend = new StateBackend()
+        const bytes = new TextEncoder().encode('hi from bytes')
+        await backend.write('/workspace/decoded.txt', bytes)
+        const result = await backend.read('/workspace/decoded.txt')
+        expect('content' in result).toBe(true)
+        if ('content' in result) {
+            expect(typeof result.content).toBe('string')
+            expect(result.content).toBe('hi from bytes')
+            expect(result.mimeType).toBe('text/plain')
+        }
+    })
+
     it('constructor accepts initialFiles and makes them readable', async () => {
         const now = Date.now()
         const initialFiles: Record<string, FileData> = {

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/backends/StateBackend.test.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/backends/StateBackend.test.ts
@@ -1,7 +1,7 @@
 import { StateBackend } from './StateBackend'
 import { FileData } from '../BackendProtocol'
 
-describe('StateBackend', () => {
+describe('StateBackend — write/read', () => {
     it('write + read round-trip returns the written content', async () => {
         const backend = new StateBackend()
         await backend.write('/workspace/hello.txt', 'hi from sandbox')
@@ -53,6 +53,281 @@ describe('StateBackend', () => {
         expect('content' in result).toBe(true)
         if ('content' in result) {
             expect(result.content).toBe('seeded')
+        }
+    })
+})
+
+describe('StateBackend — read pagination', () => {
+    it('returns only the requested lines when offset and limit are set', async () => {
+        const backend = new StateBackend()
+        await backend.write('/paginated.txt', 'line1\nline2\nline3\nline4\nline5')
+        const result = await backend.read('/paginated.txt', 1, 2)
+        if ('content' in result) {
+            const lines = (result.content as string).split('\n').filter(Boolean)
+            expect(lines).toHaveLength(2)
+            expect(lines[0]).toBe('line2')
+            expect(lines[1]).toBe('line3')
+        }
+    })
+
+    it('returns content from offset 0 up to limit', async () => {
+        const backend = new StateBackend()
+        await backend.write('/short.txt', 'a\nb\nc')
+        const result = await backend.read('/short.txt', 0, 2)
+        if ('content' in result) {
+            const lines = (result.content as string).split('\n').filter(Boolean)
+            expect(lines).toHaveLength(2)
+            expect(lines[0]).toBe('a')
+        }
+    })
+})
+
+describe('StateBackend — readRaw', () => {
+    it('returns the underlying FileData', async () => {
+        const backend = new StateBackend()
+        await backend.write('/raw.txt', 'raw bytes')
+        const result = await backend.readRaw('/raw.txt')
+        expect('data' in result).toBe(true)
+        if ('data' in result) {
+            expect(result.data.content).toBe('raw bytes')
+            expect(result.data.mimeType).toBe('text/plain')
+            expect(typeof result.data.created_at).toBe('number')
+            expect(typeof result.data.modified_at).toBe('number')
+        }
+    })
+
+    it('returns an error for missing file', async () => {
+        const backend = new StateBackend()
+        const result = await backend.readRaw('/nope.txt')
+        expect('error' in result).toBe(true)
+    })
+})
+
+describe('StateBackend — ls', () => {
+    async function seed() {
+        const backend = new StateBackend()
+        await backend.write('/a.txt', 'A')
+        await backend.write('/dir/b.txt', 'B')
+        await backend.write('/dir/sub/c.txt', 'C')
+        return backend
+    }
+
+    it('ls("/") returns top-level file and synthesized directory', async () => {
+        const backend = await seed()
+        const result = await backend.ls('/')
+        expect('files' in result).toBe(true)
+        if ('files' in result) {
+            const names = result.files.map((f) => f.name)
+            expect(names).toContain('a.txt')
+            expect(names).toContain('dir')
+            const dir = result.files.find((f) => f.name === 'dir')
+            expect(dir!.isDirectory).toBe(true)
+            const file = result.files.find((f) => f.name === 'a.txt')
+            expect(file!.isDirectory).toBe(false)
+        }
+    })
+
+    it('ls("/dir") lists nested files and synthesizes deeper directory', async () => {
+        const backend = await seed()
+        const result = await backend.ls('/dir')
+        expect('files' in result).toBe(true)
+        if ('files' in result) {
+            const names = result.files.map((f) => f.name)
+            expect(names).toContain('b.txt')
+            expect(names).toContain('sub')
+            const sub = result.files.find((f) => f.name === 'sub')
+            expect(sub!.isDirectory).toBe(true)
+        }
+    })
+
+    it('returns entries sorted alphabetically', async () => {
+        const backend = new StateBackend()
+        await backend.write('/zeta.txt', '')
+        await backend.write('/alpha.txt', '')
+        await backend.write('/mu.txt', '')
+        const result = await backend.ls('/')
+        if ('files' in result) {
+            const names = result.files.map((f) => f.name)
+            expect(names).toEqual(['alpha.txt', 'mu.txt', 'zeta.txt'])
+        }
+    })
+})
+
+describe('StateBackend — edit', () => {
+    it('replaces a single match and returns FilesUpdate', async () => {
+        const backend = new StateBackend()
+        await backend.write('/edit.txt', 'hello world')
+        const before = (await backend.readRaw('/edit.txt')) as { data: FileData }
+        // Force a delta in modified_at
+        await new Promise((r) => setTimeout(r, 2))
+        const result = await backend.edit('/edit.txt', 'world', 'sandbox')
+        expect('error' in result).toBe(false)
+        if (!('error' in result)) {
+            expect(result.occurrences).toBe(1)
+            expect(result.filesUpdate).not.toBeNull()
+            expect(result.filesUpdate!['/edit.txt']).toBeDefined()
+            expect(result.filesUpdate!['/edit.txt']!.modified_at).toBeGreaterThanOrEqual(before.data.modified_at)
+        }
+        const after = await backend.read('/edit.txt')
+        if ('content' in after) {
+            expect(after.content).toBe('hello sandbox')
+        }
+    })
+
+    it('replaceAll replaces every occurrence', async () => {
+        const backend = new StateBackend()
+        await backend.write('/all.txt', 'foo bar foo')
+        const result = await backend.edit('/all.txt', 'foo', 'baz', true)
+        if (!('error' in result)) {
+            expect(result.occurrences).toBe(2)
+        }
+        const after = await backend.read('/all.txt')
+        if ('content' in after) {
+            expect(after.content).toBe('baz bar baz')
+        }
+    })
+
+    it('zero matches returns an error mentioning the file path', async () => {
+        const backend = new StateBackend()
+        await backend.write('/empty.txt', 'hello')
+        const result = await backend.edit('/empty.txt', 'missing', 'x')
+        expect('error' in result).toBe(true)
+        if ('error' in result) {
+            expect(result.error).toContain('/empty.txt')
+        }
+    })
+
+    it('multiple matches without replaceAll errors and reports the count', async () => {
+        const backend = new StateBackend()
+        await backend.write('/multi.txt', 'foo foo foo')
+        const result = await backend.edit('/multi.txt', 'foo', 'bar')
+        expect('error' in result).toBe(true)
+        if ('error' in result) {
+            expect(result.error).toContain('3')
+        }
+    })
+
+    it('errors when target file is binary', async () => {
+        const backend = new StateBackend()
+        await backend.write('/img.png', new Uint8Array([137, 80, 78, 71]))
+        const result = await backend.edit('/img.png', 'a', 'b')
+        expect('error' in result).toBe(true)
+        if ('error' in result) {
+            expect(result.error).toMatch(/binary/i)
+        }
+    })
+
+    it('errors when file is missing', async () => {
+        const backend = new StateBackend()
+        const result = await backend.edit('/none.txt', 'a', 'b')
+        expect('error' in result).toBe(true)
+    })
+})
+
+describe('StateBackend — glob', () => {
+    it('matches files by pattern across directories', async () => {
+        const backend = new StateBackend()
+        await backend.write('/src/foo.ts', '')
+        await backend.write('/src/bar.js', '')
+        await backend.write('/lib/baz.ts', '')
+        const result = await backend.glob('**/*.ts', '/')
+        expect('files' in result).toBe(true)
+        if ('files' in result) {
+            const paths = result.files.map((f) => f.path).sort()
+            expect(paths).toEqual(['/lib/baz.ts', '/src/foo.ts'])
+        }
+    })
+
+    it('matches single-segment pattern within a directory', async () => {
+        const backend = new StateBackend()
+        await backend.write('/src/foo.ts', '')
+        await backend.write('/src/deep/bar.ts', '')
+        const result = await backend.glob('*.ts', '/src')
+        if ('files' in result) {
+            const paths = result.files.map((f) => f.path)
+            expect(paths).toEqual(['/src/foo.ts'])
+        }
+    })
+})
+
+describe('StateBackend — grep', () => {
+    it('finds matching lines and reports 1-indexed line numbers', async () => {
+        const backend = new StateBackend()
+        await backend.write('/notes.txt', 'line one\nfind me\nline three')
+        const result = await backend.grep('find me', '/')
+        expect('matches' in result).toBe(true)
+        if ('matches' in result) {
+            expect(result.matches).toHaveLength(1)
+            expect(result.matches[0].line).toBe(2)
+            expect(result.matches[0].path).toBe('/notes.txt')
+            expect(result.matches[0].content).toBe('find me')
+        }
+    })
+
+    it('respects glob filename filter', async () => {
+        const backend = new StateBackend()
+        await backend.write('/a.ts', 'target')
+        await backend.write('/a.js', 'target')
+        const result = await backend.grep('target', '/', '*.ts')
+        if ('matches' in result) {
+            expect(result.matches).toHaveLength(1)
+            expect(result.matches[0].path).toBe('/a.ts')
+        }
+    })
+
+    it('finds matches across multiple files and returns all', async () => {
+        const backend = new StateBackend()
+        await backend.write('/a.txt', 'match here\nnot here')
+        await backend.write('/b.txt', 'also a match here\nskip')
+        const result = await backend.grep('match', '/')
+        if ('matches' in result) {
+            expect(result.matches).toHaveLength(2)
+            const paths = result.matches.map((m) => m.path).sort()
+            expect(paths).toEqual(['/a.txt', '/b.txt'])
+        }
+    })
+
+    it('null dirPath searches from root', async () => {
+        const backend = new StateBackend()
+        await backend.write('/deep/nested/file.txt', 'find me')
+        const result = await backend.grep('find me', null)
+        if ('matches' in result) {
+            expect(result.matches).toHaveLength(1)
+            expect(result.matches[0].path).toBe('/deep/nested/file.txt')
+        }
+    })
+
+    it('skips binary files', async () => {
+        const backend = new StateBackend()
+        await backend.write('/img.png', new Uint8Array([137, 80, 78, 71]))
+        await backend.write('/text.txt', 'hello')
+        const result = await backend.grep('hello', '/')
+        if ('matches' in result) {
+            expect(result.matches).toHaveLength(1)
+            expect(result.matches[0].path).toBe('/text.txt')
+        }
+    })
+})
+
+describe('StateBackend — isolation & binary', () => {
+    it('two instances do not share state', async () => {
+        const a = new StateBackend()
+        const b = new StateBackend()
+        await a.write('/shared.txt', 'only in A')
+        const fromB = await b.read('/shared.txt')
+        expect('error' in fromB).toBe(true)
+    })
+
+    it('binary write/read round-trip preserves bytes and mime', async () => {
+        const backend = new StateBackend()
+        const png = new Uint8Array([137, 80, 78, 71])
+        await backend.write('/img.png', png)
+        const result = await backend.read('/img.png')
+        expect('content' in result).toBe(true)
+        if ('content' in result) {
+            expect(result.content).toBeInstanceOf(Uint8Array)
+            expect(Array.from(result.content as Uint8Array)).toEqual([137, 80, 78, 71])
+            expect(result.mimeType).toBe('image/png')
         }
     })
 })

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/backends/StateBackend.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/backends/StateBackend.ts
@@ -13,7 +13,7 @@ import {
     ReadResult,
     WriteResult
 } from '../BackendProtocol'
-import { escapeRegex, getMimeType, globToRegex, isTextMimeType, paginateLines } from '../utils'
+import { escapeRegex, getMimeType, globToRegex, isTextMimeType, normalizeContent, paginateLines } from '../utils'
 
 type FileStore = Record<string, FileData>
 
@@ -21,7 +21,10 @@ export class StateBackend implements BackendProtocol {
     protected files: FileStore
 
     constructor(initialFiles: FileStore = {}) {
-        this.files = { ...initialFiles }
+        this.files = {}
+        for (const [path, data] of Object.entries(initialFiles)) {
+            this.files[path] = { ...data, content: normalizeContent(data.content, data.mimeType) }
+        }
     }
 
     async write(filePath: string, content: string | Uint8Array): Promise<WriteResult> {
@@ -30,7 +33,7 @@ export class StateBackend implements BackendProtocol {
         }
         const mimeType = getMimeType(filePath)
         const now = Date.now()
-        const data: FileData = { content, mimeType, created_at: now, modified_at: now }
+        const data: FileData = { content: normalizeContent(content, mimeType), mimeType, created_at: now, modified_at: now }
         this.files[filePath] = data
         const filesUpdate: FilesUpdate = { [filePath]: data }
 

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/backends/StateBackend.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/backends/StateBackend.ts
@@ -1,10 +1,21 @@
-import { BackendProtocol, DEFAULT_READ_LIMIT, FileData, FilesUpdate, ReadResult, WriteResult } from '../BackendProtocol'
-import { getMimeType, isTextMimeType, paginateLines } from '../utils'
+import {
+    BackendProtocol,
+    DEFAULT_READ_LIMIT,
+    EditResult,
+    FileData,
+    FileInfo,
+    FilesUpdate,
+    GlobResult,
+    GrepMatch,
+    GrepResult,
+    LsResult,
+    ReadRawResult,
+    ReadResult,
+    WriteResult
+} from '../BackendProtocol'
+import { escapeRegex, getMimeType, globToRegex, isTextMimeType, paginateLines } from '../utils'
 
 type FileStore = Record<string, FileData>
-
-// TODO: Will be implemented in later stages.
-const NOT_IMPL = 'not implemented yet'
 
 export class StateBackend implements BackendProtocol {
     protected files: FileStore
@@ -28,28 +39,130 @@ export class StateBackend implements BackendProtocol {
 
     async read(filePath: string, offset = 0, limit = DEFAULT_READ_LIMIT): Promise<ReadResult> {
         const file = this.files[filePath]
-        if (!file) return { error: `File not found: ${filePath}` }
+        if (!file) {
+            return { error: `File not found: ${filePath}` }
+        }
         if (!isTextMimeType(file.mimeType)) {
             return { content: file.content as Uint8Array, mimeType: file.mimeType }
         }
+        const { content: paginated, truncated } = paginateLines(file.content as string, offset, limit)
 
-        return { content: paginateLines(file.content as string, offset, limit), mimeType: file.mimeType }
+        return { content: paginated, mimeType: file.mimeType, truncated }
     }
 
-    // TODO: Will be implemented in later stages.
-    ls(_p: string): Promise<never> {
-        throw new Error(NOT_IMPL)
+    async readRaw(filePath: string): Promise<ReadRawResult> {
+        const file = this.files[filePath]
+        if (!file) {
+            return { error: `File not found: ${filePath}` }
+        }
+
+        return { data: file }
     }
-    readRaw(_p: string): Promise<never> {
-        throw new Error(NOT_IMPL)
+
+    async edit(filePath: string, oldStr: string, newStr: string, replaceAll = false): Promise<EditResult> {
+        const file = this.files[filePath]
+        if (!file) {
+            return { error: `File not found: ${filePath}` }
+        }
+        if (!isTextMimeType(file.mimeType)) {
+            return { error: `Cannot edit binary file: ${filePath}` }
+        }
+
+        const content = file.content as string
+        const matches = content.match(new RegExp(escapeRegex(oldStr), 'g'))
+        const occurrences = matches ? matches.length : 0
+        if (occurrences === 0) {
+            return { error: `String not found in ${filePath}` }
+        }
+        if (occurrences > 1 && !replaceAll) {
+            return {
+                error: `Found ${occurrences} occurrences of the string in ${filePath}. Pass replaceAll=true to replace all, or provide a more specific oldStr.`
+            }
+        }
+        const updated = replaceAll ? content.replaceAll(oldStr, newStr) : content.replace(oldStr, newStr)
+        const newData: FileData = { ...file, content: updated, modified_at: Date.now() }
+        this.files[filePath] = newData
+        const filesUpdate: FilesUpdate = { [filePath]: newData }
+
+        return { path: filePath, occurrences, filesUpdate }
     }
-    edit(_p: string, _o: string, _n: string, _a?: boolean): Promise<never> {
-        throw new Error(NOT_IMPL)
+
+    async ls(dirPath: string): Promise<LsResult> {
+        const normalized = dirPath === '/' ? '/' : dirPath.endsWith('/') ? dirPath : dirPath + '/'
+        const seen = new Set<string>()
+        const files: FileInfo[] = []
+
+        for (const [key, data] of Object.entries(this.files)) {
+            if (!key.startsWith(normalized)) continue
+            const remaining = key.slice(normalized.length)
+            if (!remaining) continue
+            const firstSegment = remaining.split('/')[0]
+            if (seen.has(firstSegment)) continue
+            seen.add(firstSegment)
+            const isDirectory = remaining.includes('/')
+            files.push({
+                name: firstSegment,
+                path: normalized + firstSegment,
+                size: isDirectory ? 0 : data.content.length,
+                isDirectory,
+                mimeType: isDirectory ? undefined : data.mimeType
+            })
+        }
+        files.sort((a, b) => a.name.localeCompare(b.name))
+
+        return { files }
     }
-    grep(_p: string, _path?: string | null, _g?: string | null): Promise<never> {
-        throw new Error(NOT_IMPL)
+
+    async glob(pattern: string, basePath = '/'): Promise<GlobResult> {
+        const regex = globToRegex(pattern)
+        const normalized = basePath === '/' ? '/' : basePath.endsWith('/') ? basePath : basePath + '/'
+        const files: FileInfo[] = []
+
+        for (const [key, data] of Object.entries(this.files)) {
+            if (!key.startsWith(normalized)) continue
+            const relative = key.slice(normalized.length)
+            if (!relative) continue
+            if (!regex.test(relative)) continue
+            files.push({
+                name: relative.split('/').pop() ?? relative,
+                path: key,
+                size: data.content.length,
+                isDirectory: false,
+                mimeType: data.mimeType
+            })
+        }
+        files.sort((a, b) => a.path.localeCompare(b.path))
+
+        return { files, truncated: false }
     }
-    glob(_p: string, _path?: string): Promise<never> {
-        throw new Error(NOT_IMPL)
+
+    async grep(pattern: string, dirPath: string | null = '/', glob: string | null = null): Promise<GrepResult> {
+        let regex: RegExp
+        try {
+            regex = new RegExp(pattern)
+        } catch {
+            return { error: `Invalid regex pattern: ${pattern}` }
+        }
+        const globRx = glob ? globToRegex(glob) : null
+        const basePath = dirPath ?? '/'
+        const normalized = basePath === '/' ? '/' : basePath.endsWith('/') ? basePath : basePath + '/'
+        const matches: GrepMatch[] = []
+
+        for (const [key, data] of Object.entries(this.files)) {
+            if (!key.startsWith(normalized)) continue
+            if (!isTextMimeType(data.mimeType)) continue
+            if (globRx) {
+                const basename = key.split('/').pop() ?? key
+                if (!globRx.test(basename)) continue
+            }
+            const lines = (data.content as string).split('\n')
+            for (let i = 0; i < lines.length; i++) {
+                if (regex.test(lines[i])) {
+                    matches.push({ path: key, line: i + 1, content: lines[i] })
+                }
+            }
+        }
+
+        return { matches, truncated: false }
     }
 }

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/tools/fs.test.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/tools/fs.test.ts
@@ -1,0 +1,51 @@
+import { buildFsTools } from './fs'
+import { StateBackend } from '../backends/StateBackend'
+import { FilesUpdate } from '../BackendProtocol'
+
+function findTool(tools: ReturnType<typeof buildFsTools>, name: string) {
+    const tool = tools.find((t) => t.name === name)
+    if (!tool) throw new Error(`tool not found: ${name}`)
+    return tool
+}
+
+describe('buildFsTools — onFilesUpdate', () => {
+    it('write_file invokes onFilesUpdate with backend FilesUpdate on success', async () => {
+        const backend = new StateBackend()
+        const updates: FilesUpdate[] = []
+        const tools = buildFsTools(backend, (update) => updates.push(update))
+        const writeFile = findTool(tools, 'write_file')
+
+        const result = await writeFile.invoke({ file_path: '/x.txt', content: 'hello' })
+
+        expect(result).toContain('Successfully wrote')
+        expect(updates).toHaveLength(1)
+        expect(updates[0]['/x.txt']).toBeDefined()
+        expect(updates[0]['/x.txt']!.content).toBe('hello')
+    })
+
+    it('write_file does NOT invoke onFilesUpdate when path already exists', async () => {
+        const backend = new StateBackend()
+        const updates: FilesUpdate[] = []
+        const tools = buildFsTools(backend, (update) => updates.push(update))
+        const writeFile = findTool(tools, 'write_file')
+
+        await writeFile.invoke({ file_path: '/dup.txt', content: 'first' })
+        const second = await writeFile.invoke({ file_path: '/dup.txt', content: 'second' })
+
+        expect(second).toMatch(/Error/i)
+        // First successful write should have produced one update; the failing duplicate must NOT add another.
+        expect(updates).toHaveLength(1)
+    })
+
+    it('read_file never invokes onFilesUpdate', async () => {
+        const backend = new StateBackend()
+        await backend.write('/r.txt', 'content')
+        const updates: FilesUpdate[] = []
+        const tools = buildFsTools(backend, (update) => updates.push(update))
+        const readFile = findTool(tools, 'read_file')
+
+        await readFile.invoke({ file_path: '/r.txt' })
+
+        expect(updates).toHaveLength(0)
+    })
+})

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/tools/fs.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/tools/fs.ts
@@ -15,7 +15,8 @@ export function buildFsTools(backend: BackendProtocol, onFilesUpdate?: (update: 
         func: async ({ file_path, offset, limit }) => {
             const result = await backend.read(file_path, offset, limit)
             if ('error' in result) return `Error: ${result.error}`
-            if (result.content instanceof Uint8Array) return 'Error: binary files not supported in demo slice'
+            // TODO: Support binary files local and statebackend are completed
+            if (result.content instanceof Uint8Array) return 'Error: binary files not supported yet'
             return formatWithLineNumbers(result.content, offset ?? 0)
         }
     })

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/tools/fs.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/tools/fs.ts
@@ -1,9 +1,9 @@
 import { DynamicStructuredTool } from '@langchain/core/tools'
 import { z } from 'zod'
-import { BackendProtocol } from '../BackendProtocol'
+import { BackendProtocol, FilesUpdate } from '../BackendProtocol'
 import { formatWithLineNumbers } from '../utils'
 
-export function buildFsTools(backend: BackendProtocol): DynamicStructuredTool[] {
+export function buildFsTools(backend: BackendProtocol, onFilesUpdate?: (update: FilesUpdate) => void): DynamicStructuredTool[] {
     const readFileTool = new DynamicStructuredTool({
         name: 'read_file',
         description: 'Read a text file from the sandbox filesystem. Returns file contents with line numbers.',
@@ -31,9 +31,73 @@ export function buildFsTools(backend: BackendProtocol): DynamicStructuredTool[] 
         func: async ({ file_path, content }) => {
             const result = await backend.write(file_path, content)
             if ('error' in result) return `Error: ${result.error}`
+            if (result.filesUpdate) onFilesUpdate?.(result.filesUpdate)
             return `Successfully wrote ${result.path}`
         }
     })
 
-    return [readFileTool, writeFileTool]
+    const editFileTool = new DynamicStructuredTool({
+        name: 'edit_file',
+        description:
+            'Edit an existing text file by replacing a specific string. Fails if the string appears more than once unless replace_all is true.',
+        schema: z.object({
+            file_path: z.string().describe('Absolute path of the file to edit (e.g. /workspace/hello.txt)'),
+            old_str: z.string().describe('Exact string to find and replace'),
+            new_str: z.string().describe('String to replace it with'),
+            replace_all: z.boolean().optional().describe('Replace every occurrence instead of requiring exactly one (default false)')
+        }),
+        func: async ({ file_path, old_str, new_str, replace_all }) => {
+            const result = await backend.edit(file_path, old_str, new_str, replace_all ?? false)
+            if ('error' in result) return `Error: ${result.error}`
+            if (result.filesUpdate) onFilesUpdate?.(result.filesUpdate)
+            return `Edited ${result.path} (${result.occurrences} replacement${result.occurrences === 1 ? '' : 's'})`
+        }
+    })
+
+    const listFilesTool = new DynamicStructuredTool({
+        name: 'list_files',
+        description: 'List files and directories at a given path in the sandbox filesystem.',
+        schema: z.object({
+            dir_path: z.string().describe('Absolute directory path to list (e.g. /workspace or /)')
+        }),
+        func: async ({ dir_path }) => {
+            const result = await backend.ls(dir_path)
+            if ('error' in result) return `Error: ${result.error}`
+            if (!result.files.length) return `(empty directory)`
+            return result.files.map((f) => `${f.isDirectory ? 'd' : 'f'}  ${f.path}${f.isDirectory ? '/' : ''}  ${f.size}b`).join('\n')
+        }
+    })
+
+    const globFilesTool = new DynamicStructuredTool({
+        name: 'glob_files',
+        description: 'Find files matching a glob pattern (e.g. **/*.ts) within a base directory.',
+        schema: z.object({
+            pattern: z.string().describe('Glob pattern (e.g. **/*.ts, *.txt)'),
+            base_path: z.string().optional().describe('Base directory to search from (default /)')
+        }),
+        func: async ({ pattern, base_path }) => {
+            const result = await backend.glob(pattern, base_path ?? '/')
+            if ('error' in result) return `Error: ${result.error}`
+            if (!result.files.length) return `No files matched pattern "${pattern}"`
+            return result.files.map((f) => f.path).join('\n')
+        }
+    })
+
+    const grepFilesTool = new DynamicStructuredTool({
+        name: 'grep_files',
+        description: 'Search file contents for a regex pattern. Returns matching lines with file path and line number.',
+        schema: z.object({
+            pattern: z.string().describe('Regex pattern to search for (e.g. "function|const")'),
+            dir_path: z.string().optional().describe('Directory to search in (default /). Pass null to search all files.'),
+            glob: z.string().optional().describe('Optional glob to filter filenames (e.g. *.ts)')
+        }),
+        func: async ({ pattern, dir_path, glob }) => {
+            const result = await backend.grep(pattern, dir_path ?? '/', glob ?? null)
+            if ('error' in result) return `Error: ${result.error}`
+            if (!result.matches.length) return `No matches for "${pattern}"`
+            return result.matches.map((m) => `${m.path}:${m.line}  ${m.content}`).join('\n')
+        }
+    })
+
+    return [readFileTool, writeFileTool, editFileTool, listFilesTool, globFilesTool, grepFilesTool]
 }

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/tools/fs.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/tools/fs.ts
@@ -42,7 +42,7 @@ export function buildFsTools(backend: BackendProtocol, onFilesUpdate?: (update: 
             'Edit an existing text file by replacing a specific string. Fails if the string appears more than once unless replace_all is true.',
         schema: z.object({
             file_path: z.string().describe('Absolute path of the file to edit (e.g. /workspace/hello.txt)'),
-            old_str: z.string().describe('Exact string to find and replace'),
+            old_str: z.string().min(1).describe('Exact string to find and replace'),
             new_str: z.string().describe('String to replace it with'),
             replace_all: z.boolean().optional().describe('Replace every occurrence instead of requiring exactly one (default false)')
         }),
@@ -87,7 +87,7 @@ export function buildFsTools(backend: BackendProtocol, onFilesUpdate?: (update: 
         name: 'grep_files',
         description: 'Search file contents for a regex pattern. Returns matching lines with file path and line number.',
         schema: z.object({
-            pattern: z.string().describe('Regex pattern to search for (e.g. "function|const")'),
+            pattern: z.string().min(1).describe('Regex pattern to search for (e.g. "function|const")'),
             dir_path: z.string().optional().describe('Directory to search in (default /). Pass null to search all files.'),
             glob: z.string().optional().describe('Optional glob to filter filenames (e.g. *.ts)')
         }),

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/utils.test.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/utils.test.ts
@@ -30,13 +30,16 @@ describe('isTextMimeType', () => {
 describe('paginateLines', () => {
     const text = 'line1\nline2\nline3\nline4\nline5'
     it('returns first N lines from offset 0', () => {
-        expect(paginateLines(text, 0, 3)).toBe('line1\nline2\nline3')
+        expect(paginateLines(text, 0, 3)).toEqual({ content: 'line1\nline2\nline3', truncated: true })
     })
     it('returns slice from non-zero offset', () => {
-        expect(paginateLines(text, 2, 2)).toBe('line3\nline4')
+        expect(paginateLines(text, 2, 2)).toEqual({ content: 'line3\nline4', truncated: true })
     })
     it('returns remaining lines if limit exceeds length', () => {
-        expect(paginateLines(text, 4, 100)).toBe('line5')
+        expect(paginateLines(text, 4, 100)).toEqual({ content: 'line5', truncated: false })
+    })
+    it('sets truncated false when all lines fit', () => {
+        expect(paginateLines(text, 0, 100)).toEqual({ content: text, truncated: false })
     })
 })
 

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/utils.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/utils.ts
@@ -93,6 +93,15 @@ export function isTextMimeType(mimeType: string): boolean {
     return TEXT_MIME_PREFIXES.some((p) => mimeType.startsWith(p)) || TEXT_MIME_EXACT.has(mimeType)
 }
 
+// Coerce content to match its mimeType so backends can rely on
+// "text mimeType ⇒ string content, binary mimeType ⇒ Uint8Array content" as an invariant.
+export function normalizeContent(content: string | Uint8Array, mimeType: string): string | Uint8Array {
+    if (isTextMimeType(mimeType)) {
+        return typeof content === 'string' ? content : new TextDecoder().decode(content)
+    }
+    return content instanceof Uint8Array ? content : new TextEncoder().encode(content)
+}
+
 export function paginateLines(text: string, offset: number, limit: number): { content: string; truncated: boolean } {
     const lines = text.split('\n')
     const truncated = lines.length > offset + limit

--- a/packages/components/nodes/agentflow/SmartAgent/sandbox/utils.ts
+++ b/packages/components/nodes/agentflow/SmartAgent/sandbox/utils.ts
@@ -93,9 +93,11 @@ export function isTextMimeType(mimeType: string): boolean {
     return TEXT_MIME_PREFIXES.some((p) => mimeType.startsWith(p)) || TEXT_MIME_EXACT.has(mimeType)
 }
 
-export function paginateLines(text: string, offset: number, limit: number): string {
+export function paginateLines(text: string, offset: number, limit: number): { content: string; truncated: boolean } {
     const lines = text.split('\n')
-    return lines.slice(offset, offset + limit).join('\n')
+    const truncated = lines.length > offset + limit
+
+    return { content: lines.slice(offset, offset + limit).join('\n'), truncated }
 }
 
 export function escapeRegex(s: string): string {

--- a/packages/components/nodes/agentflow/Start/Start.ts
+++ b/packages/components/nodes/agentflow/Start/Start.ts
@@ -186,7 +186,7 @@ class Start_Agentflow implements INode {
         }
 
         const runtimeState = options.agentflowRuntime?.state as ICommonObject
-        if (startPersistState === true && runtimeState && Object.keys(runtimeState).length) {
+        if (runtimeState && Object.keys(runtimeState).length) {
             for (const state in runtimeState) {
                 flowState[state] = runtimeState[state]
             }

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -1617,9 +1617,12 @@ export const executeAgentFlow = async ({
         }
     }
 
-    // If the state is persistent, get the state from the previous execution
+    // If the state is persistent, get the state from the previous execution.
+    // SmartAgent with SANDBOX_TYPE=state always requires state persistence for its sandbox filesystem.
     const startPersistState = nodes.find((node) => node.data.name === 'startAgentflow')?.data.inputs?.startPersistState
-    if (startPersistState === true && previousExecution) {
+    const hasStatefulSmartAgent =
+        nodes.some((node) => node.data.name === 'smartAgentAgentflow') && (process.env.SANDBOX_TYPE || 'state') === 'state'
+    if ((startPersistState === true || hasStatefulSmartAgent) && previousExecution) {
         const previousExecutionData = (JSON.parse(previousExecution.executionData) as IAgentflowExecutedData[]) ?? []
 
         let previousState = {}


### PR DESCRIPTION
## Changes
- updated fs tools with universal edit_file, list_file, glob_files, and grep_file capabilities, add, and write already existed
- Updated systemPromptBuilder with additional fs tools
- SmartAgents: synced Statebackend using runTimeState.files to sync mutations and files so data is persisted across execution.

## Warnings
- current persistent of workspace "files" live in state.files and are persisted as part of executionData per turn.
- So every execution saves all of the workspace files in the executionData state again
- But this is also being done for chats in general, and the state files only take up a small amount of space in comparison after a few chats
- This is due to piggy backing off an existing engine pattern
- A more proper way is to save all workspace into a new table or ofcourse, just use a different sandbox mode.

## Videos
<details>
  <summary>Test Videos Demo</summary>

  <b>read-write-edit.mp4</b>
  <video src="https://github.com/user-attachments/assets/51e21519-944b-4832-94e9-68148d74ef4d" controls width="100%"></video>

  <br />

  <b>ls-grep-glob.mp4</b>
  <video src="https://github.com/user-attachments/assets/5fa73a15-ea17-41c8-8b97-4047836a1132" controls width="100%"></video>
</details>

