### PR TITLE
fix(agentflow): preserve raw tool_calls metadata for OpenAI-compatible providers

### DIFF
--- a/packages/components/nodes/agentflow/Agent/Agent.ts
+++ b/packages/components/nodes/agentflow/Agent/Agent.ts
@@ -2227,6 +2227,32 @@ class Agent_Agentflow implements INode {
             response.tool_calls.splice(response.tool_calls.indexOf(toolCall), 1)
         }
 
+        // Ensure raw OpenAI-compatible tool_calls are preserved for providers
+        // that require provider-specific fields (e.g. thought_signature) on follow-up turns.
+        if (response.tool_calls?.length) {
+            const existingRawToolCalls = (response.additional_kwargs as any)?.tool_calls
+            const mergedRawToolCalls = response.tool_calls.map((toolCall: any) => {
+                const existing = Array.isArray(existingRawToolCalls)
+                    ? existingRawToolCalls.find((raw: any) => raw?.id && toolCall?.id && raw.id === toolCall.id)
+                    : undefined
+                if (existing) return existing
+                return {
+                    id: toolCall.id,
+                    type: 'function',
+                    function: {
+                        name: toolCall.name,
+                        arguments: JSON.stringify(toolCall.args ?? {}),
+                        ...(toolCall?.thought_signature ? { thought_signature: toolCall.thought_signature } : {}),
+                        ...(toolCall?.thoughtSignature ? { thought_signature: toolCall.thoughtSignature } : {})
+                    }
+                }
+            })
+            response.additional_kwargs = {
+                ...(response.additional_kwargs ?? {}),
+                tool_calls: mergedRawToolCalls
+            }
+        }
+
         // Add LLM response with tool calls to messages
         messages.push(response)
 
@@ -2606,6 +2632,32 @@ class Agent_Agentflow implements INode {
 
         for (const toolCall of toBeRemovedToolCalls) {
             response.tool_calls.splice(response.tool_calls.indexOf(toolCall), 1)
+        }
+
+        // Ensure raw OpenAI-compatible tool_calls are preserved for providers
+        // that require provider-specific fields (e.g. thought_signature) on follow-up turns.
+        if (response.tool_calls?.length) {
+            const existingRawToolCalls = (response.additional_kwargs as any)?.tool_calls
+            const mergedRawToolCalls = response.tool_calls.map((toolCall: any) => {
+                const existing = Array.isArray(existingRawToolCalls)
+                    ? existingRawToolCalls.find((raw: any) => raw?.id && toolCall?.id && raw.id === toolCall.id)
+                    : undefined
+                if (existing) return existing
+                return {
+                    id: toolCall.id,
+                    type: 'function',
+                    function: {
+                        name: toolCall.name,
+                        arguments: JSON.stringify(toolCall.args ?? {}),
+                        ...(toolCall?.thought_signature ? { thought_signature: toolCall.thought_signature } : {}),
+                        ...(toolCall?.thoughtSignature ? { thought_signature: toolCall.thoughtSignature } : {})
+                    }
+                }
+            })
+            response.additional_kwargs = {
+                ...(response.additional_kwargs ?? {}),
+                tool_calls: mergedRawToolCalls
+            }
         }
 
         // Add LLM response with tool calls to messages


### PR DESCRIPTION
## Summary
Preserve raw OpenAI-compatible 	ool_calls metadata on assistant tool-call turns before re-invoking the model in AgentFlow.

This prevents provider-specific fields (for example 	hought_signature) from being dropped between tool-call round trips.

## What changed
- In both AgentFlow tool-call handling paths, before pushing the assistant tool-call message back into messages, rebuild dditional_kwargs.tool_calls by:
  - reusing existing raw tool call entries when available
  - otherwise synthesizing OpenAI-compatible raw entries from parsed 	ool_calls
- Preserve provider extensions such as 	hought_signature/	houghtSignature when present.

## Why
Some OpenAI-compatible providers (notably Gemini-compatible gateways) require extra metadata in tool-call payloads for follow-up requests after tool execution. If this metadata is lost, the second request can fail.

## Scope
- No behavior change for providers that do not need extra tool-call metadata.
- No changes to tool execution logic.

Closes #6275