### PR TITLE
docker: add setup guide and fix .env.example defaults

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -4,7 +4,8 @@ PORT=3000
 ############################################## DATABASE ####################################################
 ############################################################################################################
 
-# DATABASE_PATH=/your_database_path/.flowise
+# Path inside the container — matches the volume mount ~/.flowise:/root/.flowise
+DATABASE_PATH=/root/.flowise
 # DATABASE_TYPE=postgres
 # DATABASE_PORT=5432
 # DATABASE_HOST=""
@@ -20,8 +21,8 @@ PORT=3000
 ############################################## SECRET KEYS #################################################
 ############################################################################################################
 
-# SECRETKEY_STORAGE_TYPE=local #(local | aws)
-# SECRETKEY_PATH=/your_secret_path/.flowise
+SECRETKEY_STORAGE_TYPE=local
+SECRETKEY_PATH=/root/.flowise
 # FLOWISE_SECRETKEY_OVERWRITE=myencryptionkey # (if you want to overwrite the secret key)
 # SECRETKEY_AWS_ACCESS_KEY=<your-access-key>
 # SECRETKEY_AWS_SECRET_KEY=<your-secret-key>
@@ -36,8 +37,8 @@ PORT=3000
 ############################################################################################################
 
 # DEBUG=true
-# LOG_PATH=/your_log_path/.flowise/logs
-# LOG_LEVEL=info #(error | warn | info | verbose | debug)
+LOG_PATH=/root/.flowise/logs
+LOG_LEVEL=info #(error | warn | info | verbose | debug)
 # LOG_SANITIZE_BODY_FIELDS=password,pwd,pass,secret,token,apikey,api_key,accesstoken,access_token,refreshtoken,refresh_token,clientsecret,client_secret,privatekey,private_key,secretkey,secret_key,auth,authorization,credential,credentials
 # LOG_SANITIZE_HEADER_FIELDS=authorization,x-api-key,x-auth-token,cookie
 # TOOL_FUNCTION_BUILTIN_DEP=crypto,fs
@@ -49,8 +50,8 @@ PORT=3000
 ############################################## STORAGE #####################################################
 ############################################################################################################
 
-# STORAGE_TYPE=local (local | s3 | gcs | azure)
-# BLOB_STORAGE_PATH=/your_storage_path/.flowise/storage
+STORAGE_TYPE=local
+BLOB_STORAGE_PATH=/root/.flowise/storage
 # S3_STORAGE_BUCKET_NAME=flowise
 # S3_STORAGE_ACCESS_KEY_ID=<your-access-key>
 # S3_STORAGE_SECRET_ACCESS_KEY=<your-secret-key>
@@ -82,7 +83,7 @@ PORT=3000
 # CUSTOM_MCP_TOOLS_MAX_BYTES=524288
 # CUSTOM_MCP_AUTHORIZE_TIMEOUT_MS=15000
 # SHOW_COMMUNITY_NODES=true
-# DISABLE_FLOWISE_TELEMETRY=true
+DISABLE_FLOWISE_TELEMETRY=true
 # DISABLED_NODES=bufferMemory,chatOpenAI (comma separated list of node names to disable)
 # Uncomment the following line to enable model list config, load the list of models from your local config file
 # see https://raw.githubusercontent.com/FlowiseAI/Flowise/main/packages/components/models.json for the format
@@ -93,7 +94,7 @@ PORT=3000
 ############################################ AUTH PARAMETERS ###############################################
 ############################################################################################################
 
-# APP_URL=http://localhost:3000
+APP_URL=http://localhost:3000
 
 # SMTP_HOST=smtp.host.com
 # SMTP_PORT=465
@@ -105,8 +106,8 @@ PORT=3000
 
 # Auth secrets: set via env (backwards compat) or leave unset to use file/AWS storage (SECRETKEY_PATH or SECRETKEY_STORAGE_TYPE=aws)
 # Generate a secure 32-byte secret using: openssl rand -hex 32
-# JWT_AUTH_TOKEN_SECRET=
-# JWT_REFRESH_TOKEN_SECRET=
+JWT_AUTH_TOKEN_SECRET=<run: openssl rand -hex 32>
+JWT_REFRESH_TOKEN_SECRET=<run: openssl rand -hex 32>
 
 JWT_ISSUER=Flowise
 JWT_AUDIENCE=Flowise
