### PR TITLE
feat: remove scoped view option from ExecutionsListTable

### DIFF
--- a/packages/observe/src/features/executions/components/ExecutionsListTable.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionsListTable.tsx
@@ -13,8 +13,6 @@ interface ExecutionsListTableProps {
     onRowClick: (execution: Execution) => void
     onDelete?: (execution: Execution) => void
     allowDelete?: boolean
-    /** When true, hides the Agentflow Name column (scoped view) */
-    scoped?: boolean
 }
 
 function formatDate(iso: string): string {
@@ -37,8 +35,7 @@ export function ExecutionsListTable({
     onSelectAll,
     onRowClick,
     onDelete,
-    allowDelete = false,
-    scoped = false
+    allowDelete = false
 }: ExecutionsListTableProps) {
     const theme = useTheme()
     const allSelected = executions.length > 0 && executions.every((e) => selectedIds.has(e.id))
@@ -58,7 +55,7 @@ export function ExecutionsListTable({
                     </TableCell>
                     <TableCell>Status</TableCell>
                     <TableCell>Last Updated</TableCell>
-                    {!scoped && <TableCell>Agentflow</TableCell>}
+                    <TableCell>Agentflow</TableCell>
                     <TableCell>Session ID</TableCell>
                     <TableCell>Created</TableCell>
                     {allowDelete && <TableCell padding='checkbox' />}
@@ -91,11 +88,9 @@ export function ExecutionsListTable({
                         <TableCell>
                             <Typography variant='body2'>{formatDate(execution.updatedDate)}</Typography>
                         </TableCell>
-                        {!scoped && (
-                            <TableCell>
-                                <Typography variant='body2'>{execution.agentflow?.name ?? '—'}</Typography>
-                            </TableCell>
-                        )}
+                        <TableCell>
+                            <Typography variant='body2'>{execution.agentflow?.name ?? '—'}</Typography>
+                        </TableCell>
                         <TableCell>
                             <Tooltip title={execution.sessionId}>
                                 <Typography variant='body2' sx={{ fontFamily: 'monospace', fontSize: '0.7rem' }}>

--- a/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
+++ b/packages/observe/src/features/executions/components/ExecutionsViewer.tsx
@@ -38,8 +38,8 @@ const EXECUTION_STATES: Array<ExecutionState | ''> = ['', 'INPROGRESS', 'FINISHE
 
 /**
  * Top-level executions list + detail drawer.
- * When agentflowId is provided: scoped view (M1 — hides agentflow name column).
- * When agentflowId is omitted: full cross-agent list (M2).
+ * When agentflowId is provided: scoped view (filters list + hides agentflow-name filter).
+ * When agentflowId is omitted: full cross-agent list.
  */
 export function ExecutionsViewer({
     agentflowId,
@@ -234,7 +234,6 @@ export function ExecutionsViewer({
                         onRowClick={setDrawerExecution}
                         onDelete={(e) => setDeleteTarget(e)}
                         allowDelete={allowDelete}
-                        scoped={isScoped}
                     />
                 )}
             </Box>


### PR DESCRIPTION
- Removed the `scoped` prop from `ExecutionsListTable` to simplify the component.
- Adjusted the rendering logic to always display the Agentflow Name column.
- Updated comments in `ExecutionsViewer` to clarify the behavior of the agentflowId prop.''

Before
<img width="1093" height="835" alt="image" src="https://github.com/user-attachments/assets/b4a1a170-35f3-451a-96db-8403d48ec0f0" />

After 
<img width="1093" height="835" alt="image" src="https://github.com/user-attachments/assets/6d2e78d6-21ff-4df2-ae0f-1a7e579c14bf" />
