### PR TITLE
fix(chatmodels): add newer Azure OpenAI models

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -701,6 +701,42 @@
             "name": "azureChatOpenAI",
             "models": [
                 {
+                    "label": "gpt-5.5",
+                    "name": "gpt-5.5",
+                    "input_cost": 0.000005,
+                    "output_cost": 0.00003
+                },
+                {
+                    "label": "gpt-5.5-pro",
+                    "name": "gpt-5.5-pro",
+                    "input_cost": 0.00003,
+                    "output_cost": 0.00018
+                },
+                {
+                    "label": "gpt-5.4",
+                    "name": "gpt-5.4",
+                    "input_cost": 0.0000025,
+                    "output_cost": 0.000015
+                },
+                {
+                    "label": "gpt-5.4-pro",
+                    "name": "gpt-5.4-pro",
+                    "input_cost": 0.00003,
+                    "output_cost": 0.00018
+                },
+                {
+                    "label": "gpt-5.4-mini",
+                    "name": "gpt-5.4-mini",
+                    "input_cost": 0.00000075,
+                    "output_cost": 0.0000045
+                },
+                {
+                    "label": "gpt-5.4-nano",
+                    "name": "gpt-5.4-nano",
+                    "input_cost": 0.0000002,
+                    "output_cost": 0.00000125
+                },
+                {
                     "label": "gpt-5.2",
                     "name": "gpt-5.2",
                     "input_cost": 0.00000175,

--- a/packages/components/src/modelRegistry.test.ts
+++ b/packages/components/src/modelRegistry.test.ts
@@ -1,0 +1,32 @@
+import models from '../models.json'
+
+type ModelEntry = {
+    label: string
+    name: string
+    input_cost: number
+    output_cost: number
+}
+
+type ProviderEntry = {
+    name: string
+    models: ModelEntry[]
+}
+
+const getChatProvider = (name: string): ProviderEntry => {
+    const provider = (models.chat as ProviderEntry[]).find((entry) => entry.name === name)
+    if (!provider) throw new Error(`Missing chat provider ${name}`)
+    return provider
+}
+
+describe('models.json Azure ChatOpenAI registry', () => {
+    it('keeps newer GPT-5.x Azure ChatOpenAI options aligned with ChatOpenAI', () => {
+        const chatOpenAI = getChatProvider('chatOpenAI')
+        const azureChatOpenAI = getChatProvider('azureChatOpenAI')
+
+        for (const modelName of ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-pro', 'gpt-5.4-mini', 'gpt-5.4-nano']) {
+            const openAIModel = chatOpenAI.models.find((model) => model.name === modelName)
+            expect(openAIModel).toBeDefined()
+            expect(azureChatOpenAI.models.find((model) => model.name === modelName)).toEqual(openAIModel)
+        }
+    })
+})

--- a/packages/components/src/modelRegistry.test.ts
+++ b/packages/components/src/modelRegistry.test.ts
@@ -19,14 +19,16 @@ const getChatProvider = (name: string): ProviderEntry => {
 }
 
 describe('models.json Azure ChatOpenAI registry', () => {
-    it('keeps newer GPT-5.x Azure ChatOpenAI options aligned with ChatOpenAI', () => {
+    const newerGpt5Models = ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-pro', 'gpt-5.4-mini', 'gpt-5.4-nano']
+
+    it.each(newerGpt5Models)('keeps %s Azure ChatOpenAI aligned with ChatOpenAI', (modelName) => {
         const chatOpenAI = getChatProvider('chatOpenAI')
         const azureChatOpenAI = getChatProvider('azureChatOpenAI')
+        const openAIModel = chatOpenAI.models.find((model) => model.name === modelName)
+        const azureModel = azureChatOpenAI.models.find((model) => model.name === modelName)
 
-        for (const modelName of ['gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4', 'gpt-5.4-pro', 'gpt-5.4-mini', 'gpt-5.4-nano']) {
-            const openAIModel = chatOpenAI.models.find((model) => model.name === modelName)
-            expect(openAIModel).toBeDefined()
-            expect(azureChatOpenAI.models.find((model) => model.name === modelName)).toEqual(openAIModel)
-        }
+        expect(openAIModel).toBeDefined()
+        expect(azureModel).toBeDefined()
+        expect(azureModel).toEqual(openAIModel)
     })
 })


### PR DESCRIPTION
## Summary
- add the newer GPT-5.4 and GPT-5.5 model options to the Azure ChatOpenAI registry
- keep Azure ChatOpenAI costs aligned with the existing ChatOpenAI entries
- add a focused registry test so these newer GPT-5.x options do not drift again

Closes #6411.

## Validation
- `node -e "const m=require('./packages/components/models.json'); const names=['gpt-5.5','gpt-5.5-pro','gpt-5.4','gpt-5.4-pro','gpt-5.4-mini','gpt-5.4-nano']; const azure=m.chat.find(p=>p.name==='azureChatOpenAI').models; const open=m.chat.find(p=>p.name==='chatOpenAI').models; for (const n of names) { const a=azure.find(x=>x.name===n); const o=open.find(x=>x.name===n); if (JSON.stringify(a)!==JSON.stringify(o)) throw new Error(n); } console.log('azure model parity ok')"`
- `git diff --check`
- `pnpm exec prettier --check packages/components/models.json packages/components/src/modelRegistry.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter flowise-components test -- modelRegistry.test.ts --runInBand`

Note: the first focused Jest attempt hit the default Node heap limit locally; rerunning the same focused suite with a 4096 MB heap completed successfully.