### PR TITLE
Expose artifacts in Agentflow variable resolution

### DIFF
--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -441,7 +441,7 @@ export const resolveVariables = async (
             if (nodeData && nodeData.data) {
                 // Replace the reference with actual value
                 const nodeOutput = nodeData.data['output'] as ICommonObject
-                const actualValue = nodeOutput?.content ?? nodeOutput?.http?.data
+                const actualValue = nodeOutput?.content ?? nodeOutput?.http?.data ?? nodeOutput?.artifacts
                 // For arrays and objects, stringify them to prevent toString() conversion issues
                 const formattedValue =
                     Array.isArray(actualValue) || (typeof actualValue === 'object' && actualValue !== null)


### PR DESCRIPTION
Summary
Updated Agentflow variable resolution to expose node artifacts in addition to content and HTTP response data.

Changes Made:
* Added `nodeOutput?.artifacts` fallback in `resolveVariables`
* Allows downstream variable references to access artifacts when content and HTTP data are unavailable

Testing
* Verified lint passes successfully
* Confirmed minimal diff limited to `buildAgentflow.ts`