@@ -116,7 +117,7 @@ JWT_REFRESH_TOKEN_EXPIRY_IN_MINUTES=43200
 # EXPIRE_AUTH_TOKENS_ON_RESTART=true # (if you need to expire all tokens on app restart)
 
 # Generate a secure 32-byte secret using: openssl rand -hex 32 (or leave unset for file/AWS storage)
-# EXPRESS_SESSION_SECRET=
+EXPRESS_SESSION_SECRET=<run: openssl rand -hex 32>
 
 # SECURE_COOKIES=
 
@@ -125,7 +126,7 @@ JWT_REFRESH_TOKEN_EXPIRY_IN_MINUTES=43200
 # PASSWORD_SALT_HASH_ROUNDS=10
 
 # Generate a secure 32-byte secret using: openssl rand -hex 32 (or leave unset for file/AWS storage)
-# TOKEN_HASH_SECRET=
+TOKEN_HASH_SECRET=<run: openssl rand -hex 32>
 
 # WORKSPACE_INVITE_TEMPLATE_PATH=/path/to/custom/workspace_invite.hbs
 

--- a/docker/SETUP.md
+++ b/docker/SETUP.md
@@ -1,0 +1,143 @@
+# Flowise — Docker Setup Guide
+
+Local deployment of [FlowiseAI/Flowise](https://github.com/FlowiseAI/Flowise) using Docker Compose with SQLite storage.
+
+## Prerequisites
+
+- Docker Desktop (or Docker Engine + Compose plugin)
+- `openssl` available in your shell (for generating secrets)
+
+## 1. Clone and enter the docker directory
+
+```bash
+git clone https://github.com/FlowiseAI/Flowise.git
+cd Flowise/docker
+```
+
+## 2. Create and configure the `.env` file
+
+```bash
+cp .env.example .env
+```
+
+The `.env.example` ships with safe defaults pre-filled for a local Docker deployment. The only values you **must** replace are the four secret tokens — generate them with:
+
+```bash
+openssl rand -hex 32   # run once per secret
+```
+
+Fill in these four variables in `.env`:
+
+| Variable | Purpose |
+|---|---|
+| `JWT_AUTH_TOKEN_SECRET` | Signs access tokens |
+| `JWT_REFRESH_TOKEN_SECRET` | Signs refresh tokens |
+| `EXPRESS_SESSION_SECRET` | Secures session cookies |
+| `TOKEN_HASH_SECRET` | Hashes stored API tokens |
+
+All path variables (`DATABASE_PATH`, `LOG_PATH`, etc.) are pre-set to `/root/.flowise`, which maps to `~/.flowise` on the host via the volume defined in `docker-compose.yml`:
+
+```yaml
+volumes:
+  - ~/.flowise:/root/.flowise
+```
+
+### Root cause of startup failures
+
+Flowise will crash-loop with `ENOENT: no such file or directory, mkdir ''` if any path variable is passed as an empty string. The pre-filled values in `.env.example` prevent this.
+
+### Optional: use PostgreSQL instead of SQLite
+
+Uncomment and fill in the `DATABASE_*` block, then set:
+
+```env
+DATABASE_TYPE=postgres
+DATABASE_HOST=host.docker.internal  # reach the host from inside the container
+DATABASE_PORT=5432
+DATABASE_NAME=flowise
+DATABASE_USER=<your-pg-user>
+DATABASE_PASSWORD=<your-pg-password>
+```
+
+## 3. Start the container
+
+```bash
+docker compose up -d
+```
+
+Verify it started cleanly:
+
+```bash
+docker compose logs --tail=30
+# Should end with: "Flowise Server is listening at :3000"
+
+curl http://localhost:3000/api/v1/ping
+# → pong
+```
+
+## 4. Create the first admin account
+
+On a fresh install the database is empty. Register via the API (the `/register` endpoint is public on the first run):
+
+```bash
+curl -X POST http://localhost:3000/api/v1/account/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "user": {"name": "Admin", "email": "you@example.com", "credential": "YourPassword1!"},
+    "organization": {},
+    "workspace": {}
+  }'
+```
+
+Then open **http://localhost:3000** and log in with those credentials.
+
+> Registration is only accepted once. Subsequent calls return `400 You can only have one organization`.
+
+## 5. Stop / restart
+
+```bash
+docker compose down          # stop (data persisted in ~/.flowise)
+docker compose up -d         # restart
+
+# Pick up .env changes without rebuilding the image:
+docker compose up -d --force-recreate
+```
+
+## 6. Build a real LLM flow (quick start)
+
+1. Open **http://localhost:3000** → **Chatflows** → **+ Add New**
+2. Choose a template (e.g. *Conversation Chain*) or drag nodes manually
+3. Add a **ChatOpenAI** node → click the key icon → add your OpenAI API key as a credential
+4. Connect **ChatOpenAI** → **Conversation Chain** → **Save**
+5. Click the chat bubble (bottom-right) and send a message
+
+## Data persistence
+
+All application data lives in `~/.flowise` on the host:
+
+```
+~/.flowise/
+├── database.sqlite       # chatflows, credentials, API keys, users
+├── encryption.key        # key used to encrypt stored credentials
+├── logs/                 # server and audit logs
+└── storage/              # uploaded files and blob storage
+```
+
+Back up this directory to preserve your data across host migrations.
+
+## Environment variables reference
+
+See `.env.example` for the full list with inline comments.
+The table below covers the variables that differ from Flowise upstream defaults:
+
+| Variable | Set to | Why |
+|---|---|---|
+| `DATABASE_PATH` | `/root/.flowise` | Must match the container-side volume path |
+| `SECRETKEY_PATH` | `/root/.flowise` | Must match the container-side volume path |
+| `LOG_PATH` | `/root/.flowise/logs` | Must match the container-side volume path |
+| `BLOB_STORAGE_PATH` | `/root/.flowise/storage` | Must match the container-side volume path |
+| `SECRETKEY_STORAGE_TYPE` | `local` | Use local filesystem (not AWS Secrets Manager) |
+| `STORAGE_TYPE` | `local` | Use local filesystem (not S3/GCS/Azure) |
+| `LOG_LEVEL` | `info` | Reasonable verbosity for development |
+| `DISABLE_FLOWISE_TELEMETRY` | `true` | Opt out of usage analytics |
+| `APP_URL` | `http://localhost:3000` | Required for auth redirects and email links |


### PR DESCRIPTION
## Summary

This PR fixes a startup crash-loop that affects anyone deploying Flowise locally with Docker Compose, and adds a setup guide to prevent future confusion.

### Problem

When `docker compose up` is run after `cp .env.example .env` without filling in path variables, Docker passes empty strings for `DATABASE_PATH`, `LOG_PATH`, `BLOB_STORAGE_PATH`, and `SECRETKEY_PATH` into the container. Flowise then crashes immediately with:

```
Error: ENOENT: no such file or directory, mkdir ''
```

The container enters a restart loop and never becomes healthy.

### Changes

#### `docker/.env.example`
- Pre-fill all path variables to `/root/.flowise` — the container-side path of the existing `~/.flowise:/root/.flowise` volume mount. This is the correct default and prevents the crash.
- Set `SECRETKEY_STORAGE_TYPE=local` and `STORAGE_TYPE=local` explicitly (were commented out).
- Enable `LOG_LEVEL=info`, `DISABLE_FLOWISE_TELEMETRY=true`, and `APP_URL=http://localhost:3000` as working defaults.
- Mark the four auth secret tokens (`JWT_AUTH_TOKEN_SECRET`, `JWT_REFRESH_TOKEN_SECRET`, `EXPRESS_SESSION_SECRET`, `TOKEN_HASH_SECRET`) with `<run: openssl rand -hex 32>` placeholders so operators know they must be generated before starting.

#### `docker/SETUP.md` (new)
Step-by-step local deployment guide covering:
- Prerequisites
- `.env` configuration (which variables to set and why)
- Container startup and health verification
- First admin account creation via the API
- Stop / restart commands
- Quick-start guide for building a real LLM chatflow
- Data persistence layout of `~/.flowise`
- Environment variables reference table

### Testing

Verified on macOS with Docker Desktop:
1. `cp .env.example .env` + fill in the four secrets → `docker compose up -d` starts cleanly
2. `curl http://localhost:3000/api/v1/ping` → `pong`
3. Admin account registered via `POST /api/v1/account/register`
4. Chatflow created, read back, and listed via the REST API

---
*Generated with [Warp](https://app.warp.dev/conversation/bd8dff72-e400-499c-8499-3db8c505f4cf)*
Co-Authored-By: Oz <oz-agent@warp.dev>