### PR TITLE
fix: add null checks in document store component node functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
         "*.{js,jsx,ts,tsx,json,md}": "eslint --fix"
     },
     "devDependencies": {
-        "@changesets/cli": "^2.27.0",
         "@babel/preset-env": "^7.19.4",
         "@babel/preset-typescript": "7.18.6",
+        "@changesets/cli": "^2.27.0",
         "@types/express": "^4.17.13",
         "@typescript-eslint/typescript-estree": "^7.13.1",
         "eslint": "^8.24.0",
@@ -67,8 +67,26 @@
     },
     "pnpm": {
         "onlyBuiltDependencies": [
+            "@swc/core",
+            "bufferutil",
+            "canvas",
+            "core-js",
+            "core-js-pure",
+            "couchbase",
+            "cpu-features",
+            "cypress",
+            "es5-ext",
+            "esbuild",
             "faiss-node",
-            "sqlite3"
+            "grpc-tools",
+            "msgpackr-extract",
+            "protobufjs",
+            "puppeteer",
+            "sharp",
+            "sqlite3",
+            "ssh2",
+            "unrs-resolver",
+            "utf-8-validate"
         ],
         "overrides": {
             "axios": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
         "*.{js,jsx,ts,tsx,json,md}": "eslint --fix"
     },
     "devDependencies": {
+        "@changesets/cli": "^2.27.0",
         "@babel/preset-env": "^7.19.4",
         "@babel/preset-typescript": "7.18.6",
-        "@changesets/cli": "^2.27.0",
         "@types/express": "^4.17.13",
         "@typescript-eslint/typescript-estree": "^7.13.1",
         "eslint": "^8.24.0",
@@ -67,26 +67,8 @@
     },
     "pnpm": {
         "onlyBuiltDependencies": [
-            "@swc/core",
-            "bufferutil",
-            "canvas",
-            "core-js",
-            "core-js-pure",
-            "couchbase",
-            "cpu-features",
-            "cypress",
-            "es5-ext",
-            "esbuild",
             "faiss-node",
-            "grpc-tools",
-            "msgpackr-extract",
-            "protobufjs",
-            "puppeteer",
-            "sharp",
-            "sqlite3",
-            "ssh2",
-            "unrs-resolver",
-            "utf-8-validate"
+            "sqlite3"
         ],
         "overrides": {
             "axios": "1.15.0",

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1583,6 +1583,9 @@ const _createEmbeddingsObject = async (
 ): Promise<any> => {
     // prepare embedding node data
     const embeddingComponent = componentNodes[data.embeddingName]
+    if (!embeddingComponent) {
+        throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, `Embedding "${data.embeddingName}" not found in component nodes`)
+    }
     const embeddingNodeData: any = {
         inputs: { ...data.embeddingConfig },
         outputs: { output: 'document' },
@@ -1618,6 +1621,12 @@ const _createRecordManagerObject = async (
 ) => {
     // prepare record manager node data
     const recordManagerComponent = componentNodes[data.recordManagerName]
+    if (!recordManagerComponent) {
+        throw new InternalFlowiseError(
+            StatusCodes.INTERNAL_SERVER_ERROR,
+            `Record Manager "${data.recordManagerName}" not found in component nodes`
+        )
+    }
     const rmNodeData: any = {
         inputs: { ...data.recordManagerConfig },
         id: `${recordManagerComponent.name}_0`,
@@ -1646,6 +1655,12 @@ const _createRecordManagerObject = async (
 
 const _createVectorStoreNodeData = (componentNodes: IComponentNodes, data: ICommonObject, embeddingObj: any, recordManagerObj?: any) => {
     const vectorStoreComponent = componentNodes[data.vectorStoreName]
+    if (!vectorStoreComponent) {
+        throw new InternalFlowiseError(
+            StatusCodes.INTERNAL_SERVER_ERROR,
+            `Vector Store "${data.vectorStoreName}" not found in component nodes`
+        )
+    }
     const vStoreNodeData: any = {
         id: `${vectorStoreComponent.name}_0`,
         inputs: { ...data.vectorStoreConfig },
@@ -1679,7 +1694,14 @@ const _createVectorStoreObject = async (
     vStoreNodeData: INodeData,
     upsertHistory?: Record<string, any>
 ) => {
-    const vStoreNodeInstanceFilePath = componentNodes[data.vectorStoreName].filePath as string
+    const vectorStoreComponent = componentNodes[data.vectorStoreName]
+    if (!vectorStoreComponent || !vectorStoreComponent.filePath) {
+        throw new InternalFlowiseError(
+            StatusCodes.INTERNAL_SERVER_ERROR,
+            `Vector Store "${data.vectorStoreName}" not found or filePath not configured in component nodes`
+        )
+    }
+    const vStoreNodeInstanceFilePath = vectorStoreComponent.filePath as string
     const vStoreNodeModule = await import(vStoreNodeInstanceFilePath)
     const vStoreNodeInstance = new vStoreNodeModule.nodeClass()
     if (upsertHistory) upsertHistory['flowData'] = saveUpsertFlowData(vStoreNodeData, upsertHistory)

--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1583,7 +1583,7 @@ const _createEmbeddingsObject = async (
 ): Promise<any> => {
     // prepare embedding node data
     const embeddingComponent = componentNodes[data.embeddingName]
-    if (!embeddingComponent) {
+    if (!embeddingComponent || !embeddingComponent.filePath) {
         throw new InternalFlowiseError(StatusCodes.INTERNAL_SERVER_ERROR, `Embedding "${data.embeddingName}" not found in component nodes`)
     }
     const embeddingNodeData: any = {
@@ -1621,7 +1621,7 @@ const _createRecordManagerObject = async (
 ) => {
     // prepare record manager node data
     const recordManagerComponent = componentNodes[data.recordManagerName]
-    if (!recordManagerComponent) {
+    if (!recordManagerComponent || !recordManagerComponent.filePath) {
         throw new InternalFlowiseError(
             StatusCodes.INTERNAL_SERVER_ERROR,
             `Record Manager "${data.recordManagerName}" not found in component nodes`


### PR DESCRIPTION
Fixes #6405

## Problem
When upserting to vector store, the following error occurs:
TypeError: Cannot read properties of undefined (reading '0')

This happens because _createEmbeddingsObject, _createRecordManagerObject, 
_createVectorStoreNodeData and _createVectorStoreObject were directly 
accessing component properties without null checks.

## Fix
Added null checks in all 4 functions before accessing component nodes.
This gives a clear error message instead of a confusing undefined crash.