### PR TITLE
fix: Add URL validation for Tool Icon Source field

### DIFF
--- a/packages/ui/src/views/tools/ToolDialog.jsx
+++ b/packages/ui/src/views/tools/ToolDialog.jsx
@@ -79,6 +79,7 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     const [toolName, setToolName] = useState('')
     const [toolDesc, setToolDesc] = useState('')
     const [toolIcon, setToolIcon] = useState('')
+    const [toolIconError, setToolIconError] = useState('')
     const [toolSchema, setToolSchema] = useState([])
     const [toolFunc, setToolFunc] = useState('')
     const [showHowToDialog, setShowHowToDialog] = useState(false)
@@ -96,6 +97,32 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
         },
         []
     )
+
+    const validateIconUrl = (url) => {
+        if (!url || url.trim() === '') {
+            setToolIconError('')
+            return true
+        }
+        
+        try {
+            const urlObj = new URL(url)
+            if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+                setToolIconError('Icon source must be a valid http or https URL')
+                return false
+            }
+            setToolIconError('')
+            return true
+        } catch (error) {
+            setToolIconError('Icon source must be a valid URL')
+            return false
+        }
+    }
+
+    const handleIconChange = (e) => {
+        const value = e.target.value
+        setToolIcon(value)
+        validateIconUrl(value)
+    }
 
     const addNewRow = () => {
         setTimeout(() => {
@@ -277,6 +304,10 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     }
 
     const addNewTool = async () => {
+        if (!validateIconUrl(toolIcon)) {
+            return
+        }
+        
         try {
             const obj = {
                 name: toolName,
@@ -323,6 +354,10 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     }
 
     const saveTool = async () => {
+        if (!validateIconUrl(toolIcon)) {
+            return
+        }
+        
         try {
             const saveResp = await toolsApi.updateTool(toolId, {
                 name: toolName,
@@ -513,8 +548,14 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
                             placeholder='https://raw.githubusercontent.com/gilbarbara/logos/main/logos/airtable.svg'
                             value={toolIcon}
                             name='toolIcon'
-                            onChange={(e) => setToolIcon(e.target.value)}
+                            onChange={handleIconChange}
+                            error={!!toolIconError}
                         />
+                        {toolIconError && (
+                            <Typography variant='caption' color='error' sx={{ mt: 0.5, display: 'block' }}>
+                                {toolIconError}
+                            </Typography>
+                        )}
                     </Box>
                     <Box>
                         <Stack sx={{ position: 'relative', justifyContent: 'space-between' }} direction='row'>
@@ -583,7 +624,7 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
                 {dialogProps.type !== 'TEMPLATE' && (
                     <StyledPermissionButton
                         permissionId={'tools:update,tools:create'}
-                        disabled={!(toolName && toolDesc)}
+                        disabled={!(toolName && toolDesc) || !!toolIconError}
                         variant='contained'
                         onClick={() => (dialogProps.type === 'ADD' || dialogProps.type === 'IMPORT' ? addNewTool() : saveTool())}
                     >


### PR DESCRIPTION
## Summary

Fixes the Tool Icon Source field accepting invalid values and lacking proper validation.

## Problem

The Tool Icon Source field in the Tools creation/edit dialog:
- Accepts any random string (non-URL values)
- Allows saving tools with invalid icon sources
- Results in broken or missing icons in the Tools list/card views
- No user feedback when an invalid value is entered

## Solution

### Added URL Validation
- Real-time validation as user types
- Validates that the value is a proper URL with http/https protocol
- Empty values are allowed (optional field)
- Clear error message displayed when validation fails

### User Experience Improvements
- Error message appears immediately below the input field
- Input field shows error state (red border)
- Save button is disabled when validation fails
- Prevents saving tools with invalid icon sources

### Fallback Handling

The existing color-based fallback icon already handles cases where:
- Tool Icon Source is empty
- The image URL fails to load
- The image is not accessible

## Changes

- Added `toolIconError` state to track validation errors
- Added `validateIconUrl()` function to validate URL format and protocol
- Added `handleIconChange()` to validate on input change
- Updated `addNewTool()` and `saveTool()` to validate before saving
- Updated UI to display error message and error state
- Updated save button to be disabled when validation fails

## Testing

### Manual Testing Steps

1. **Valid URL**: Enter `https://example.com/icon.svg` → No error, can save
2. **Invalid URL**: Enter `abc123` → Error message shown, cannot save
3. **Empty field**: Leave empty → No error, can save (uses color fallback)
4. **Non-http protocol**: Enter `ftp://example.com/icon.svg` → Error message shown
5. **Edit existing tool**: Open tool with valid icon → No error
6. **Edit existing tool**: Change to invalid value → Error shown, cannot save

### Expected Behavior

- ✅ Valid http/https URLs are accepted
- ✅ Empty values are accepted (optional field)
- ✅ Invalid URLs show clear error message
- ✅ Non-http/https protocols are rejected
- ✅ Save button is disabled when validation fails
- ✅ Existing color-based fallback continues to work

## Screenshots

_Before_: Tool could be saved with invalid icon source `abc123`
_After_: Clear error message prevents saving with invalid value

## Related Issue

Fixes #6382

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are focused and minimal
- [x] User experience is improved
- [x] Backward compatible (existing tools unaffected)
- [x] No breaking changes