### PR TITLE
feat(stt): support custom Azure Speech transcription endpoint URL

### DIFF
--- a/packages/components/src/speechToText.ts
+++ b/packages/components/src/speechToText.ts
@@ -14,6 +14,19 @@ const SpeechToTextType = {
     GROQ_WHISPER: 'groqWhisper'
 }
 
+export const buildAzureSpeechToTextUrl = (serviceRegion: string, apiVersion: string, baseUrl?: string) => {
+    const trimmedBaseUrl = baseUrl?.trim()
+    const base = trimmedBaseUrl
+        ? trimmedBaseUrl.replace(/\/+$/, '')
+        : `https://${serviceRegion}.cognitiveservices.azure.com/speechtotext/transcriptions:transcribe`
+
+    if (/[?&]api-version=/.test(base)) {
+        return base
+    }
+
+    return `${base}${base.includes('?') ? '&' : '?'}api-version=${encodeURIComponent(apiVersion)}`
+}
+
 export const convertSpeechToText = async (upload: IFileUpload, speechToTextConfig: ICommonObject, options: ICommonObject) => {
     if (speechToTextConfig) {
         const credentialId = speechToTextConfig.credentialId as string
@@ -76,8 +89,12 @@ export const convertSpeechToText = async (upload: IFileUpload, speechToTextConfi
             }
             case SpeechToTextType.AZURE_COGNITIVE: {
                 try {
-                    const baseUrl = `https://${credentialData.serviceRegion}.cognitiveservices.azure.com/speechtotext/transcriptions:transcribe`
                     const apiVersion = credentialData.apiVersion || '2024-05-15-preview'
+                    const azureSpeechToTextUrl = buildAzureSpeechToTextUrl(
+                        credentialData.serviceRegion,
+                        apiVersion,
+                        speechToTextConfig?.baseUrl
+                    )
 
                     const formData = new FormData()
                     const audioBlob = new Blob([new Uint8Array(audio_file)], { type: upload.type })
@@ -93,7 +110,7 @@ export const convertSpeechToText = async (upload: IFileUpload, speechToTextConfi
                     }
                     formData.append('definition', JSON.stringify(definition))
 
-                    const response = await axios.post(`${baseUrl}?api-version=${apiVersion}`, formData, {
+                    const response = await axios.post(azureSpeechToTextUrl, formData, {
                         headers: {
                             'Ocp-Apim-Subscription-Key': credentialData.azureSubscriptionKey,
                             Accept: 'application/json'

--- a/packages/components/src/utils.test.ts
+++ b/packages/components/src/utils.test.ts
@@ -1,4 +1,5 @@
 import { removeInvalidImageMarkdown, convertRequireToImport, COMMONJS_REQUIRE_REGEX, IMPORT_EXTRACTION_REGEX } from './utils'
+import { buildAzureSpeechToTextUrl } from './speechToText'
 
 describe('removeInvalidImageMarkdown', () => {
     describe('strips non-http/https image markdown', () => {
@@ -227,5 +228,36 @@ describe('Import extraction regex (utils.ts line 1596 pattern)', () => {
 
     it('returns empty array when there are no imports', () => {
         expect(extractModules('console.log("hello")')).toEqual([])
+    })
+})
+
+describe('buildAzureSpeechToTextUrl', () => {
+    it('builds default regional URL', () => {
+        const url = buildAzureSpeechToTextUrl('eastus', '2024-05-15-preview')
+        expect(url).toBe(
+            'https://eastus.cognitiveservices.azure.com/speechtotext/transcriptions:transcribe?api-version=2024-05-15-preview'
+        )
+    })
+
+    it('uses custom baseUrl and appends api-version', () => {
+        const url = buildAzureSpeechToTextUrl(
+            'eastus',
+            '2024-05-15-preview',
+            'https://custom.example.com/speechtotext/transcriptions:transcribe/'
+        )
+        expect(url).toBe(
+            'https://custom.example.com/speechtotext/transcriptions:transcribe?api-version=2024-05-15-preview'
+        )
+    })
+
+    it('keeps existing api-version in custom baseUrl', () => {
+        const url = buildAzureSpeechToTextUrl(
+            'eastus',
+            '2024-05-15-preview',
+            'https://custom.example.com/speechtotext/transcriptions:transcribe?api-version=2023-10-01'
+        )
+        expect(url).toBe(
+            'https://custom.example.com/speechtotext/transcriptions:transcribe?api-version=2023-10-01'
+        )
     })
 })

--- a/packages/ui/src/ui-component/extended/SpeechToText.jsx
+++ b/packages/ui/src/ui-component/extended/SpeechToText.jsx
@@ -166,6 +166,15 @@ const speechToTextProviders = {
                 optional: true
             },
             {
+                label: 'Base URL',
+                name: 'baseUrl',
+                type: 'string',
+                description:
+                    'Optional custom Azure Speech endpoint URL. Leave blank to use the default regional endpoint.',
+                placeholder: 'https://{region}.cognitiveservices.azure.com/speechtotext/transcriptions:transcribe',
+                optional: true
+            },
+            {
                 label: 'Profanity Filter Mode',
                 name: 'profanityFilterMode',
                 type: 'options',


### PR DESCRIPTION
## Summary\nThis addresses #3767 by enabling Azure STT users to provide a custom endpoint URL in Speech-to-Text configuration.\n\nFlowise's current Azure STT implementation uses the Azure REST transcription endpoint (not the browser SpeechSDK path that sets endpointId directly). To align with current architecture while enabling custom deployments, this PR adds a configurable aseUrl override for Azure STT requests.\n\n## Changes\n- Add uildAzureSpeechToTextUrl() helper in packages/components/src/speechToText.ts to safely construct Azure transcription URL.\n- Support optional speechToTextConfig.baseUrl for Azure STT; default behavior remains unchanged when omitted.\n- Add Azure STT Base URL input in UI (packages/ui/src/ui-component/extended/SpeechToText.jsx).\n- Add focused URL-construction regression tests in packages/components/src/utils.test.ts.\n\n## Notes\n- No behavior change for existing users unless they set Base URL.\n- Local test execution was not possible in this environment because dependencies are not installed (pnpm unavailable and network-constrained for install).