### PR TITLE
fix: add URL validation and error feedback for Tool Icon Source

### DIFF
--- a/packages/ui/src/views/tools/ToolDialog.jsx
+++ b/packages/ui/src/views/tools/ToolDialog.jsx
@@ -79,6 +79,7 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     const [toolName, setToolName] = useState('')
     const [toolDesc, setToolDesc] = useState('')
     const [toolIcon, setToolIcon] = useState('')
+    const [toolIconError, setToolIconError] = useState('')
     const [toolSchema, setToolSchema] = useState([])
     const [toolFunc, setToolFunc] = useState('')
     const [showHowToDialog, setShowHowToDialog] = useState(false)
@@ -96,6 +97,31 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
         },
         []
     )
+
+    const validateToolIconUrl = (url) => {
+        if (!url || url.trim() === '') {
+            setToolIconError('')
+            return true
+        }
+        try {
+            const urlObj = new URL(url)
+            if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+                setToolIconError('Tool Icon Source must be a valid http or https URL')
+                return false
+            }
+            setToolIconError('')
+            return true
+        } catch (error) {
+            setToolIconError('Tool Icon Source must be a valid URL')
+            return false
+        }
+    }
+
+    const handleToolIconChange = (e) => {
+        const value = e.target.value
+        setToolIcon(value)
+        validateToolIconUrl(value)
+    }
 
     const addNewRow = () => {
         setTimeout(() => {
@@ -225,6 +251,7 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
             setToolName('')
             setToolDesc('')
             setToolIcon('')
+            setToolIconError('')
             setToolSchema([])
             setToolFunc('')
         }
@@ -277,6 +304,9 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     }
 
     const addNewTool = async () => {
+        if (!validateToolIconUrl(toolIcon)) {
+            return
+        }
         try {
             const obj = {
                 name: toolName,
@@ -323,6 +353,9 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
     }
 
     const saveTool = async () => {
+        if (!validateToolIconUrl(toolIcon)) {
+            return
+        }
         try {
             const saveResp = await toolsApi.updateTool(toolId, {
                 name: toolName,
@@ -513,8 +546,14 @@ const ToolDialog = ({ show, dialogProps, onUseTemplate, onCancel, onConfirm, set
                             placeholder='https://raw.githubusercontent.com/gilbarbara/logos/main/logos/airtable.svg'
                             value={toolIcon}
                             name='toolIcon'
-                            onChange={(e) => setToolIcon(e.target.value)}
+                            onChange={handleToolIconChange}
+                            error={!!toolIconError}
                         />
+                        {toolIconError && (
+                            <Typography variant='caption' color='error' sx={{ mt: 0.5 }}>
+                                {toolIconError}
+                            </Typography>
+                        )}
                     </Box>
                     <Box>
                         <Stack sx={{ position: 'relative', justifyContent: 'space-between' }} direction='row'>


### PR DESCRIPTION
## Description

Fixes #6382

Adds URL validation and error feedback for the **Tool Icon Source** field in the Tools dialog.

## Changes

- ✅ Add URL validation for Tool Icon Source field
- ✅ Display error message when invalid URL is entered
- ✅ Block saving when Tool Icon Source contains invalid URL
- ✅ Allow empty Tool Icon Source (optional field)
- ✅ Validate on input change for immediate feedback
- ✅ Clear error state when dialog is reset

## Validation Rules

- Empty values are allowed (optional field)
- Only `http://` and `https://` URLs are accepted
- Clear error messages guide users to correct format
- Saving is prevented until validation passes

## Testing

### Before
- Tool Icon Source accepted any random string (e.g., `abc123`)
- No validation or error feedback
- Broken icons in Tools list/card views

### After
- Invalid URLs show clear error message
- Save button is blocked until validation passes
- Empty field is allowed (optional)
- Valid URLs work as expected

## Screenshots

**Error feedback for invalid URL:**
- Entering `abc123` shows: "Tool Icon Source must be a valid URL"
- Entering `ftp://example.com` shows: "Tool Icon Source must be a valid http or https URL"

**Valid cases:**
- Empty field: ✅ No error, save allowed
- `https://example.com/icon.svg`: ✅ No error, save allowed

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings