### PR TITLE
  bugfix: don't cache empty inference-profile sets in AWSBedrock

### DIFF
--- a/packages/components/nodes/chatmodels/AWSBedrock/utils.ts
+++ b/packages/components/nodes/chatmodels/AWSBedrock/utils.ts
@@ -144,12 +144,11 @@ export async function discoverInferenceProfiles(
             }
             nextToken = resp.nextToken
         } while (nextToken)
-        _regionProfileCache.set(region, ids)
+        if (ids.size > 0) _regionProfileCache.set(region, ids)
         return ids
-    } catch {
-        const empty = new Set<string>()
-        _regionProfileCache.set(region, empty)
-        return empty
+    } catch (err) {
+        console.error(`[AWSBedrock] discoverInferenceProfiles(${region}) failed:`, err)
+        return new Set<string>()
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a process-lifetime cache poisoning bug in the AWS Bedrock chat model node.

`discoverInferenceProfiles()` in `packages/components/nodes/chatmodels/AWSBedrock/utils.ts` previously cached an empty `Set<string>` on both thrown errors and empty successful responses. Once poisoned, every subsequent call for that region in the same process would short-circuit and return the empty set. `resolveBedrockModel()` then skipped auto-applying a cross-region inference profile, Flowise rejected the bare model ID with:

> "This model requires a cross-region inference profile. The system attempted to auto-apply one but none was available in this region."
> Bedrock API response: "Invocation of model ID anthropic.claude-sonnet-4-6 with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model."

This reproduces when the first Bedrock invocation for a region happens before AWS credentials are available in the Node process — e.g. a server startup race where `AWS_PROFILE` / SSO creds refresh after Flowise starts. The `ListInferenceProfiles` call throws, the bare `catch` swallows it, an empty set is cached, and the region never recovers until the server is restarted.

## Fix

- Only cache when `ListInferenceProfiles` returns at least one profile.
- On exception, return an empty set without writing to the cache, so the next invocation retries.
- Log the underlying error via `console.error` so operators can diagnose credential or permission issues instead of seeing a silent failure that manifests only later as a confusing Bedrock validation error.

## Test plan

- [x] Verified locally in `us-east-1` with `anthropic.claude-sonnet-4-6`: before the fix, the AgentFlow Agent node failed with the "requires inference profile" error on every invocation until server restart; after the fix, discovery succeeds and `us.anthropic.claude-sonnet-4-6` is auto-applied.
- [x] Confirmed other regions continue to work as before (they were never poisoned because their first call succeeded).
- [x] `aws bedrock list-inference-profiles --region us-east-1 --type-equals SYSTEM_DEFINED` confirms the `us.anthropic.claude-sonnet-4-6` profile is active on the account under test.
