### PR TITLE
docs: add missing JSDoc comment for getGlobalVariable utility function

### DIFF
--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -806,6 +806,14 @@ export const clearSessionMemory = async (
     }
 }
 
+/**
+ * Get global variables from available variables and override config
+ * @param {ICommonObject} overrideConfig
+ * @param {IVariable[]} availableVariables
+ * @param {ICommonObject[]} variableOverrides
+ * @returns {Promise<object>}
+ */
+
 export const getGlobalVariable = async (
     overrideConfig?: ICommonObject,
     availableVariables: IVariable[] = [],


### PR DESCRIPTION
Added missing JSDoc comment for the `getGlobalVariable` function 
in packages/server/src/utils/index.ts.

Every other exported function in this file has JSDoc documentation,
but getGlobalVariable was missing it. This improves code consistency
and developer experience.