### PR TITLE
fix(server): harden tools and chatmessage route contracts

### DIFF
--- a/packages/server/src/routes/chat-messages/index.ts
+++ b/packages/server/src/routes/chat-messages/index.ts
@@ -7,12 +7,12 @@ const router = express.Router()
 // router.post(['/', '/:id'], chatMessageController.createChatMessage)
 
 // READ
-router.get(['/', '/:id'], chatMessageController.getAllChatMessages)
+router.get('/:id', chatMessageController.getAllChatMessages)
 
 // UPDATE
-router.put(['/abort/', '/abort/:chatflowid/:chatid'], chatMessageController.abortChatMessage)
+router.put('/abort/:chatflowid/:chatid', chatMessageController.abortChatMessage)
 
 // DELETE
-router.delete(['/', '/:id'], chatMessageController.removeAllChatMessages)
+router.delete('/:id', chatMessageController.removeAllChatMessages)
 
 export default router

--- a/packages/server/src/routes/tools/index.ts
+++ b/packages/server/src/routes/tools/index.ts
@@ -9,12 +9,12 @@ router.post('/', checkPermission('tools:create'), toolsController.createTool)
 
 // READ
 router.get('/', checkPermission('tools:view'), toolsController.getAllTools)
-router.get(['/', '/:id'], checkAnyPermission('tools:view'), toolsController.getToolById)
+router.get('/:id', checkAnyPermission('tools:view'), toolsController.getToolById)
 
 // UPDATE
-router.put(['/', '/:id'], checkAnyPermission('tools:update,tools:create'), toolsController.updateTool)
+router.put('/:id', checkAnyPermission('tools:update,tools:create'), toolsController.updateTool)
 
 // DELETE
-router.delete(['/', '/:id'], checkPermission('tools:delete'), toolsController.deleteTool)
+router.delete('/:id', checkPermission('tools:delete'), toolsController.deleteTool)
 
 export default router


### PR DESCRIPTION
### Summary
fixes : #6428 

This PR removes ambiguous / route variants for handlers that require :id, and aligns route definitions with current controller expectations. 
Even though normal frontend flows were already working, these route definitions were still inconsistent and could cause avoidable 412 errors for future integrations or refactors.

### What changed
* Updated tools routes to require :id for id-based handlers:
  * GET /tools/:id (removed / variant for get-by-id)
  * PUT /tools/:id (removed / variant for update)
  * DELETE /tools/:id (removed / variant for delete)
* Updated chatmessage routes similarly:
  * GET /chatmessage/:id (removed / variant)
  * DELETE /chatmessage/:id (removed / variant)
* Normalized abort route to PUT /chatmessage/abort/:chatflowid/:chatid

### Files changed
* packages/server/src/routes/tools/index.ts
* packages/server/src/routes/chat-messages/index.ts

### Why this matters
Controllers for these handlers already require req.params.id.
Previous route setup accepted both / and /:id, which made the API contract ambiguous.
Calling / for id-required handlers could hit controller logic and fail with 412 (id not provided) instead of being clearly non-matching at the route layer.
This change makes behavior predictable and safer for future clients and tests.

### Compatibility and risk
* Low risk, backend-only route-contract hardening.
* No change to controller/service business logic.
* Existing frontend usage remains compatible because UI already calls /:id endpoints.

### Validation
* Verified current frontend API callers still target /:id: 
  * packages/ui/src/api/tools.js
  * packages/ui/src/api/chatmessage.js
* Local commit hooks passed successfully.
* Also tested frontend side -- not giving any issue.

### Checklist
- [x] Kept existing functionality intact for current UI flows
- [x] Limited scope to route contract cleanup
- [x] No unrelated files included in commit