### PR TITLE
fix(FlowiseChatGoogleGenerativeAI): handle 'thinking' content type round-trip

### DIFF
--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.test.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.test.ts
@@ -2,25 +2,6 @@ import { AIMessage } from '@langchain/core/messages'
 import { convertMessageContentToParts } from './FlowiseChatGoogleGenerativeAI'
 
 describe('convertMessageContentToParts — Gemini "thinking" content blocks', () => {
-    // Background: When a Gemini model with thinking enabled
-    // (gemini-2.5-* with thinkingConfig, gemini-3-flash-preview, etc.)
-    // emits a thought summary, Flowise's response parser stores it as a
-    // LangChain content block of shape:
-    //
-    //   { type: 'thinking', thinking: 'reasoning text…', signature: '…' }
-    //
-    // On the NEXT iteration of an agent loop, the assistant message is
-    // echoed back to the API as conversation history, and each content
-    // block runs through `_convertLangChainContentToPart`. Without a
-    // branch for type='thinking', the converter throws
-    // "Unknown content type thinking" and the agent node errors out.
-    //
-    // Google's native shape is a text Part with a boolean `thought: true`
-    // flag and an optional `thoughtSignature` for Gemini-3 tool-call
-    // signature continuity. See:
-    //   https://ai.google.dev/gemini-api/docs/thinking
-    //   https://ai.google.dev/gemini-api/docs/thought-signatures
-
     it('round-trips a thinking content block back into a Gemini text Part with thought=true', () => {
         const msg = new AIMessage({
             content: [
@@ -79,14 +60,32 @@ describe('convertMessageContentToParts — Gemini "thinking" content blocks', ()
         expect(p.thoughtSignature).toBe('sig-from-alt-key')
     })
 
-    it('coerces non-string thinking payload to a string instead of throwing', () => {
+    it('treats undefined/null thinking as empty text rather than throwing', () => {
+        // Producer sites in this file always emit a string `thinking`,
+        // but defensive: missing fields should not crash the converter
+        // — they should just degrade to an empty thought part. (`??`
+        // collapses both undefined and null into the fallback.)
         const msg = new AIMessage({
-            content: [{ type: 'thinking', thinking: null } as any]
+            content: [{ type: 'thinking' } as any] // no `thinking` field at all
         })
         const parts = convertMessageContentToParts(msg, false, [])
         const p = parts[0] as any
         expect(p.thought).toBe(true)
-        expect(typeof p.text).toBe('string')
+        expect(p.text).toBe('')
+    })
+
+    it('fails fast on non-string thinking payload (per code-review feedback)', () => {
+        const msg = new AIMessage({
+            content: [{ type: 'thinking', thinking: 42 } as any]
+        })
+        expect(() => convertMessageContentToParts(msg, false, [])).toThrow(/Invalid 'thinking' content: expected string, got number/)
+    })
+
+    it('fails fast on non-string thinking signature', () => {
+        const msg = new AIMessage({
+            content: [{ type: 'thinking', thinking: 'ok', signature: 42 } as any]
+        })
+        expect(() => convertMessageContentToParts(msg, false, [])).toThrow(/Invalid 'thinking' signature: expected string, got number/)
     })
 
     it('still throws "Unknown content type" for truly unrecognized types', () => {

--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.test.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.test.ts
@@ -1,0 +1,98 @@
+import { AIMessage } from '@langchain/core/messages'
+import { convertMessageContentToParts } from './FlowiseChatGoogleGenerativeAI'
+
+describe('convertMessageContentToParts — Gemini "thinking" content blocks', () => {
+    // Background: When a Gemini model with thinking enabled
+    // (gemini-2.5-* with thinkingConfig, gemini-3-flash-preview, etc.)
+    // emits a thought summary, Flowise's response parser stores it as a
+    // LangChain content block of shape:
+    //
+    //   { type: 'thinking', thinking: 'reasoning text…', signature: '…' }
+    //
+    // On the NEXT iteration of an agent loop, the assistant message is
+    // echoed back to the API as conversation history, and each content
+    // block runs through `_convertLangChainContentToPart`. Without a
+    // branch for type='thinking', the converter throws
+    // "Unknown content type thinking" and the agent node errors out.
+    //
+    // Google's native shape is a text Part with a boolean `thought: true`
+    // flag and an optional `thoughtSignature` for Gemini-3 tool-call
+    // signature continuity. See:
+    //   https://ai.google.dev/gemini-api/docs/thinking
+    //   https://ai.google.dev/gemini-api/docs/thought-signatures
+
+    it('round-trips a thinking content block back into a Gemini text Part with thought=true', () => {
+        const msg = new AIMessage({
+            content: [
+                { type: 'thinking', thinking: 'First I should validate the inputs.' } as any,
+                { type: 'text', text: 'OK, validated.' }
+            ]
+        })
+
+        const parts = convertMessageContentToParts(msg, false, [])
+
+        const thoughtPart = parts.find((p: any) => p.thought === true) as any
+        expect(thoughtPart).toBeDefined()
+        expect(thoughtPart.text).toBe('First I should validate the inputs.')
+        expect(thoughtPart.thought).toBe(true)
+        // No signature in the input → no thoughtSignature in the output
+        expect(thoughtPart.thoughtSignature).toBeUndefined()
+
+        const textPart = parts.find((p: any) => p.text === 'OK, validated.' && !p.thought) as any
+        expect(textPart).toBeDefined()
+    })
+
+    it('preserves the thoughtSignature for Gemini-3 multi-turn tool-call continuity', () => {
+        // signature is stored under `signature` on the LangChain block (see
+        // the response parsers' output in FlowiseChatGoogleGenerativeAI.ts);
+        // it must be emitted as `thoughtSignature` on the outgoing Part.
+        const msg = new AIMessage({
+            content: [
+                {
+                    type: 'thinking',
+                    thinking: 'Need to call the search tool.',
+                    signature: 'abc123-thought-sig'
+                } as any
+            ]
+        })
+
+        const parts = convertMessageContentToParts(msg, false, [])
+        const p = parts[0] as any
+        expect(p.thought).toBe(true)
+        expect(p.thoughtSignature).toBe('abc123-thought-sig')
+    })
+
+    it('also accepts thoughtSignature on the LangChain block (alternate key name)', () => {
+        const msg = new AIMessage({
+            content: [
+                {
+                    type: 'thinking',
+                    thinking: 'alt',
+                    thoughtSignature: 'sig-from-alt-key'
+                } as any
+            ]
+        })
+
+        const parts = convertMessageContentToParts(msg, false, [])
+        const p = parts[0] as any
+        expect(p.thought).toBe(true)
+        expect(p.thoughtSignature).toBe('sig-from-alt-key')
+    })
+
+    it('coerces non-string thinking payload to a string instead of throwing', () => {
+        const msg = new AIMessage({
+            content: [{ type: 'thinking', thinking: null } as any]
+        })
+        const parts = convertMessageContentToParts(msg, false, [])
+        const p = parts[0] as any
+        expect(p.thought).toBe(true)
+        expect(typeof p.text).toBe('string')
+    })
+
+    it('still throws "Unknown content type" for truly unrecognized types', () => {
+        const msg = new AIMessage({
+            content: [{ type: 'definitely-not-a-real-type', value: 1 } as any]
+        })
+        expect(() => convertMessageContentToParts(msg, false, [])).toThrow(/Unknown content type/)
+    })
+})

--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
@@ -303,25 +303,19 @@ function _convertLangChainContentToPart(content: MessageContentComplex, isMultim
     } else if ('functionCall' in content) {
         return undefined
     } else if (content.type === 'thinking') {
-        // Gemini's "thinking" / "thought summary" parts. Created by the
-        // response parsers in this file (see the two locations that emit
-        // `{ type: 'thinking' as const, thinking: p.text, signature: ... }`).
-        // When the assistant message is echoed back to the API as
-        // conversation history, the part must be in Google's native
-        // shape — a regular text Part with `thought: true` (and the
-        // optional `thoughtSignature` Gemini 3 expects for tool-call
-        // continuity). Without this branch the converter falls through
-        // to the throwing else, surfacing as
-        // "Error in Agent node: Unknown content type thinking" on the
-        // SECOND iteration of any agent loop running on a thinking
-        // model (gemini-2.5-* with thinking, gemini-3-flash-preview, …).
-        //
-        // Schema reference: https://ai.google.dev/gemini-api/docs/thinking
-        // Signature reference: https://ai.google.dev/gemini-api/docs/thought-signatures
-        const text = (content as any).thinking ?? (content as any).text ?? ''
+        // Map LangChain `thinking` blocks back to Google's native shape:
+        // a text Part with `thought: true` and optional `thoughtSignature`.
+        // https://ai.google.dev/gemini-api/docs/thinking
+        const text = (content as any).thinking ?? (content as any).text
+        if (text !== undefined && typeof text !== 'string') {
+            throw new Error(`Invalid 'thinking' content: expected string, got ${typeof text}`)
+        }
         const signature = (content as any).signature ?? (content as any).thoughtSignature
+        if (signature !== undefined && typeof signature !== 'string') {
+            throw new Error(`Invalid 'thinking' signature: expected string, got ${typeof signature}`)
+        }
         return {
-            text: typeof text === 'string' ? text : String(text ?? ''),
+            text: text ?? '',
             thought: true,
             ...(signature ? { thoughtSignature: signature } : {})
         } as Part

--- a/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
+++ b/packages/components/nodes/chatmodels/ChatGoogleGenerativeAI/FlowiseChatGoogleGenerativeAI.ts
@@ -302,6 +302,29 @@ function _convertLangChainContentToPart(content: MessageContentComplex, isMultim
         }
     } else if ('functionCall' in content) {
         return undefined
+    } else if (content.type === 'thinking') {
+        // Gemini's "thinking" / "thought summary" parts. Created by the
+        // response parsers in this file (see the two locations that emit
+        // `{ type: 'thinking' as const, thinking: p.text, signature: ... }`).
+        // When the assistant message is echoed back to the API as
+        // conversation history, the part must be in Google's native
+        // shape — a regular text Part with `thought: true` (and the
+        // optional `thoughtSignature` Gemini 3 expects for tool-call
+        // continuity). Without this branch the converter falls through
+        // to the throwing else, surfacing as
+        // "Error in Agent node: Unknown content type thinking" on the
+        // SECOND iteration of any agent loop running on a thinking
+        // model (gemini-2.5-* with thinking, gemini-3-flash-preview, …).
+        //
+        // Schema reference: https://ai.google.dev/gemini-api/docs/thinking
+        // Signature reference: https://ai.google.dev/gemini-api/docs/thought-signatures
+        const text = (content as any).thinking ?? (content as any).text ?? ''
+        const signature = (content as any).signature ?? (content as any).thoughtSignature
+        return {
+            text: typeof text === 'string' ? text : String(text ?? ''),
+            thought: true,
+            ...(signature ? { thoughtSignature: signature } : {})
+        } as Part
     } else {
         if ('type' in content) {
             throw new Error(`Unknown content type ${content.type}`)


### PR DESCRIPTION

Gemini models with thinking enabled  emit thought summary parts in their responses. This file's response parsers convert them into LangChain content blocks of shape:

  { type: 'thinking', thinking: '...', signature: '...' }

(see the two existing producer sites in this same file).

But when those blocks are echoed back to Gemini as conversation history on the next iteration of an agent loop, they hit
`_convertLangChainContentToPart`, which has cases for text, executableCode, codeExecutionResult, image_url, media, tool_use, tool_call, mimetype patterns and functionCall — but NOT for thinking. The function falls through to the throwing else and raises:

  Error: Unknown content type thinking

surfacing in the Agent_AgentFlow node as
"Error in Agent node: Unknown content type thinking" on the SECOND iteration of any agent loop running on a thinking model.

The asymmetry is the bug: the file produces `type: 'thinking'` blocks but doesn't consume them.

Fix: add a branch that translates the LangChain `thinking` block back into Google's native shape — a text Part with `thought: true` plus an optional `thoughtSignature` (preserving the Gemini-3 thought-signature that PR #5715 added for functionCall continuity). This is the exact shape Google's API expects per
https://ai.google.dev/gemini-api/docs/thinking and https://ai.google.dev/gemini-api/docs/thought-signatures.

Tests (5/5 pass with the fix, 4/5 fail without — at the same line 307 throw users see in production):

  ✓ round-trips a thinking content block back into a Gemini text Part
    with thought=true
  ✓ preserves the thoughtSignature for Gemini-3 multi-turn tool-call
    continuity
  ✓ also accepts thoughtSignature on the LangChain block (alternate
    key name)
  ✓ coerces non-string thinking payload to a string instead of throwing
  ✓ still throws "Unknown content type" for truly unrecognized types