### PR TITLE
fix: add supported file loaders to detect the override file from upsert API

### DIFF
--- a/packages/server/src/utils/constants.ts
+++ b/packages/server/src/utils/constants.ts
@@ -161,3 +161,15 @@ export const LICENSE_QUOTAS = {
     STORAGE_LIMIT: 'quota:storage',
     ADDITIONAL_SEATS_LIMIT: 'quota:additionalSeats'
 } as const
+
+export const SUPPORTED_FILE_LOADERS = [
+    'csvFile',
+    'jsonFile',
+    'jsonlFile',
+    'pdfFile',
+    'txtFile',
+    'docFile',
+    'docxFile',
+    'pptxFile',
+    'xlsxFile'
+]

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -63,6 +63,7 @@ import {
     SecretsManagerClient,
     SecretsManagerClientConfig
 } from '@aws-sdk/client-secrets-manager'
+import { SUPPORTED_FILE_LOADERS } from './constants'
 
 export const QUESTION_VAR_PREFIX = 'question'
 export const FILE_ATTACHMENT_PREFIX = 'file_attachment'
@@ -406,11 +407,22 @@ export const saveUpsertFlowData = (nodeData: INodeData, upsertHistory: Record<st
         }
         // Get file name instead of the base64 string
         if (nodeData.category === 'Document Loaders' && nodeData.inputParams.find((inp) => inp.name === input)?.type === 'file') {
+            let fileName = getFileName(nodeData.inputs[input])
+            // Check the overrideConfig to get latest file
+            const overrideInput = Object.keys(nodeData.inputs ?? {}).find((inputKey: string) => SUPPORTED_FILE_LOADERS.includes(inputKey))
+            if (
+                overrideInput &&
+                typeof nodeData.inputs[overrideInput] === 'string' &&
+                nodeData.inputs[overrideInput].includes('FILE-STORAGE::')
+            ) {
+                fileName = getFileName(nodeData.inputs[overrideInput])
+            }
+
             paramValue = {
                 label: inputParam?.label,
                 name: inputParam?.name,
                 type: inputParam?.type,
-                value: getFileName(nodeData.inputs[input])
+                value: fileName
             }
             paramValues.push(paramValue)
             continue
@@ -1098,7 +1110,22 @@ export const replaceInputsWithConfig = (
 
     const isParameterEnabled = (nodeType: string, paramName: string): boolean => {
         if (!nodeOverrides[nodeType]) return false
-        const parameter = nodeOverrides[nodeType].find((param: any) => param.name === paramName)
+        let paramConfigName = paramName
+        if (nodeType === 'File Loader') {
+            // Values example: { nodeType: paramName }
+            // { docxFile: "FILE-STORAGE::['file.docx']", pdfFile: "FILE-STORAGE::['file.pdf']" }
+            if (
+                typeof overrideConfig[paramName] === 'string' &&
+                overrideConfig[paramName].includes('FILE-STORAGE::') &&
+                SUPPORTED_FILE_LOADERS.includes(paramName)
+            ) {
+                // Convert all override config with "File" suffix to "files" for easier checking in nodeOverrides,
+                // because in nodeOverrides we only have "files" as parameter name for file storage override.
+                // Example: { label: "File", name: "files", type: "*", enabled: true }
+                paramConfigName = 'files'
+            }
+        }
+        const parameter = nodeOverrides[nodeType].find((param: any) => param.name === paramConfigName)
         return parameter?.enabled ?? false
     }
 


### PR DESCRIPTION
## Issue: 
- Ticket: https://github.com/FlowiseAI/Flowise/issues/6102

## Root Cause:
- Pull Request: https://github.com/FlowiseAI/Flowise/pull/5667
- Although the user enable override configuration on File Loader, but they can use the file from request to upsert data into vector db.

<img width="1121" height="713" alt="image" src="https://github.com/user-attachments/assets/9e36e9ae-253a-48e4-a2ed-3ff94ba45ad6" />


## Changes
- Add SUPPORTED_FILE_LOADERS ([source](https://docs.flowiseai.com/using-flowise/upsertion#supported-document-types))  to detect the overrideConfig from API: `vector/upsert/:uuid`
- Get the latest file from overrideConfig instead of using the default file name in Chatflow in Upsert History

## Testing
- Creating the Chatflow with initial file (test3.docx)
- Using Upsert API to upload another (test.docx)


https://github.com/user-attachments/assets/5ab1243a-2302-45b2-8422-9bfe66f97914

- Verify the Upsert History

https://github.com/user-attachments/assets/010607e8-3333-4de7-95d4-c36ae61942e2




