### PR TITLE
fix(ui): validate optional tool icon URL and add fallback icon if user doesn't input URL

### DIFF
--- a/packages/ui/src/ui-component/table/ToolsListTable.jsx
+++ b/packages/ui/src/ui-component/table/ToolsListTable.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import { useSelector } from 'react-redux'
 import { styled } from '@mui/material/styles'
-import { tableCellClasses } from '@mui/material/TableCell'
 import {
     Button,
     Paper,
@@ -16,22 +15,21 @@ import {
     useTheme
 } from '@mui/material'
 
-const StyledTableCell = styled(TableCell)(({ theme }) => ({
-    borderColor: theme.palette.grey[900] + 25,
-
-    [`&.${tableCellClasses.head}`]: {
-        color: theme.palette.grey[900]
-    },
-    [`&.${tableCellClasses.body}`]: {
-        fontSize: 14,
-        height: 64
-    }
-}))
-
 const StyledTableRow = styled(TableRow)(() => ({
     // hide last border
     '&:last-child td, &:last-child th': {
         border: 0
+    }
+}))
+
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+    borderColor: theme.palette.grey[900] + 25,
+    [`&.MuiTableCell-head`]: {
+        color: theme.palette.grey[900]
+    },
+    [`&.MuiTableCell-body`]: {
+        fontSize: 14,
+        height: 64
     }
 }))
 

--- a/packages/ui/src/ui-component/table/ToolsListTable.jsx
+++ b/packages/ui/src/ui-component/table/ToolsListTable.jsx
@@ -14,6 +14,9 @@ import {
     Typography,
     useTheme
 } from '@mui/material'
