### PR TITLE
feat: add Select All checkbox for credential workspace sharing

### DIFF
--- a/packages/ui/src/ui-component/dialog/ShareWithWorkspaceDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ShareWithWorkspaceDialog.jsx
@@ -6,7 +6,7 @@ import { enqueueSnackbar as enqueueSnackbarAction, closeSnackbar as closeSnackba
 import { cloneDeep } from 'lodash'
 
 // Material
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Box, Stack, OutlinedInput, Typography } from '@mui/material'
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Box, Stack, OutlinedInput, Typography, Checkbox, FormControlLabel } from '@mui/material'
 
 // Project imports
 import { StyledButton } from '@/ui-component/button/StyledButton'
@@ -47,6 +47,28 @@ const ShareWithWorkspaceDialog = ({ show, dialogProps, onCancel, setError }) => 
     const [outputSchema, setOutputSchema] = useState([])
 
     const [name, setName] = useState('')
+    const [selectAll, setSelectAll] = useState(false)
+
+    // Handle select all / deselect all
+    const handleSelectAllChange = (event) => {
+        const checked = event.target.checked
+        setSelectAll(checked)
+        setOutputSchema((prevRows) => {
+            return prevRows.map((row) => ({
+                ...row,
+                shared: checked
+            }))
+        })
+    }
+
+    // Update selectAll state when individual rows change
+    useEffect(() => {
+        if (outputSchema.length > 0) {
+            const allSelected = outputSchema.every((row) => row.shared)
+            const noneSelected = outputSchema.every((row) => !row.shared)
+            setSelectAll(allSelected ? true : noneSelected ? false : false)
+        }
+    }, [outputSchema])
 
     const onRowUpdate = (newRow) => {
         setTimeout(() => {
@@ -187,6 +209,13 @@ const ShareWithWorkspaceDialog = ({ show, dialogProps, onCancel, setError }) => 
                     <OutlinedInput id='name' type='string' disabled={true} fullWidth placeholder={name} value={name} name='name' />
                 </Box>
                 <Box sx={{ p: 2 }}>
+                    <Stack direction='row' alignItems='center' justifyContent='space-between' sx={{ mb: 1 }}>
+                        <Typography variant='overline'>Workspaces</Typography>
+                        <FormControlLabel
+                            control={<Checkbox checked={selectAll} onChange={handleSelectAllChange} size='small' />}
+                            label={<Typography variant='body2'>Select All</Typography>}
+                        />
+                    </Stack>
                     <Grid columns={columns} rows={outputSchema} onRowUpdate={onRowUpdate} />
                 </Box>
             </DialogContent>


### PR DESCRIPTION
## Description

Fixes #5639

When managing credential sharing across multiple workspaces, users had to manually check/uncheck each workspace individually. This was tedious and time-consuming, especially when unsharing a credential from all workspaces.

## Problem

**Current behavior:**
- User wants to unshare a credential from all workspaces
- Must scroll through the list and manually uncheck every workspace
- No bulk action available
- Tedious for organizations with many workspaces

**User quote from issue:**
> "In order to unshare a credential from all workspaces it would be helpful to have a one-click option instead of scrolling the list and unchecking every workspace."

## Solution

Add a "Select All" checkbox above the workspace list that allows users to:
- ✅ Check all workspaces with one click
- ✅ Uncheck all workspaces with one click
- ✅ Automatically updates when individual checkboxes are toggled

### Changes

**`packages/ui/src/ui-component/dialog/ShareWithWorkspaceDialog.jsx`**

1. **Import MUI components:**
```diff
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Box, Stack, OutlinedInput, Typography } from '@mui/material'
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Box, Stack, OutlinedInput, Typography, Checkbox, FormControlLabel } from '@mui/material'
```

2. **Add state and handlers:**
```javascript
const [selectAll, setSelectAll] = useState(false)

// Handle select all / deselect all
const handleSelectAllChange = (event) => {
    const checked = event.target.checked
    setSelectAll(checked)
    setOutputSchema((prevRows) => {
        return prevRows.map((row) => ({
            ...row,
            shared: checked
        }))
    })
}

// Update selectAll state when individual rows change
useEffect(() => {
    if (outputSchema.length > 0) {
        const allSelected = outputSchema.every((row) => row.shared)
        const noneSelected = outputSchema.every((row) => !row.shared)
        setSelectAll(allSelected ? true : noneSelected ? false : false)
    }
}, [outputSchema])
```

3. **Add UI above the grid:**
```jsx
<Stack direction='row' alignItems='center' justifyContent='space-between' sx={{ mb: 1 }}>
    <Typography variant='overline'>Workspaces</Typography>
    <FormControlLabel
        control={<Checkbox checked={selectAll} onChange={handleSelectAllChange} size='small' />}
        label={<Typography variant='body2'>Select All</Typography>}
    />
</Stack>
<Grid columns={columns} rows={outputSchema} onRowUpdate={onRowUpdate} />
```

## Features

### 1. One-Click Select All
- Check the "Select All" box
- All workspace checkboxes are instantly checked
- Credential will be shared with all workspaces on save

### 2. One-Click Deselect All
- Uncheck the "Select All" box
- All workspace checkboxes are instantly unchecked
- Credential will be unshared from all workspaces on save

### 3. Smart Synchronization
- If all workspaces are checked individually → "Select All" automatically checks
- If any workspace is unchecked → "Select All" automatically unchecks
- Keeps UI state consistent with user actions

### 4. Clean UI Integration
- Positioned in the top-right, next to "Workspaces" label
- Uses MUI's FormControlLabel for consistent styling
- Small checkbox size to avoid visual clutter
- Doesn't interfere with existing grid functionality

## UI/UX

### Before
```
┌─────────────────────────────────────┐
│ Share Credential                    │
├─────────────────────────────────────┤
│ Name: My API Key                    │
│                                     │
│ ┌─────────────────────────────────┐ │
│ │ Workspace A        [ ]          │ │
│ │ Workspace B        [ ]          │ │
│ │ Workspace C        [ ]          │ │
│ │ Workspace D        [ ]          │ │
│ │ Workspace E        [ ]          │ │
│ │ ... (scroll to see more)        │ │
│ └─────────────────────────────────┘ │
│                                     │
│           [Cancel]  [Save]          │
└─────────────────────────────────────┘

❌ Must click each checkbox individually
```

### After
```
┌─────────────────────────────────────┐
│ Share Credential                    │
├─────────────────────────────────────┤
│ Name: My API Key                    │
│                                     │
│ WORKSPACES          [✓] Select All  │ ← NEW!
│ ┌─────────────────────────────────┐ │
│ │ Workspace A        [✓]          │ │
│ │ Workspace B        [✓]          │ │
│ │ Workspace C        [✓]          │ │
│ │ Workspace D        [✓]          │ │
│ │ Workspace E        [✓]          │ │
│ │ ... (all checked!)              │ │
│ └─────────────────────────────────┘ │
│                                     │
│           [Cancel]  [Save]          │
└─────────────────────────────────────┘

✅ One click to select/deselect all!
```

## Testing

### Manual Testing

1. **Basic select all:**
   - Go to Credentials page
   - Click share icon on any credential
   - Click "Select All" checkbox
   - ✅ All workspace checkboxes are checked

2. **Basic deselect all:**
   - With all workspaces checked
   - Click "Select All" checkbox again
   - ✅ All workspace checkboxes are unchecked

3. **Smart sync (all → some):**
   - Click "Select All" to check all
   - Manually uncheck one workspace
   - ✅ "Select All" checkbox automatically unchecks

4. **Smart sync (some → all):**
   - Manually check all workspaces one by one
   - ✅ "Select All" checkbox automatically checks

5. **Save functionality:**
   - Select some workspaces (mix of checked/unchecked)
   - Click Save
   - ✅ Credential is shared only with checked workspaces
   - ✅ Success message appears

6. **Reopen dialog:**
   - Close and reopen the share dialog
   - ✅ Previously saved state is preserved
   - ✅ "Select All" reflects current state

### Edge Cases

1. **No workspaces:**
   - User has only one workspace (active workspace is filtered out)
   - ✅ Dialog shows empty grid
   - ✅ "Select All" checkbox is visible but has no effect

2. **All already shared:**
   - Credential is already shared with all workspaces
   - Open dialog
   - ✅ "Select All" is automatically checked

3. **None shared:**
   - Credential is not shared with any workspace
   - Open dialog
   - ✅ "Select All" is unchecked

## Implementation Details

### State Management
- `selectAll` state tracks the checkbox
- `handleSelectAllChange` updates all rows when checkbox is toggled
- `useEffect` syncs `selectAll` with individual row changes
- Uses `outputSchema.every()` to determine if all/none are selected

### Performance
- No API calls on checkbox toggle (only on Save)
- State updates are batched by React
- Works efficiently with large workspace lists

### Accessibility
- Uses MUI's FormControlLabel for proper label association
- Checkbox is keyboard accessible (Tab + Space)
- Screen readers announce "Select All" label

## Type of Change

- [ ] Bug fix
- [x] New feature (UI/UX improvement)
- [ ] Breaking change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Feature is simple and focused (30 lines of code)
- [x] Uses existing MUI components (Checkbox, FormControlLabel)
- [x] Smart synchronization with individual checkboxes
- [x] Clean UI integration (top-right positioning)
- [x] No breaking changes
- [x] Addresses the exact problem described in #5639