### PR TITLE
fix(server): apply pagination when fetching chat messages

### DIFF
--- a/packages/server/src/utils/getChatMessage.test.ts
+++ b/packages/server/src/utils/getChatMessage.test.ts
@@ -108,4 +108,20 @@ describe('utilGetChatMessage', () => {
             })
         )
     })
+
+    it('does not paginate when page/pageSize are invalid', async () => {
+        await utilGetChatMessage({
+            chatflowid: 'flow-1',
+            activeWorkspaceId: 'ws-1',
+            page: 0,
+            pageSize: 0
+        })
+
+        expect(mockFind).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                skip: expect.anything(),
+                take: expect.anything()
+            })
+        )
+    })
 })

--- a/packages/server/src/utils/getChatMessage.test.ts
+++ b/packages/server/src/utils/getChatMessage.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+jest.mock(
+    'typeorm',
+    () => {
+        const noop = () => (_target: any, _key?: any) => {}
+        return {
+            Entity: () => noop(),
+            Column: () => noop(),
+            PrimaryGeneratedColumn: () => noop(),
+            PrimaryColumn: () => noop(),
+            CreateDateColumn: () => noop(),
+            UpdateDateColumn: () => noop(),
+            DeleteDateColumn: () => noop(),
+            ManyToOne: () => noop(),
+            OneToMany: () => noop(),
+            OneToOne: () => noop(),
+            JoinColumn: () => noop(),
+            JoinTable: () => noop(),
+            Index: () => noop(),
+            Unique: () => noop(),
+            Tree: () => noop(),
+            TreeChildren: () => noop(),
+            TreeParent: () => noop(),
+            MoreThanOrEqual: jest.fn((value: Date) => ({ type: 'moreThanOrEqual', value })),
+            LessThanOrEqual: jest.fn((value: Date) => ({ type: 'lessThanOrEqual', value })),
+            Between: jest.fn((from: Date, to: Date) => ({ type: 'between', from, to })),
+            In: jest.fn((value: unknown[]) => ({ type: 'in', value }))
+        }
+    },
+    { virtual: true }
+)
+
+jest.mock('../database/entities/ChatFlow', () => ({
+    ChatFlow: class ChatFlow {}
+}))
+
+jest.mock('../database/entities/ChatMessageFeedback', () => ({
+    ChatMessageFeedback: class ChatMessageFeedback {}
+}))
+
+const mockFindOneBy: any = jest.fn()
+const mockFind: any = jest.fn()
+const mockCreateQueryBuilder: any = jest.fn()
+const mockGetRepository: any = jest.fn((entity: unknown) => {
+    const entityName = (entity as { name?: string })?.name
+    if (entityName === 'ChatFlow') {
+        return { findOneBy: mockFindOneBy }
+    }
+    return {
+        find: mockFind,
+        createQueryBuilder: mockCreateQueryBuilder
+    }
+})
+
+jest.mock('../utils/getRunningExpressApp', () => ({
+    getRunningExpressApp: jest.fn(() => ({
+        AppDataSource: {
+            getRepository: mockGetRepository
+        }
+    }))
+}))
+
+import { utilGetChatMessage } from './getChatMessage'
+
+describe('utilGetChatMessage', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockFindOneBy.mockResolvedValue({ id: 'flow-1', workspaceId: 'ws-1' })
+        mockFind.mockResolvedValue([{ id: 'msg-1' }])
+        mockCreateQueryBuilder.mockReset()
+    })
+
+    it('applies skip/take pagination in the non-feedback branch', async () => {
+        await utilGetChatMessage({
+            chatflowid: 'flow-1',
+            chatTypes: ['EXTERNAL' as any],
+            sortOrder: 'DESC',
+            activeWorkspaceId: 'ws-1',
+            page: 2,
+            pageSize: 10
+        })
+
+        expect(mockFind).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    chatflowid: 'flow-1'
+                }),
+                order: {
+                    createdDate: 'DESC'
+                },
+                skip: 10,
+                take: 10
+            })
+        )
+    })
+
+    it('does not paginate when page/pageSize are not provided', async () => {
+        await utilGetChatMessage({
+            chatflowid: 'flow-1',
+            activeWorkspaceId: 'ws-1'
+        })
+
+        expect(mockFind).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                skip: expect.anything(),
+                take: expect.anything()
+            })
+        )
+    })
+})

--- a/packages/server/src/utils/getChatMessage.test.ts
+++ b/packages/server/src/utils/getChatMessage.test.ts
@@ -124,4 +124,23 @@ describe('utilGetChatMessage', () => {
             })
         )
     })
+
+    it('applies take without skip when only pageSize is provided', async () => {
+        await utilGetChatMessage({
+            chatflowid: 'flow-1',
+            activeWorkspaceId: 'ws-1',
+            pageSize: 10
+        })
+
+        expect(mockFind).toHaveBeenCalledWith(
+            expect.objectContaining({
+                take: 10
+            })
+        )
+        expect(mockFind).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                skip: expect.anything()
+            })
+        )
+    })
 })

--- a/packages/server/src/utils/getChatMessage.ts
+++ b/packages/server/src/utils/getChatMessage.ts
@@ -54,7 +54,13 @@ export const utilGetChatMessage = async ({
 }: GetChatMessageParams): Promise<ChatMessage[]> => {
     if (!page) page = -1
     if (!pageSize) pageSize = -1
-    const pagination = page > 0 && pageSize > 0 ? { skip: pageSize * (page - 1), take: pageSize } : {}
+    const pagination =
+        pageSize > 0
+            ? {
+                  skip: page > 1 ? pageSize * (page - 1) : undefined,
+                  take: pageSize
+              }
+            : {}
 
     const appServer = getRunningExpressApp()
 

--- a/packages/server/src/utils/getChatMessage.ts
+++ b/packages/server/src/utils/getChatMessage.ts
@@ -54,6 +54,7 @@ export const utilGetChatMessage = async ({
 }: GetChatMessageParams): Promise<ChatMessage[]> => {
     if (!page) page = -1
     if (!pageSize) pageSize = -1
+    const pagination = page > 0 && pageSize > 0 ? { skip: pageSize * (page - 1), take: pageSize } : {}
 
     const appServer = getRunningExpressApp()
 
@@ -116,8 +117,7 @@ export const utilGetChatMessage = async ({
         order: {
             createdDate: sortOrder === 'DESC' ? 'DESC' : 'ASC'
         },
-        skip: page > -1 && pageSize > -1 ? pageSize * (page - 1) : undefined,
-        take: page > -1 && pageSize > -1 ? pageSize : undefined
+        ...pagination
     })
 
     return messages

--- a/packages/server/src/utils/getChatMessage.ts
+++ b/packages/server/src/utils/getChatMessage.ts
@@ -115,7 +115,9 @@ export const utilGetChatMessage = async ({
         },
         order: {
             createdDate: sortOrder === 'DESC' ? 'DESC' : 'ASC'
-        }
+        },
+        skip: page > -1 && pageSize > -1 ? pageSize * (page - 1) : undefined,
+        take: page > -1 && pageSize > -1 ? pageSize : undefined
     })
 
     return messages


### PR DESCRIPTION
## Description

Fixes an issue where `page` and `limit` were accepted by the chat message retrieval path but not applied in the non-feedback query branch.

The change applies `skip`/`take` consistently when fetching chat messages, so paginated requests return the expected slice of results.

Fixes #6296.

## Changes

- Apply pagination in the non-feedback chat message query path.
- Add a focused unit test covering `page`/`limit` behavior.

## Test

```bash
pnpm --filter flowise-server exec jest packages/server/src/utils/getChatMessage.test.ts
```

The focused test passes locally.

Note: a full normal install was blocked locally by an unrelated native dependency setup issue (`faiss-node` / BLAS). I used an install path sufficient to run the targeted Jest test for this change.