+import { Avatar } from '@mui/material'
+import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined'
+import { tableCellClasses } from '@mui/material/TableCell'
 
 const StyledTableRow = styled(TableRow)(() => ({
     // hide last border
@@ -24,10 +27,10 @@ const StyledTableRow = styled(TableRow)(() => ({
 
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
     borderColor: theme.palette.grey[900] + 25,
-    [`&.MuiTableCell-head`]: {
+    [`&.${tableCellClasses.head}`]: {
         color: theme.palette.grey[900]
     },
-    [`&.MuiTableCell-body`]: {
+    [`&.${tableCellClasses.body}`]: {
         fontSize: 14,
         height: 64
     }
@@ -88,20 +91,27 @@ export const ToolsTable = ({ data, isLoading, onSelect }) => {
                                 {data?.map((row, index) => (
                                     <StyledTableRow key={index}>
                                         <StyledTableCell sx={{ display: 'flex', alignItems: 'center', gap: 1 }} key='0'>
-                                            <div
-                                                style={{
+                                            <Avatar
+                                                src={(() => {
+                                                    try {
+                                                        const parsed = new URL(row.iconSrc)
+                                                        return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+                                                            ? row.iconSrc
+                                                            : undefined
+                                                    } catch {
+                                                        return undefined
+                                                    }
+                                                })()}
+                                                alt={row.templateName || row.name}
+                                                sx={{
                                                     width: 35,
                                                     height: 35,
-                                                    display: 'flex',
                                                     flexShrink: 0,
-                                                    marginRight: 10,
-                                                    borderRadius: '50%',
-                                                    backgroundImage: `url(${row.iconSrc})`,
-                                                    backgroundSize: 'contain',
-                                                    backgroundRepeat: 'no-repeat',
-                                                    backgroundPosition: 'center center'
+                                                    marginRight: 1
                                                 }}
-                                            ></div>
+                                            >
+                                                <BuildOutlinedIcon fontSize='small' />
+                                            </Avatar>
                                             <Typography
                                                 sx={{
                                                     display: '-webkit-box',

--- a/packages/ui/src/views/tools/ToolDialog.jsx
+++ b/packages/ui/src/views/tools/ToolDialog.jsx
@@ -1,3 +1,15 @@
+import {
+    Box,
+    Button,
+    Typography,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Stack,
+    OutlinedInput,
+    FormHelperText
+} from '@mui/material'
 import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 import { useState, useEffect, useCallback, useMemo } from 'react'
@@ -5,7 +17,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import { enqueueSnackbar as enqueueSnackbarAction, closeSnackbar as closeSnackbarAction } from '@/store/actions'
 import { cloneDeep } from 'lodash'
 
-import { Box, Button, Typography, Dialog, DialogActions, DialogContent, DialogTitle, Stack, OutlinedInput } from '@mui/material'
 import { StyledButton } from '@/ui-component/button/StyledButton'
 import { Grid } from '@/ui-component/grid/Grid'
 import { TooltipWithParser } from '@/ui-component/tooltip/TooltipWithParser'
@@ -82,6 +93,28 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     const [toolSchema, setToolSchema] = useState([])
     const [toolFunc, setToolFunc] = useState('')
     const [showHowToDialog, setShowHowToDialog] = useState(false)
+    const [toolIconError, setToolIconError] = useState('')
+    // URL validation: only allow empty or http/https URLs
+    const validateIconUrl = (url) => {
+        if (!url) return ''
+        try {
+            const parsed = new URL(url)
+            if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return ''
+            return 'Icon URL must start with http:// or https://'
+        } catch {
+            return 'Icon URL must be a valid http(s) URL'
+        }
+    }
+
+    // Validate on change
+    const handleToolIconChange = (e) => {
+        const value = e.target.value
+        setToolIcon(value)
+        setToolIconError(validateIconUrl(value))
+    }
+    {
+        toolIconError ? <FormHelperText error>{toolIconError}</FormHelperText> : null
+    }
 
     const [exportAsTemplateDialogOpen, setExportAsTemplateDialogOpen] = useState(false)
     const [exportAsTemplateDialogProps, setExportAsTemplateDialogProps] = useState({})
@@ -513,8 +546,10 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
                             placeholder='https://raw.githubusercontent.com/gilbarbara/logos/main/logos/airtable.svg'
                             value={toolIcon}
                             name='toolIcon'
-                            onChange={(e) => setToolIcon(e.target.value)}
+                            error={!!toolIconError}
+                            onChange={handleToolIconChange}
                         />
+                        {toolIconError && <FormHelperText error>{toolIconError}</FormHelperText>}
                     </Box>
                     <Box>
                         <Stack sx={{ position: 'relative', justifyContent: 'space-between' }} direction='row'>
@@ -583,7 +618,7 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
                 {dialogProps.type !== 'TEMPLATE' && (
                     <StyledPermissionButton
                         permissionId={'tools:update,tools:create'}
-                        disabled={!(toolName && toolDesc)}
+                        disabled={!(toolName && toolDesc) || !!toolIconError}
                         variant='contained'
                         onClick={() => (dialogProps.type === 'ADD' || dialogProps.type === 'IMPORT' ? addNewTool() : saveTool())}
                     >

--- a/packages/ui/src/views/tools/ToolDialog.jsx
+++ b/packages/ui/src/views/tools/ToolDialog.jsx
@@ -89,32 +89,51 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     const [toolId, setToolId] = useState('')
     const [toolName, setToolName] = useState('')
     const [toolDesc, setToolDesc] = useState('')
+    // const [toolIcon, setToolIcon] = useState('')
+    // const [toolSchema, setToolSchema] = useState([])
+    // const [toolFunc, setToolFunc] = useState('')
+    // const [showHowToDialog, setShowHowToDialog] = useState(false)
+    // const [toolIconError, setToolIconError] = useState('')
+    // // URL validation: only allow empty or http/https URLs
+    // const validateIconUrl = (url) => {
+    //     if (!url) return ''
+    //     try {
+    //         const parsed = new URL(url)
+    //         if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return ''
+    //         return 'Icon URL must start with http:// or https://'
+    //     } catch {
+    //         return 'Icon URL must be a valid http(s) URL'
+    //     }
+    // }
+
+    // // Validate on change
+    // const handleToolIconChange = (e) => {
+    //     const value = e.target.value
+    //     setToolIcon(value)
+    //     setToolIconError(validateIconUrl(value))
+    // }
+    // {
+    //     toolIconError ? <FormHelperText error>{toolIconError}</FormHelperText> : null
+    // }
+
     const [toolIcon, setToolIcon] = useState('')
     const [toolSchema, setToolSchema] = useState([])
     const [toolFunc, setToolFunc] = useState('')
     const [showHowToDialog, setShowHowToDialog] = useState(false)
-    const [toolIconError, setToolIconError] = useState('')
-    // URL validation: only allow empty or http/https URLs
-    const validateIconUrl = (url) => {
-        if (!url) return ''
+
+    const toolIconError = useMemo(() => {
+        const value = toolIcon.trim()
+
+        if (!value) return ''
+
         try {
-            const parsed = new URL(url)
+            const parsed = new URL(value)
             if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return ''
             return 'Icon URL must start with http:// or https://'
         } catch {
             return 'Icon URL must be a valid http(s) URL'
         }
-    }
-
-    // Validate on change
-    const handleToolIconChange = (e) => {
-        const value = e.target.value
-        setToolIcon(value)
-        setToolIconError(validateIconUrl(value))
-    }
-    {
-        toolIconError ? <FormHelperText error>{toolIconError}</FormHelperText> : null
-    }
+    }, [toolIcon])
 
     const [exportAsTemplateDialogOpen, setExportAsTemplateDialogOpen] = useState(false)
     const [exportAsTemplateDialogProps, setExportAsTemplateDialogProps] = useState({})
@@ -547,7 +566,7 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
                             value={toolIcon}
                             name='toolIcon'
                             error={!!toolIconError}
-                            onChange={handleToolIconChange}
+                            onChange={(e) => setToolIcon(e.target.value)}
                         />
                         {toolIconError && <FormHelperText error>{toolIconError}</FormHelperText>}
                     </Box>


### PR DESCRIPTION
# BugFix : Added Validation check for TOOL ICON SOURCE Field in Tools Dialogue, and add a default icon image if user has not provided

## Related issue
Closes #6382

## Summary

This PR improves the Tools icon experience by keeping **Tool Icon Source** optional while validating it when a value is provided. It also adds a safe fallback icon so Tools never render with a broken or empty icon in list/card views.

## What’s fixed

- **Tool Icon Source** now accepts only valid `http` / `https` URLs when a value is entered.
- Empty icon source is still allowed.
- Invalid icon values show inline validation feedback and block save.
- Existing invalid icon values are validated when the edit dialog opens.
- Tools list/table view now shows a default fallback icon when:
    - the icon source is empty
    - the icon URL is invalid
    - the image fails to load

https://github.com/user-attachments/assets/97df22ee-9060-4fdb-b8bf-6806fd75de24

## Problem

Previously:

- Any random string could be saved in **Tool Icon Source**.
- This caused broken or missing icons in the Tools list/card views.
- There was no consistent fallback when the icon source was empty or invalid.

## Changes

### ToolDialog.jsx

- Added URL validation for **Tool Icon Source**.
- Kept the field optional, so empty values are allowed.
- Added inline error text for invalid URLs.
- Disabled Add/Save when the icon URL is invalid.
- Validated existing icon values when the dialog opens in edit mode.

### ToolsTable.jsx

- Added a safe default fallback icon for tool rows.
- Prevented broken image rendering when `iconSrc` is missing or invalid.

## Behavior after this PR

- Empty icon source: allowed, tool saves successfully, fallback icon is shown.
- Valid icon URL: tool saves successfully, custom icon is shown.
- Invalid icon value such as `abc123`: validation error is shown and save is blocked.

## Testing done

- Created a tool with a valid icon URL → saved successfully and icon rendered.
- Created a tool with invalid text in icon source → validation error shown and save blocked.
- Left icon source empty → saved successfully and default icon shown.
- Opened an existing tool with bad icon URL → fallback icon displayed in the Tools view.

## Scope / Notes

- Frontend-only fix.
- No backend validation changes were added in this PR.
- No unrelated files were changed.