### PR TITLE
feat: add Jungle Grid integration

### DIFF
--- a/packages/components/credentials/JungleGridApi.credential.ts
+++ b/packages/components/credentials/JungleGridApi.credential.ts
@@ -1,0 +1,33 @@
+import { INodeParams, INodeCredential } from '../src/Interface'
+
+class JungleGridApiCredential implements INodeCredential {
+    label: string
+    name: string
+    version: number
+    description: string
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'Jungle Grid API'
+        this.name = 'jungleGridApi'
+        this.version = 1.0
+        this.description =
+            'Use a Jungle Grid API key to estimate, submit, monitor, cancel, and retrieve artifacts for long-running workloads.'
+        this.inputs = [
+            {
+                label: 'Jungle Grid API Key',
+                name: 'apiKey',
+                type: 'password'
+            },
+            {
+                label: 'Jungle Grid API Base URL',
+                name: 'baseUrl',
+                type: 'url',
+                default: 'https://api.junglegrid.dev',
+                description: 'Override only for development or self-hosted Jungle Grid orchestrators.'
+            }
+        ]
+    }
+}
+
+module.exports = { credClass: JungleGridApiCredential }

--- a/packages/components/credentials/JungleGridApi.credential.ts
+++ b/packages/components/credentials/JungleGridApi.credential.ts
@@ -12,7 +12,7 @@ class JungleGridApiCredential implements INodeCredential {
         this.name = 'jungleGridApi'
         this.version = 1.0
         this.description =
-            'Use a Jungle Grid API key to estimate, submit, monitor, cancel, and retrieve artifacts for long-running workloads.'
+            'Use a Jungle Grid API key to prepare inputs, estimate, submit, monitor, cancel, and retrieve outputs for asynchronous workloads.'
         this.inputs = [
             {
                 label: 'Jungle Grid API Key',

--- a/packages/components/nodes/tools/JungleGrid/JungleGrid.test.ts
+++ b/packages/components/nodes/tools/JungleGrid/JungleGrid.test.ts
@@ -1,5 +1,5 @@
 import { secureAxiosRequest } from '../../../src/httpSecurity'
-import { convertMultiOptionsToStringArray, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { getCredentialData, getCredentialParam } from '../../../src/utils'
 
 jest.mock('../../../src/httpSecurity', () => ({
     secureAxiosRequest: jest.fn()
@@ -14,41 +14,31 @@ jest.mock('../../../src/utils', () => ({
 const mockedSecureAxiosRequest = secureAxiosRequest as jest.MockedFunction<typeof secureAxiosRequest>
 const mockedGetCredentialData = getCredentialData as jest.MockedFunction<typeof getCredentialData>
 const mockedGetCredentialParam = getCredentialParam as jest.MockedFunction<typeof getCredentialParam>
-const mockedConvertMultiOptionsToStringArray = convertMultiOptionsToStringArray as jest.MockedFunction<
-    typeof convertMultiOptionsToStringArray
->
 
 describe('JungleGrid_Tools', () => {
     beforeEach(() => {
         mockedSecureAxiosRequest.mockReset()
-        mockedSecureAxiosRequest.mockResolvedValue({
-            status: 200,
-            data: { available: true }
-        } as any)
+        mockedSecureAxiosRequest.mockResolvedValue({ status: 200, data: { ok: true, data: { available: true } } } as any)
         mockedGetCredentialData.mockReset()
         mockedGetCredentialParam.mockClear()
-        mockedConvertMultiOptionsToStringArray.mockClear()
     })
 
-    it('loads Jungle Grid credentials through Flowise credential helpers', async () => {
+    it('loads credentials through Flowise helpers and uses the configured base URL', async () => {
         mockedGetCredentialData.mockResolvedValue({
             apiKey: 'credential-api-key',
             baseUrl: 'https://api.example.test/'
         } as any)
-
         const { nodeClass } = require('./JungleGrid')
         const node = new nodeClass()
+
         const tools = await node.init(
             {
                 credential: 'credential-id',
-                inputs: {
-                    actions: ['estimateJob']
-                }
+                inputs: { actions: ['estimateJob'] }
             } as any,
             '',
             {} as any
         )
-
         await tools[0]._call({ workload_type: 'batch', image: 'python:3.11' })
 
         expect(mockedGetCredentialData).toHaveBeenCalledWith('credential-id', {})
@@ -57,18 +47,57 @@ describe('JungleGrid_Tools', () => {
             expect.objectContaining({ apiKey: 'credential-api-key' }),
             expect.anything()
         )
-        expect(mockedGetCredentialParam).toHaveBeenCalledWith(
-            'baseUrl',
-            expect.objectContaining({ baseUrl: 'https://api.example.test/' }),
-            expect.anything()
-        )
         expect(mockedSecureAxiosRequest).toHaveBeenCalledWith(
             expect.objectContaining({
-                url: 'https://api.example.test/v1/jobs/estimate',
-                headers: expect.objectContaining({
-                    Authorization: 'Bearer credential-api-key'
-                })
+                url: 'https://api.example.test/v1/mcp/jobs/estimate',
+                headers: expect.objectContaining({ Authorization: 'Bearer credential-api-key' })
             })
         )
+    })
+
+    it('lists all production actions in the requested order', () => {
+        const { nodeClass } = require('./JungleGrid')
+        const node = new nodeClass()
+
+        expect(node.inputs[0].options.map((option: any) => option.label)).toEqual([
+            'Estimate Job',
+            'Submit Job',
+            'Create Job Input Upload',
+            'List Job Inputs',
+            'List Jobs',
+            'Get Job',
+            'Get Job Events',
+            'Get Job Runtime',
+            'Get Job Logs',
+            'Cancel Job',
+            'List Artifacts',
+            'Get Artifact'
+        ])
+        expect(node.inputs[0].default).not.toContain('uploadJobInput')
+        expect(node.inputs[0].default).not.toContain('cancelJob')
+    })
+
+    it('creates selected tools only', async () => {
+        mockedGetCredentialData.mockResolvedValue({
+            apiKey: 'credential-api-key',
+            baseUrl: 'https://api.junglegrid.dev'
+        } as any)
+        const { nodeClass } = require('./JungleGrid')
+        const node = new nodeClass()
+
+        const tools = await node.init(
+            {
+                credential: 'credential-id',
+                inputs: { actions: ['uploadJobInput', 'listJobInputs', 'getJobEvents'] }
+            } as any,
+            '',
+            {} as any
+        )
+
+        expect(tools.map((tool: any) => tool.name)).toEqual([
+            'jungle_grid_upload_job_input',
+            'jungle_grid_list_job_inputs',
+            'jungle_grid_get_job_events'
+        ])
     })
 })

--- a/packages/components/nodes/tools/JungleGrid/JungleGrid.test.ts
+++ b/packages/components/nodes/tools/JungleGrid/JungleGrid.test.ts
@@ -1,0 +1,74 @@
+import { secureAxiosRequest } from '../../../src/httpSecurity'
+import { convertMultiOptionsToStringArray, getCredentialData, getCredentialParam } from '../../../src/utils'
+
+jest.mock('../../../src/httpSecurity', () => ({
+    secureAxiosRequest: jest.fn()
+}))
+
+jest.mock('../../../src/utils', () => ({
+    convertMultiOptionsToStringArray: jest.fn((value) => (Array.isArray(value) ? value : value ? [value] : [])),
+    getCredentialData: jest.fn(),
+    getCredentialParam: jest.fn((name, credentialData) => credentialData[name])
+}))
+
+const mockedSecureAxiosRequest = secureAxiosRequest as jest.MockedFunction<typeof secureAxiosRequest>
+const mockedGetCredentialData = getCredentialData as jest.MockedFunction<typeof getCredentialData>
+const mockedGetCredentialParam = getCredentialParam as jest.MockedFunction<typeof getCredentialParam>
+const mockedConvertMultiOptionsToStringArray = convertMultiOptionsToStringArray as jest.MockedFunction<
+    typeof convertMultiOptionsToStringArray
+>
+
+describe('JungleGrid_Tools', () => {
+    beforeEach(() => {
+        mockedSecureAxiosRequest.mockReset()
+        mockedSecureAxiosRequest.mockResolvedValue({
+            status: 200,
+            data: { available: true }
+        } as any)
+        mockedGetCredentialData.mockReset()
+        mockedGetCredentialParam.mockClear()
+        mockedConvertMultiOptionsToStringArray.mockClear()
+    })
+
+    it('loads Jungle Grid credentials through Flowise credential helpers', async () => {
+        mockedGetCredentialData.mockResolvedValue({
+            apiKey: 'credential-api-key',
+            baseUrl: 'https://api.example.test/'
+        } as any)
+
+        const { nodeClass } = require('./JungleGrid')
+        const node = new nodeClass()
+        const tools = await node.init(
+            {
+                credential: 'credential-id',
+                inputs: {
+                    actions: ['estimateJob']
+                }
+            } as any,
+            '',
+            {} as any
+        )
+
+        await tools[0]._call({ workload_type: 'batch', image: 'python:3.11' })
+
+        expect(mockedGetCredentialData).toHaveBeenCalledWith('credential-id', {})
+        expect(mockedGetCredentialParam).toHaveBeenCalledWith(
+            'apiKey',
+            expect.objectContaining({ apiKey: 'credential-api-key' }),
+            expect.anything()
+        )
+        expect(mockedGetCredentialParam).toHaveBeenCalledWith(
+            'baseUrl',
+            expect.objectContaining({ baseUrl: 'https://api.example.test/' }),
+            expect.anything()
+        )
+        expect(mockedSecureAxiosRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: 'https://api.example.test/v1/jobs/estimate',
+                headers: expect.objectContaining({
+                    Authorization: 'Bearer credential-api-key'
+                })
+            })
+        )
+    })
+})

--- a/packages/components/nodes/tools/JungleGrid/JungleGrid.ts
+++ b/packages/components/nodes/tools/JungleGrid/JungleGrid.ts
@@ -1,0 +1,77 @@
+import { convertMultiOptionsToStringArray, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { createJungleGridTools, DEFAULT_JUNGLE_GRID_BASE_URL, JungleGridAction, JungleGridClient } from './core'
+import type { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+
+const ALL_ACTIONS: { label: string; name: JungleGridAction }[] = [
+    { label: 'Estimate Job', name: 'estimateJob' },
+    { label: 'Submit Job', name: 'submitJob' },
+    { label: 'List Jobs', name: 'listJobs' },
+    { label: 'Get Job', name: 'getJob' },
+    { label: 'Get Job Runtime', name: 'getJobRuntime' },
+    { label: 'Cancel Job', name: 'cancelJob' },
+    { label: 'Get Job Logs', name: 'getJobLogs' },
+    { label: 'List Job Artifacts', name: 'listJobArtifacts' },
+    { label: 'Get Artifact Download URL', name: 'getArtifactDownloadUrl' }
+]
+
+class JungleGrid_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    type: string
+    icon: string
+    category: string
+    description: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+    documentation?: string
+
+    constructor() {
+        this.label = 'Jungle Grid'
+        this.name = 'jungleGrid'
+        this.version = 1.0
+        this.type = 'JungleGrid'
+        this.icon = 'junglegrid.svg'
+        this.category = 'Tools'
+        this.description = 'Estimate, submit, monitor, cancel, and retrieve artifacts for asynchronous Jungle Grid workloads'
+        this.documentation = 'https://junglegrid.dev/docs/mcp'
+        this.baseClasses = [this.type, 'Tool']
+        this.credential = {
+            label: 'Jungle Grid Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['jungleGridApi']
+        }
+        this.inputs = [
+            {
+                label: 'Actions',
+                name: 'actions',
+                type: 'multiOptions',
+                options: ALL_ACTIONS,
+                default: [
+                    'estimateJob',
+                    'submitJob',
+                    'getJob',
+                    'getJobRuntime',
+                    'getJobLogs',
+                    'listJobArtifacts',
+                    'getArtifactDownloadUrl'
+                ],
+                description: 'Choose which Jungle Grid tools to expose to the agent.'
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('apiKey', credentialData, nodeData) as string
+        const baseUrl = (getCredentialParam('baseUrl', credentialData, nodeData) as string) || DEFAULT_JUNGLE_GRID_BASE_URL
+        const actions = convertMultiOptionsToStringArray(nodeData.inputs?.actions) as JungleGridAction[]
+
+        const client = new JungleGridClient({ apiKey, baseUrl })
+        return createJungleGridTools(client, actions)
+    }
+}
+
+module.exports = { nodeClass: JungleGrid_Tools }

--- a/packages/components/nodes/tools/JungleGrid/JungleGrid.ts
+++ b/packages/components/nodes/tools/JungleGrid/JungleGrid.ts
@@ -10,8 +10,8 @@ const ALL_ACTIONS: { label: string; name: JungleGridAction }[] = [
     { label: 'Get Job Runtime', name: 'getJobRuntime' },
     { label: 'Cancel Job', name: 'cancelJob' },
     { label: 'Get Job Logs', name: 'getJobLogs' },
-    { label: 'List Job Artifacts', name: 'listJobArtifacts' },
-    { label: 'Get Artifact Download URL', name: 'getArtifactDownloadUrl' }
+    { label: 'List Artifacts', name: 'listArtifacts' },
+    { label: 'Get Artifact', name: 'getArtifact' }
 ]
 
 class JungleGrid_Tools implements INode {
@@ -35,7 +35,7 @@ class JungleGrid_Tools implements INode {
         this.icon = 'junglegrid.svg'
         this.category = 'Tools'
         this.description = 'Estimate, submit, monitor, cancel, and retrieve artifacts for asynchronous Jungle Grid workloads'
-        this.documentation = 'https://junglegrid.dev/docs/mcp'
+        this.documentation = 'https://junglegrid.dev/docs/api'
         this.baseClasses = [this.type, 'Tool']
         this.credential = {
             label: 'Jungle Grid Credential',
@@ -49,15 +49,7 @@ class JungleGrid_Tools implements INode {
                 name: 'actions',
                 type: 'multiOptions',
                 options: ALL_ACTIONS,
-                default: [
-                    'estimateJob',
-                    'submitJob',
-                    'getJob',
-                    'getJobRuntime',
-                    'getJobLogs',
-                    'listJobArtifacts',
-                    'getArtifactDownloadUrl'
-                ],
+                default: ['estimateJob', 'submitJob', 'getJob', 'getJobRuntime', 'getJobLogs', 'listArtifacts', 'getArtifact'],
                 description: 'Choose which Jungle Grid tools to expose to the agent.'
             }
         ]

--- a/packages/components/nodes/tools/JungleGrid/JungleGrid.ts
+++ b/packages/components/nodes/tools/JungleGrid/JungleGrid.ts
@@ -5,11 +5,14 @@ import type { ICommonObject, INode, INodeData, INodeParams } from '../../../src/
 const ALL_ACTIONS: { label: string; name: JungleGridAction }[] = [
     { label: 'Estimate Job', name: 'estimateJob' },
     { label: 'Submit Job', name: 'submitJob' },
+    { label: 'Create Job Input Upload', name: 'uploadJobInput' },
+    { label: 'List Job Inputs', name: 'listJobInputs' },
     { label: 'List Jobs', name: 'listJobs' },
     { label: 'Get Job', name: 'getJob' },
+    { label: 'Get Job Events', name: 'getJobEvents' },
     { label: 'Get Job Runtime', name: 'getJobRuntime' },
-    { label: 'Cancel Job', name: 'cancelJob' },
     { label: 'Get Job Logs', name: 'getJobLogs' },
+    { label: 'Cancel Job', name: 'cancelJob' },
     { label: 'List Artifacts', name: 'listArtifacts' },
     { label: 'Get Artifact', name: 'getArtifact' }
 ]
@@ -34,7 +37,7 @@ class JungleGrid_Tools implements INode {
         this.type = 'JungleGrid'
         this.icon = 'junglegrid.svg'
         this.category = 'Tools'
-        this.description = 'Estimate, submit, monitor, cancel, and retrieve artifacts for asynchronous Jungle Grid workloads'
+        this.description = 'Prepare, estimate, submit, monitor, cancel, and retrieve outputs for asynchronous Jungle Grid workloads'
         this.documentation = 'https://junglegrid.dev/docs/api'
         this.baseClasses = [this.type, 'Tool']
         this.credential = {
@@ -49,7 +52,16 @@ class JungleGrid_Tools implements INode {
                 name: 'actions',
                 type: 'multiOptions',
                 options: ALL_ACTIONS,
-                default: ['estimateJob', 'submitJob', 'getJob', 'getJobRuntime', 'getJobLogs', 'listArtifacts', 'getArtifact'],
+                default: [
+                    'estimateJob',
+                    'submitJob',
+                    'getJob',
+                    'getJobEvents',
+                    'getJobRuntime',
+                    'getJobLogs',
+                    'listArtifacts',
+                    'getArtifact'
+                ],
                 description: 'Choose which Jungle Grid tools to expose to the agent.'
             }
         ]

--- a/packages/components/nodes/tools/JungleGrid/README.md
+++ b/packages/components/nodes/tools/JungleGrid/README.md
@@ -1,138 +1,163 @@
 # Jungle Grid
 
-The Jungle Grid tool node lets Flowise agents estimate, submit, monitor, cancel, and retrieve outputs for asynchronous Jungle Grid workloads.
+The Jungle Grid Tool node lets Flowise agents prepare, estimate, submit, monitor, cancel, and retrieve outputs for asynchronous AI workloads on Jungle Grid.
 
-Jungle Grid is live production infrastructure. Submitting jobs may start managed compute and spend credits. Estimate first whenever a user needs cost, capacity, or routing information before execution.
-
-## Links
-
--   Website: https://junglegrid.dev
--   Docs: https://junglegrid.dev/docs
--   API docs: https://junglegrid.dev/docs/api
--   MCP docs: https://junglegrid.dev/docs/mcp
--   MCP server: https://github.com/Jungle-Grid/mcp-server
--   Discord: https://discord.com/invite/kpJqxXFFCs
+Submitting a job may start managed compute and spend Jungle Grid credits. Estimate first when cost, routing, or capacity matters.
 
 ## Credentials
 
 Create a `Jungle Grid API` credential in Flowise:
 
--   `Jungle Grid API Key`: a scoped Jungle Grid API key from the Jungle Grid portal.
--   `Jungle Grid API Base URL`: defaults to `https://api.junglegrid.dev`. Override only for staging, local development, or private deployments.
+-   `Jungle Grid API Key`: a scoped API key from the Jungle Grid portal.
+-   `Jungle Grid API Base URL`: defaults to `https://api.junglegrid.dev`; it can be changed for an approved staging or self-hosted deployment.
 
-Keep the API key in Flowise credentials or a server-side environment variable used to create that credential. Do not place Jungle Grid API keys in prompts, command arguments, exported flows, source code, logs, browser code, or public repositories.
+Requests use bearer authentication and the configured base URL. Keep API keys, upload tokens, and temporary signed URLs out of prompts, logs, exported flows, and source control.
 
-Recommended API key scopes:
+Relevant scopes include:
 
--   `jobs:estimate` for estimates.
--   `jobs:submit` or `jobs:write` for submit and cancel.
--   `jobs:read` for list, status, runtime, logs, and artifacts.
--   `logs:read` for stored job logs.
+-   `jobs:estimate`, `jobs:read`, or `jobs:write` for estimates.
+-   `jobs:submit` or `jobs:write` for submissions, input upload slots, and cancellation.
+-   `jobs:read` or `jobs:write` for job inputs, status, events, runtime, and artifacts.
+-   `logs:read`, `jobs:read`, or `jobs:write` for logs.
 
 ## Actions
 
--   `Estimate Job`: calls `POST /v1/jobs/estimate`. This is read-only and does not start compute.
--   `Submit Job`: calls `POST /v1/jobs`. This starts asynchronous remote work and can spend credits.
--   `List Jobs`: calls `GET /v1/jobs` with `limit`, `cursor`, and `status` filters.
--   `Get Job`: calls `GET /v1/jobs/{job_id}` for status and job details.
--   `Get Job Runtime`: calls `GET /v1/jobs/{job_id}/runtime` for runtime tails, exit code, timeout, and diagnostics where available.
--   `Get Job Logs`: calls `GET /v1/jobs/{job_id}/logs` with `tail`, `limit`, `cursor`, and `stream` filters.
--   `Cancel Job`: calls `POST /v1/jobs/{job_id}/cancel`. Use only for non-terminal jobs.
--   `List Artifacts`: calls `GET /v1/jobs/{job_id}/artifacts`.
--   `Get Artifact`: calls `POST /v1/jobs/{job_id}/artifacts/{artifact_id}/download` to create temporary download information.
+-   **Estimate Job**: estimates routing, screening, capacity, cost, and submission eligibility. It does not submit a workload.
+-   **Submit Job**: starts an asynchronous workload and may spend credits.
+-   **Create Job Input Upload**: creates a managed upload slot for an input or script. It does not upload file bytes.
+-   **List Job Inputs**: lists uploaded inputs and scripts, readiness, and mount paths.
+-   **List Jobs**: lists recent jobs with optional status filtering and cursor pagination.
+-   **Get Job**: returns the current status snapshot, phase timing, scheduling delay, routing, failure, billing, and artifact readiness where available.
+-   **Get Job Events**: returns ordered platform lifecycle progress for scheduling, capacity lookup, provisioning, input preparation, and startup.
+-   **Get Job Runtime**: returns separate runtime diagnostics, output tails, exit code, timeout state, and field availability.
+-   **Get Job Logs**: polls paginated persisted logs. It is not a true streaming connection.
+-   **Cancel Job**: may stop active execution and prevent further outputs.
+-   **List Artifacts**: lists managed output files for a job.
+-   **Get Artifact**: returns temporary download information for an artifact ID.
 
-Live log streaming uses `GET /v1/jobs/{job_id}/logs/live` as Server-Sent Events. Flowise tools execute synchronously, so this integration exposes polling through `Get Job` and `Get Job Logs` instead of holding a long-lived stream.
+Lifecycle events are platform progress. Logs are workload and runtime output. Runtime details are separate diagnostics. Artifacts are managed output files.
 
-## Usage Pattern
+## Production Workflow
 
 ```text
 Estimate Job
-  -> review estimate/capacity/cost fields
-  -> Submit Job after user approval
-  -> store job_id
-  -> Get Job / Get Job Runtime / Get Job Logs
-  -> wait for completed, failed, rejected, or cancelled
+  -> Create Job Input Upload when files are needed
+  -> upload bytes to upload_url with the returned method and headers
+  -> call complete_url with the required token and upload metadata
+  -> Submit Job with input_files or script_files
+  -> Get Job or Get Job Events
+  -> Get Job Logs
   -> List Artifacts
   -> Get Artifact
 ```
 
-`Submit Job` returns a `job_id` immediately. It does not wait for completion. Poll until Jungle Grid reports a terminal status before assuming outputs are final.
+An estimate does not reserve capacity or guarantee an immediate start. `Submit Job` returns a `job_id` before execution finishes.
 
-## Example Workloads
+## Commands
 
-Inference estimate:
+The preferred command form is an array:
 
 ```json
 {
-    "name": "flowise-inference-estimate",
-    "image": "python:3.11",
+    "command": ["python", "/workspace/scripts/transcribe.py", "/workspace/inputs/audio.ogg"]
+}
+```
+
+The legacy command-plus-args form remains supported:
+
+```json
+{
+    "command": "python",
+    "args": ["-c", "print('hello')"]
+}
+```
+
+Command arrays must contain only non-empty strings. `workload_type` supports `inference`, `training`, `fine_tuning`, and `batch`. The compatibility value `fine-tuning` is also accepted, and `fine_tuning` is converted to the REST API value.
+
+`env` is accepted as an alias for `environment`. Environment values must be strings. `routing_mode` is accepted as an alias for `optimize_for`.
+
+## Uploaded Inputs
+
+Create an upload slot with:
+
+```json
+{
+    "filename": "audio.ogg",
+    "content_type": "audio/ogg",
+    "kind": "input"
+}
+```
+
+Use `kind: "script"` for files mounted under `/workspace/scripts`. Input files are mounted under `/workspace/inputs`.
+
+The response can include `input_id`, `filename`, `method`, `upload_url`, required headers, `token`, `expires_at`, and `complete_url`. Slot creation is not upload completion:
+
+1. Upload the bytes to `upload_url` with the returned HTTP method and headers.
+2. Call `complete_url` as required by the API response.
+3. Confirm the input is ready with **List Job Inputs**.
+4. Pass the `input_id` to **Submit Job**.
+
+The structured tool does not accept local file paths or base64 file bodies. Flowise does not currently provide an agent-safe binary parameter convention for this Tool node that can complete the upload without exposing host paths or adding unrelated infrastructure.
+
+String IDs and object references are accepted:
+
+```json
+{
+    "input_files": ["inp_audio123"],
+    "script_files": [{ "input_id": "inp_script123" }]
+}
+```
+
+Both forms are sent to the API as `{ "input_id": "..." }` objects.
+
+## File-Backed Example
+
+```json
+{
+    "name": "audio-transcription",
     "workload_type": "inference",
-    "model_size_gb": 1,
-    "optimize_for": "balanced"
+    "image": "python:3.11-slim",
+    "command": ["python", "/workspace/scripts/transcribe.py", "/workspace/inputs/audio.ogg", "/workspace/artifacts/transcript.txt"],
+    "script_files": [
+        {
+            "input_id": "inp_script123"
+        }
+    ],
+    "input_files": [
+        {
+            "input_id": "inp_audio123"
+        }
+    ],
+    "expected_artifacts": ["/workspace/artifacts/transcript.txt"]
 }
 ```
 
-Low-cost batch submit:
+The current API supports one uploaded script reference. Expected artifacts should use paths under `/workspace/artifacts`.
 
-```json
-{
-    "name": "flowise-batch-smoke",
-    "image": "python:3.11",
-    "workload_type": "batch",
-    "model_size_gb": 1,
-    "optimize_for": "cost",
-    "command": "python",
-    "args": ["-c", "print(42)"]
-}
-```
+## Monitoring
 
-Agent-triggered artifact job:
+**Get Job** returns the current state. Fields can include `status`, `phase`, `execution_phase`, `status_message`, `phase_started_at`, `phase_last_updated_at`, `wait_duration_seconds`, `delayed_start`, `delay_reason`, scheduling details, estimated and actual job cost, artifact readiness, and failure information.
 
-```json
-{
-    "name": "flowise-artifact-job",
-    "image": "python:3.11",
-    "workload_type": "batch",
-    "model_size_gb": 1,
-    "command": "python",
-    "args": [
-        "-c",
-        "import json, os; os.makedirs('/workspace/artifacts', exist_ok=True); json.dump({'status':'ok'}, open('/workspace/artifacts/output.json','w'))"
-    ]
-}
-```
+**Get Job Events** returns ordered lifecycle activity that may exist before workload logs. Use it while a job is queued, scheduling, provisioning, or preparing inputs/runtime.
 
-Job monitoring:
+**Get Job Runtime** is separate from status, events, and logs. Runtime information can be unavailable while a job is waiting or starting; this is not itself a failure.
 
-```json
-{
-    "job_id": "job_..."
-}
-```
+**Get Job Logs** supports `limit`, `cursor`, `tail`, and `stream` (`stdout`, `stderr`, or `all`). Responses can include `next_cursor`, `has_more`, categories, a failure highlight, and a usage hint. Empty logs do not mean a job is stuck or failed. Polling this action is not true streaming.
 
-Logs retrieval:
+## Cancellation And Artifacts
 
-```json
-{
-    "job_id": "job_...",
-    "tail": 100,
-    "stream": "all"
-}
-```
+Cancellation is explicit and is never called by another action. It can stop pending or active execution.
 
-Artifact retrieval:
+Managed workloads write regular output files under `/workspace/artifacts`. **List Artifacts** returns artifact IDs and readiness metadata. **Get Artifact** requires an artifact ID and returns short-lived download information; it does not permanently copy the file into Flowise.
 
-```json
-{
-    "job_id": "job_...",
-    "artifact_id": "art_..."
-}
-```
+## Errors And Security
 
-## Field Notes
+The node validates workload types, command arrays, environment values, input references, artifact IDs, and upload kinds before requests. It handles API authentication and authorization failures, rate limits, non-JSON errors, upstream failures, and timeouts without returning Axios configuration or authorization headers.
 
--   `workload_type` supports `inference`, `training`, `fine_tuning` / `fine-tuning`, and `batch`. The integration sends `fine-tuning` to the REST API.
--   `routing_mode` is accepted as an agent-friendly alias for `optimize_for`.
--   `env` is accepted as an alias for `environment`; values must be strings.
--   `callback_url`, `callback_auth_token`, and `callback_metadata` follow the documented per-job callback fields. Treat callback tokens as secrets.
--   Managed jobs can upload regular files written under `/workspace/artifacts`. Direct input file upload is not part of the documented public job-submit contract; pass file references through your image, command, environment, or storage system where appropriate.
+Sensitive keys are recursively redacted in tool errors, including values nested in arrays. Bearer tokens, API keys, callback tokens, and temporary signed upload/download URLs are not written to debug logs by this integration. Successful upload-slot and artifact responses still return their temporary URLs because clients need them to complete the requested workflow; treat those values as secrets.
+
+All requests use Flowise `secureAxiosRequest`, so the configured API base URL remains subject to Flowise HTTP security and SSRF protections.
+
+## Testing
+
+The Jest tests mock every external API request. They do not require a Jungle Grid API key and do not submit live or billable workloads.

--- a/packages/components/nodes/tools/JungleGrid/README.md
+++ b/packages/components/nodes/tools/JungleGrid/README.md
@@ -1,0 +1,75 @@
+# Jungle Grid
+
+The Jungle Grid tool node lets Flowise agents estimate, submit, monitor, cancel, and retrieve artifacts for asynchronous Jungle Grid workloads.
+
+Jungle Grid acts as the durable execution layer for long-running AI workloads while Flowise remains the orchestration and visual agent-building layer.
+
+## Credentials
+
+Create a `Jungle Grid API` credential with:
+
+-   `Jungle Grid API Key`: a Jungle Grid API key.
+-   `Jungle Grid API Base URL`: defaults to `https://api.junglegrid.dev`. Override only for development or self-hosted orchestrators.
+
+Do not place Jungle Grid API keys in prompts, command arguments, environment variables, source code, exported flows, or logs.
+
+## Actions
+
+-   `Estimate Job`: calls `POST /v1/jobs/estimate` before starting work. Use this when cost, capacity, routing, or GPU tier matters.
+-   `Submit Job`: calls `POST /v1/jobs` and returns immediately with a `job_id`. A returned `job_id` does not mean the job is complete.
+-   `List Jobs`: calls `GET /v1/jobs` with verified `limit` and `status` filters.
+-   `Get Job`: calls `GET /v1/jobs/{job_id}` to retrieve current status and details.
+-   `Get Job Runtime`: calls `GET /v1/jobs/{job_id}/runtime` for stdout/stderr tails, exit information, diagnostics, and runtime availability.
+-   `Cancel Job`: calls `POST /v1/jobs/{job_id}/cancel` with an optional reason.
+-   `Get Job Logs`: uses the verified runtime endpoint to return available stdout/stderr and exit information.
+-   `List Job Artifacts`: calls `GET /v1/jobs/{job_id}/artifacts`.
+-   `Get Artifact Download URL`: calls `POST /v1/jobs/{job_id}/artifacts/{artifact_id}/download`.
+
+Live log streaming is intentionally not exposed as a Flowise tool action. The official stream route is long-lived Server-Sent Events, while Flowise agent tools execute synchronously. Polling `Get Job`, `Get Job Runtime`, and `Get Job Logs` is the production-safe Flowise path.
+
+## Usage Pattern
+
+```text
+Estimate Job
+  -> Submit Job
+  -> store job_id
+  -> Get Job / Get Job Runtime / Get Job Logs
+  -> wait for terminal status
+  -> List Job Artifacts
+  -> Get Artifact Download URL
+```
+
+`Submit Job` is asynchronous. It returns a `job_id` immediately, but that does not mean the workload has completed. Poll `Get Job`, `Get Job Runtime`, or `Get Job Logs` until Jungle Grid reports a terminal status. Retrieve artifacts after successful completion unless the API response explicitly shows partial outputs are available.
+
+## Example Workloads
+
+Minimal inference smoke-test shape:
+
+```json
+{
+    "name": "flowise-jungle-grid-smoke-test",
+    "image": "python:3.11",
+    "workload_type": "inference",
+    "model_size_gb": 1,
+    "command": "python",
+    "args": ["-c", "print(42)"]
+}
+```
+
+Artifact-producing shape:
+
+```json
+{
+    "name": "flowise-jungle-grid-artifact-test",
+    "image": "python:3.11",
+    "workload_type": "batch",
+    "model_size_gb": 1,
+    "command": "python",
+    "args": [
+        "-c",
+        "import json, os; os.makedirs('/workspace/artifacts', exist_ok=True); json.dump({'status':'ok'}, open('/workspace/artifacts/output.json','w'))"
+    ]
+}
+```
+
+Common use cases include running inference workloads, batch jobs, evaluation workloads, artifact-producing container jobs, and agent-monitored long-running compute work.

--- a/packages/components/nodes/tools/JungleGrid/README.md
+++ b/packages/components/nodes/tools/JungleGrid/README.md
@@ -1,66 +1,96 @@
 # Jungle Grid
 
-The Jungle Grid tool node lets Flowise agents estimate, submit, monitor, cancel, and retrieve artifacts for asynchronous Jungle Grid workloads.
+The Jungle Grid tool node lets Flowise agents estimate, submit, monitor, cancel, and retrieve outputs for asynchronous Jungle Grid workloads.
 
-Jungle Grid acts as the durable execution layer for long-running AI workloads while Flowise remains the orchestration and visual agent-building layer.
+Jungle Grid is live production infrastructure. Submitting jobs may start managed compute and spend credits. Estimate first whenever a user needs cost, capacity, or routing information before execution.
+
+## Links
+
+-   Website: https://junglegrid.dev
+-   Docs: https://junglegrid.dev/docs
+-   API docs: https://junglegrid.dev/docs/api
+-   MCP docs: https://junglegrid.dev/docs/mcp
+-   MCP server: https://github.com/Jungle-Grid/mcp-server
+-   Discord: https://discord.com/invite/kpJqxXFFCs
 
 ## Credentials
 
-Create a `Jungle Grid API` credential with:
+Create a `Jungle Grid API` credential in Flowise:
 
--   `Jungle Grid API Key`: a Jungle Grid API key.
--   `Jungle Grid API Base URL`: defaults to `https://api.junglegrid.dev`. Override only for development or self-hosted orchestrators.
+-   `Jungle Grid API Key`: a scoped Jungle Grid API key from the Jungle Grid portal.
+-   `Jungle Grid API Base URL`: defaults to `https://api.junglegrid.dev`. Override only for staging, local development, or private deployments.
 
-Do not place Jungle Grid API keys in prompts, command arguments, environment variables, source code, exported flows, or logs.
+Keep the API key in Flowise credentials or a server-side environment variable used to create that credential. Do not place Jungle Grid API keys in prompts, command arguments, exported flows, source code, logs, browser code, or public repositories.
+
+Recommended API key scopes:
+
+-   `jobs:estimate` for estimates.
+-   `jobs:submit` or `jobs:write` for submit and cancel.
+-   `jobs:read` for list, status, runtime, logs, and artifacts.
+-   `logs:read` for stored job logs.
 
 ## Actions
 
--   `Estimate Job`: calls `POST /v1/jobs/estimate` before starting work. Use this when cost, capacity, routing, or GPU tier matters.
--   `Submit Job`: calls `POST /v1/jobs` and returns immediately with a `job_id`. A returned `job_id` does not mean the job is complete.
--   `List Jobs`: calls `GET /v1/jobs` with verified `limit` and `status` filters.
--   `Get Job`: calls `GET /v1/jobs/{job_id}` to retrieve current status and details.
--   `Get Job Runtime`: calls `GET /v1/jobs/{job_id}/runtime` for stdout/stderr tails, exit information, diagnostics, and runtime availability.
--   `Cancel Job`: calls `POST /v1/jobs/{job_id}/cancel` with an optional reason.
--   `Get Job Logs`: uses the verified runtime endpoint to return available stdout/stderr and exit information.
--   `List Job Artifacts`: calls `GET /v1/jobs/{job_id}/artifacts`.
--   `Get Artifact Download URL`: calls `POST /v1/jobs/{job_id}/artifacts/{artifact_id}/download`.
+-   `Estimate Job`: calls `POST /v1/jobs/estimate`. This is read-only and does not start compute.
+-   `Submit Job`: calls `POST /v1/jobs`. This starts asynchronous remote work and can spend credits.
+-   `List Jobs`: calls `GET /v1/jobs` with `limit`, `cursor`, and `status` filters.
+-   `Get Job`: calls `GET /v1/jobs/{job_id}` for status and job details.
+-   `Get Job Runtime`: calls `GET /v1/jobs/{job_id}/runtime` for runtime tails, exit code, timeout, and diagnostics where available.
+-   `Get Job Logs`: calls `GET /v1/jobs/{job_id}/logs` with `tail`, `limit`, `cursor`, and `stream` filters.
+-   `Cancel Job`: calls `POST /v1/jobs/{job_id}/cancel`. Use only for non-terminal jobs.
+-   `List Artifacts`: calls `GET /v1/jobs/{job_id}/artifacts`.
+-   `Get Artifact`: calls `POST /v1/jobs/{job_id}/artifacts/{artifact_id}/download` to create temporary download information.
 
-Live log streaming is intentionally not exposed as a Flowise tool action. The official stream route is long-lived Server-Sent Events, while Flowise agent tools execute synchronously. Polling `Get Job`, `Get Job Runtime`, and `Get Job Logs` is the production-safe Flowise path.
+Live log streaming uses `GET /v1/jobs/{job_id}/logs/live` as Server-Sent Events. Flowise tools execute synchronously, so this integration exposes polling through `Get Job` and `Get Job Logs` instead of holding a long-lived stream.
 
 ## Usage Pattern
 
 ```text
 Estimate Job
-  -> Submit Job
+  -> review estimate/capacity/cost fields
+  -> Submit Job after user approval
   -> store job_id
   -> Get Job / Get Job Runtime / Get Job Logs
-  -> wait for terminal status
-  -> List Job Artifacts
-  -> Get Artifact Download URL
+  -> wait for completed, failed, rejected, or cancelled
+  -> List Artifacts
+  -> Get Artifact
 ```
 
-`Submit Job` is asynchronous. It returns a `job_id` immediately, but that does not mean the workload has completed. Poll `Get Job`, `Get Job Runtime`, or `Get Job Logs` until Jungle Grid reports a terminal status. Retrieve artifacts after successful completion unless the API response explicitly shows partial outputs are available.
+`Submit Job` returns a `job_id` immediately. It does not wait for completion. Poll until Jungle Grid reports a terminal status before assuming outputs are final.
 
 ## Example Workloads
 
-Minimal inference smoke-test shape:
+Inference estimate:
 
 ```json
 {
-    "name": "flowise-jungle-grid-smoke-test",
+    "name": "flowise-inference-estimate",
     "image": "python:3.11",
     "workload_type": "inference",
     "model_size_gb": 1,
+    "optimize_for": "balanced"
+}
+```
+
+Low-cost batch submit:
+
+```json
+{
+    "name": "flowise-batch-smoke",
+    "image": "python:3.11",
+    "workload_type": "batch",
+    "model_size_gb": 1,
+    "optimize_for": "cost",
     "command": "python",
     "args": ["-c", "print(42)"]
 }
 ```
 
-Artifact-producing shape:
+Agent-triggered artifact job:
 
 ```json
 {
-    "name": "flowise-jungle-grid-artifact-test",
+    "name": "flowise-artifact-job",
     "image": "python:3.11",
     "workload_type": "batch",
     "model_size_gb": 1,
@@ -72,4 +102,37 @@ Artifact-producing shape:
 }
 ```
 
-Common use cases include running inference workloads, batch jobs, evaluation workloads, artifact-producing container jobs, and agent-monitored long-running compute work.
+Job monitoring:
+
+```json
+{
+    "job_id": "job_..."
+}
+```
+
+Logs retrieval:
+
+```json
+{
+    "job_id": "job_...",
+    "tail": 100,
+    "stream": "all"
+}
+```
+
+Artifact retrieval:
+
+```json
+{
+    "job_id": "job_...",
+    "artifact_id": "art_..."
+}
+```
+
+## Field Notes
+
+-   `workload_type` supports `inference`, `training`, `fine_tuning` / `fine-tuning`, and `batch`. The integration sends `fine-tuning` to the REST API.
+-   `routing_mode` is accepted as an agent-friendly alias for `optimize_for`.
+-   `env` is accepted as an alias for `environment`; values must be strings.
+-   `callback_url`, `callback_auth_token`, and `callback_metadata` follow the documented per-job callback fields. Treat callback tokens as secrets.
+-   Managed jobs can upload regular files written under `/workspace/artifacts`. Direct input file upload is not part of the documented public job-submit contract; pass file references through your image, command, environment, or storage system where appropriate.

--- a/packages/components/nodes/tools/JungleGrid/core.test.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.test.ts
@@ -1,0 +1,69 @@
+import { JungleGridClient, createJungleGridTools } from './core'
+import { secureAxiosRequest } from '../../../src/httpSecurity'
+
+jest.mock('../../../src/httpSecurity', () => ({
+    secureAxiosRequest: jest.fn()
+}))
+
+const mockedSecureAxiosRequest = secureAxiosRequest as jest.MockedFunction<typeof secureAxiosRequest>
+
+describe('JungleGridClient', () => {
+    beforeEach(() => {
+        mockedSecureAxiosRequest.mockReset()
+        mockedSecureAxiosRequest.mockResolvedValue({
+            status: 200,
+            data: { ok: true }
+        } as any)
+    })
+
+    it('uses bearer authentication and the documented estimate route', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key', baseUrl: 'https://api.junglegrid.dev/' })
+
+        await client.estimateJob({ workload_type: 'inference', image: 'python:3.11' })
+
+        expect(mockedSecureAxiosRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: 'https://api.junglegrid.dev/v1/jobs/estimate',
+                method: 'POST',
+                headers: expect.objectContaining({
+                    Authorization: 'Bearer test-key',
+                    'Content-Type': 'application/json'
+                })
+            })
+        )
+    })
+
+    it('uses verified production routes for lifecycle and artifact operations', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+
+        await client.submitJob({ workload_type: 'batch', image: 'python:3.11', command: 'python', args: ['-c', 'print(42)'] })
+        await client.listJobs({ limit: 20, status: 'running' })
+        await client.getJob('job_123')
+        await client.getJobRuntime('job_123')
+        await client.cancelJob('job_123', 'test')
+        await client.listJobArtifacts('job_123')
+        await client.getArtifactDownloadUrl('job_123', 'artifact_123')
+
+        const urls = mockedSecureAxiosRequest.mock.calls.map(([config]) => config.url)
+        expect(urls).toEqual([
+            'https://api.junglegrid.dev/v1/jobs',
+            'https://api.junglegrid.dev/v1/jobs?limit=20&status=running',
+            'https://api.junglegrid.dev/v1/jobs/job_123',
+            'https://api.junglegrid.dev/v1/jobs/job_123/runtime',
+            'https://api.junglegrid.dev/v1/jobs/job_123/cancel',
+            'https://api.junglegrid.dev/v1/jobs/job_123/artifacts',
+            'https://api.junglegrid.dev/v1/jobs/job_123/artifacts/artifact_123/download'
+        ])
+    })
+})
+
+describe('createJungleGridTools', () => {
+    it('creates agent-facing tools with async job guidance', () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const tools = createJungleGridTools(client, ['estimateJob', 'submitJob', 'getJob'])
+
+        expect(tools.map((tool) => tool.name)).toEqual(['jungle_grid_estimate_job', 'jungle_grid_submit_job', 'jungle_grid_get_job'])
+        expect(tools[1].description).toContain('returns a job_id immediately')
+        expect(tools[1].description).toContain('does not mean the job has finished')
+    })
+})

--- a/packages/components/nodes/tools/JungleGrid/core.test.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.test.ts
@@ -1,4 +1,11 @@
-import { JungleGridClient, createJungleGridTools } from './core'
+import {
+    JungleGridClient,
+    createJungleGridTools,
+    normalizeJobStatusResponse,
+    redactErrorMessage,
+    redactSensitiveParams,
+    removeUndefined
+} from './core'
 import { secureAxiosRequest } from '../../../src/httpSecurity'
 
 jest.mock('../../../src/httpSecurity', () => ({
@@ -7,177 +14,373 @@ jest.mock('../../../src/httpSecurity', () => ({
 
 const mockedSecureAxiosRequest = secureAxiosRequest as jest.MockedFunction<typeof secureAxiosRequest>
 
+function mockResponse(data: unknown = { ok: true, data: { accepted: true } }, status = 200): void {
+    mockedSecureAxiosRequest.mockResolvedValue({ status, data } as any)
+}
+
+function requestConfig(call = 0): any {
+    return mockedSecureAxiosRequest.mock.calls[call][0]
+}
+
 describe('JungleGridClient', () => {
     beforeEach(() => {
         mockedSecureAxiosRequest.mockReset()
-        mockedSecureAxiosRequest.mockResolvedValue({
-            status: 200,
-            data: { ok: true }
-        } as any)
+        mockResponse()
     })
 
-    it('uses bearer authentication and the documented estimate route', async () => {
-        const client = new JungleGridClient({ apiKey: 'test-key', baseUrl: 'https://api.junglegrid.dev/' })
+    it('normalizes the configured base URL and applies bearer authentication', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key', baseUrl: 'https://api.example.test///' })
 
-        await client.estimateJob({ workload_type: 'inference', image: 'python:3.11' })
+        await client.estimateJob({ workload_type: 'inference' })
 
-        expect(mockedSecureAxiosRequest).toHaveBeenCalledWith(
+        expect(requestConfig()).toEqual(
             expect.objectContaining({
-                url: 'https://api.junglegrid.dev/v1/jobs/estimate',
+                url: 'https://api.example.test/v1/mcp/jobs/estimate',
                 method: 'POST',
                 timeout: 30000,
                 headers: expect.objectContaining({
                     Authorization: 'Bearer test-key',
                     'Content-Type': 'application/json'
-                }),
-                data: {
-                    workload_type: 'inference',
-                    image: 'python:3.11'
-                }
+                })
             })
         )
     })
 
-    it('normalizes agent-friendly aliases before submit', async () => {
+    it('rejects invalid base URLs and missing API keys', () => {
+        expect(() => new JungleGridClient({ apiKey: '', baseUrl: 'https://api.example.test' })).toThrow('Jungle Grid API key is required')
+        expect(() => new JungleGridClient({ apiKey: 'key', baseUrl: 'file:///tmp/api' })).toThrow('valid HTTP or HTTPS URL')
+        expect(() => new JungleGridClient({ apiKey: 'key', baseUrl: 'https://user:pass@example.test' })).toThrow(
+            'without embedded credentials'
+        )
+    })
+
+    it('uses the estimate route without submitting a job', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+
+        await client.estimateJob({
+            workload_type: 'batch',
+            image: 'python:3.11',
+            model_size: 2,
+            routing_mode: 'cost',
+            notes: 'screen only'
+        })
+
+        expect(requestConfig().url).toBe('https://api.junglegrid.dev/v1/mcp/jobs/estimate')
+        expect(requestConfig().data).toEqual({
+            workload_type: 'batch',
+            image: 'python:3.11',
+            model_size_gb: 2,
+            optimize_for: 'cost',
+            notes: 'screen only'
+        })
+        expect(mockedSecureAxiosRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes command arrays and current submission fields unchanged', async () => {
         const client = new JungleGridClient({ apiKey: 'test-key' })
 
         await client.submitJob({
-            name: 'flowise-job',
-            workload_type: 'fine_tuning',
+            name: 'audio-transcription',
+            workload_type: 'inference',
             image: 'python:3.11-slim',
-            routing_mode: 'cost',
-            command: 'python',
-            args: ['-c', 'print(42)'],
-            env: { CODE: 'print(42)', SHARED: 'env-value' },
-            environment: { SHARED: 'environment-value' }
+            command: ['python', '/workspace/scripts/transcribe.py', '/workspace/inputs/audio.ogg'],
+            input_files: [{ input_id: 'inp_audio' }],
+            script_files: [{ input_id: 'inp_script' }],
+            expected_artifacts: ['/workspace/artifacts/transcript.txt'],
+            metadata: { source: 'flowise' }
         })
 
-        expect(mockedSecureAxiosRequest).toHaveBeenCalledWith(
+        expect(requestConfig()).toEqual(
             expect.objectContaining({
-                url: 'https://api.junglegrid.dev/v1/jobs',
+                url: 'https://api.junglegrid.dev/v1/mcp/jobs',
+                method: 'POST',
                 data: {
-                    name: 'flowise-job',
-                    workload_type: 'fine-tuning',
+                    name: 'audio-transcription',
+                    workload_type: 'inference',
                     image: 'python:3.11-slim',
-                    optimize_for: 'cost',
-                    command: 'python',
-                    args: ['-c', 'print(42)'],
-                    environment: {
-                        CODE: 'print(42)',
-                        SHARED: 'environment-value'
-                    }
+                    command: ['python', '/workspace/scripts/transcribe.py', '/workspace/inputs/audio.ogg'],
+                    input_files: [{ input_id: 'inp_audio' }],
+                    script_files: [{ input_id: 'inp_script' }],
+                    expected_artifacts: ['/workspace/artifacts/transcript.txt'],
+                    metadata: { source: 'flowise' }
                 }
             })
         )
     })
 
-    it('uses documented production routes for lifecycle, logs, and artifacts', async () => {
+    it('preserves legacy command plus args and normalizes aliases', async () => {
         const client = new JungleGridClient({ apiKey: 'test-key' })
 
-        await client.listJobs({ limit: 20, cursor: 42, status: 'running' })
-        await client.getJob('job_123')
-        await client.getJobRuntime('job_123')
-        await client.getJobLogs('job_123', { tail: 100, cursor: 42, stream: 'stdout' })
-        await client.cancelJob('job_123', 'test')
-        await client.listJobArtifacts('job_123')
-        await client.getArtifactDownloadUrl('job_123', 'artifact_123')
+        await client.submitJob({
+            name: 'legacy-job',
+            workload_type: 'fine_tuning',
+            image: 'python:3.11',
+            command: 'python',
+            args: ['-c', 'print(42)'],
+            routing_mode: 'cost',
+            env: { CODE: 'print(42)', SHARED: 'env-value' },
+            environment: { SHARED: 'environment-value' },
+            input_files: ['inp_audio'],
+            script_files: ['inp_script']
+        })
 
-        const urls = mockedSecureAxiosRequest.mock.calls.map(([config]) => config.url)
-        expect(urls).toEqual([
-            'https://api.junglegrid.dev/v1/jobs?limit=20&cursor=42&status=running',
-            'https://api.junglegrid.dev/v1/jobs/job_123',
-            'https://api.junglegrid.dev/v1/jobs/job_123/runtime',
-            'https://api.junglegrid.dev/v1/jobs/job_123/logs?tail=100&cursor=42&stream=stdout',
-            'https://api.junglegrid.dev/v1/jobs/job_123/cancel',
-            'https://api.junglegrid.dev/v1/jobs/job_123/artifacts',
-            'https://api.junglegrid.dev/v1/jobs/job_123/artifacts/artifact_123/download'
-        ])
+        expect(requestConfig().data).toEqual({
+            name: 'legacy-job',
+            workload_type: 'fine-tuning',
+            image: 'python:3.11',
+            command: 'python',
+            args: ['-c', 'print(42)'],
+            optimize_for: 'cost',
+            environment: {
+                CODE: 'print(42)',
+                SHARED: 'environment-value'
+            },
+            input_files: [{ input_id: 'inp_audio' }],
+            script_files: [{ input_id: 'inp_script' }]
+        })
     })
 
-    it('formats API errors with Jungle Grid code and message', async () => {
-        mockedSecureAxiosRequest.mockResolvedValueOnce({
-            status: 403,
-            data: {
-                error: {
-                    code: 'FORBIDDEN',
-                    message: 'The token is not authorized for this Jungle Grid action.'
-                }
-            }
-        } as any)
+    it('uses verified routes for inputs, events, runtime, logs, cancellation, and artifacts', async () => {
         const client = new JungleGridClient({ apiKey: 'test-key' })
 
-        await expect(client.getJob('job_123')).rejects.toThrow(
-            'GET /v1/jobs/job_123 failed with status 403: FORBIDDEN: The token is not authorized for this Jungle Grid action.'
-        )
+        await client.uploadJobInput({ filename: 'audio.wav', content_type: 'audio/wav', kind: 'input' })
+        await client.listJobInputs()
+        await client.listJobs({ limit: 20, cursor: 'next cursor', status: 'starting' })
+        await client.getJob('job/123')
+        await client.getJobEvents('job/123')
+        await client.getJobRuntime('job/123')
+        await client.getJobLogs('job/123', { limit: 100, cursor: 42, tail: 50, stream: 'stdout' })
+        await client.cancelJob('job/123', 'user requested')
+        await client.listJobArtifacts('job/123')
+        await client.getArtifactDownloadUrl('job/123', 'artifact/123')
+
+        expect(mockedSecureAxiosRequest.mock.calls.map(([config]) => config.url)).toEqual([
+            'https://api.junglegrid.dev/v1/job-inputs',
+            'https://api.junglegrid.dev/v1/job-inputs',
+            'https://api.junglegrid.dev/v1/mcp/jobs?limit=20&cursor=next+cursor&status=starting',
+            'https://api.junglegrid.dev/v1/mcp/jobs/job%2F123',
+            'https://api.junglegrid.dev/v1/jobs/job%2F123/events',
+            'https://api.junglegrid.dev/v1/jobs/job%2F123/runtime',
+            'https://api.junglegrid.dev/v1/mcp/jobs/job%2F123/logs?limit=100&cursor=42&tail=50&stream=stdout',
+            'https://api.junglegrid.dev/v1/mcp/jobs/job%2F123/cancel',
+            'https://api.junglegrid.dev/v1/mcp/jobs/job%2F123/artifacts',
+            'https://api.junglegrid.dev/v1/mcp/jobs/job%2F123/artifacts/artifact%2F123/download'
+        ])
+        expect(requestConfig(0).data).toEqual({ filename: 'audio.wav', content_type: 'audio/wav', kind: 'input' })
+        expect(requestConfig(7).data).toEqual({ reason: 'user requested' })
+    })
+
+    it('does not send undefined optional fields', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+
+        await client.uploadJobInput({ filename: 'script.py', content_type: undefined, kind: 'script' })
+
+        expect(requestConfig().data).toEqual({ filename: 'script.py', kind: 'script' })
+    })
+
+    it('unwraps MCP response envelopes without discarding useful fields', async () => {
+        mockResponse({
+            ok: true,
+            data: {
+                routing: { route_status: 'available' },
+                capacity: { live_capacity_available: true },
+                can_submit: true
+            }
+        })
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+
+        await expect(client.estimateJob({ workload_type: 'training' })).resolves.toEqual({
+            routing: { route_status: 'available' },
+            capacity: { live_capacity_available: true },
+            can_submit: true
+        })
+    })
+
+    it('returns a safe unavailable result when runtime data is not ready', async () => {
+        mockResponse({ error: { code: 'NOT_FOUND', message: 'job runtime not available yet' } }, 404)
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+
+        await expect(client.getJobRuntime('job_123')).resolves.toEqual({
+            job_id: 'job_123',
+            runtime_available: false,
+            message: 'Job runtime information is not available yet.'
+        })
+    })
+
+    it('handles non-JSON API errors and rate limits safely', async () => {
+        mockResponse('<html>upstream unavailable</html>', 503)
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+
+        await expect(client.getJob('job_123')).rejects.toThrow('<html>upstream unavailable</html>')
+
+        mockResponse(undefined, 429)
+        await expect(client.getJob('job_123')).rejects.toThrow('RATE_LIMITED')
+    })
+
+    it('handles timeouts without exposing API keys or Axios configuration', async () => {
+        mockedSecureAxiosRequest.mockRejectedValue(new Error('timeout of 30000ms exceeded Authorization: Bearer jg_live_secret_fixture'))
+        const client = new JungleGridClient({ apiKey: 'jg_live_secret_fixture' })
+
+        const [tool] = createJungleGridTools(client, ['getJob'])
+        const result = await (tool as any)._call({ job_id: 'job_123' })
+
+        expect(result).toContain('request timed out')
+        expect(result).not.toContain('jg_live_secret_fixture')
+        expect(result).not.toContain('Authorization')
     })
 })
 
-describe('createJungleGridTools', () => {
+describe('Jungle Grid tools', () => {
     beforeEach(() => {
         mockedSecureAxiosRequest.mockReset()
-        mockedSecureAxiosRequest.mockResolvedValue({
-            status: 200,
-            data: { ok: true }
-        } as any)
+        mockResponse()
     })
 
-    it('creates agent-facing tools with async job guidance and current artifact names', () => {
+    it('creates every selected action and does not expose unselected actions', () => {
         const client = new JungleGridClient({ apiKey: 'test-key' })
-        const tools = createJungleGridTools(client, ['estimateJob', 'submitJob', 'getJobLogs', 'listArtifacts', 'getArtifact'])
+        const actions = [
+            'estimateJob',
+            'submitJob',
+            'uploadJobInput',
+            'listJobInputs',
+            'listJobs',
+            'getJob',
+            'getJobEvents',
+            'getJobRuntime',
+            'getJobLogs',
+            'cancelJob',
+            'listArtifacts',
+            'getArtifact'
+        ] as const
 
-        expect(tools.map((tool) => tool.name)).toEqual([
+        expect(createJungleGridTools(client, [...actions]).map((tool) => tool.name)).toEqual([
             'jungle_grid_estimate_job',
             'jungle_grid_submit_job',
+            'jungle_grid_upload_job_input',
+            'jungle_grid_list_job_inputs',
+            'jungle_grid_list_jobs',
+            'jungle_grid_get_job',
+            'jungle_grid_get_job_events',
+            'jungle_grid_get_job_runtime',
             'jungle_grid_get_job_logs',
+            'jungle_grid_cancel_job',
             'jungle_grid_list_artifacts',
             'jungle_grid_get_artifact'
         ])
-        expect(tools[1].description).toContain('returns a job_id immediately')
-        expect(tools[1].description).toContain('does not mean the job has finished')
+        expect(createJungleGridTools(client, ['getJob']).map((tool) => tool.name)).toEqual(['jungle_grid_get_job'])
     })
 
-    it('validates missing required fields before submit', async () => {
+    it('validates workload types and required submission fields before requests', async () => {
         const client = new JungleGridClient({ apiKey: 'test-key' })
         const [submitTool] = createJungleGridTools(client, ['submitJob'])
 
-        const result = await (submitTool as any)._call({ workload_type: 'batch' })
+        const result = await (submitTool as any)._call({ workload_type: 'unsupported' })
 
         expect(result).toContain('jungle_grid_submit_job failed')
-        expect(result).toContain('name: Required')
-        expect(result).toContain('image: Required')
+        expect(result).toContain('Invalid enum value')
         expect(mockedSecureAxiosRequest).not.toHaveBeenCalled()
     })
 
-    it('runs estimate and submit flows through tool calls', async () => {
+    it('rejects empty command-array entries', async () => {
         const client = new JungleGridClient({ apiKey: 'test-key' })
-        const [estimateTool, submitTool] = createJungleGridTools(client, ['estimateJob', 'submitJob'])
+        const [submitTool] = createJungleGridTools(client, ['submitJob'])
 
-        await (estimateTool as any)._call({ workload_type: 'inference', image: 'python:3.11', model_size_gb: 1 })
-        await (submitTool as any)._call({
-            name: 'flowise-smoke',
+        const result = await (submitTool as any)._call({
+            name: 'bad-command',
             workload_type: 'batch',
             image: 'python:3.11',
-            command: 'python',
-            args: ['-c', 'print(42)']
+            command: ['python', ' ']
         })
 
-        expect(mockedSecureAxiosRequest).toHaveBeenNthCalledWith(
-            1,
-            expect.objectContaining({ url: expect.stringContaining('/v1/jobs/estimate') })
-        )
-        expect(mockedSecureAxiosRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({ url: expect.stringContaining('/v1/jobs') }))
+        expect(result).toContain('command.1: Must not be empty')
+        expect(mockedSecureAxiosRequest).not.toHaveBeenCalled()
     })
 
-    it('redacts callback tokens from tool errors and echoed params', async () => {
-        mockedSecureAxiosRequest.mockResolvedValueOnce({
-            status: 400,
-            data: {
+    it('rejects malformed environment values without echoing values', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const [submitTool] = createJungleGridTools(client, ['submitJob'])
+
+        const result = await (submitTool as any)._call({
+            name: 'bad-env',
+            workload_type: 'batch',
+            image: 'python:3.11',
+            env: { SECRET_VALUE: 42 }
+        })
+
+        expect(result).toContain('env.SECRET_VALUE')
+        expect(result).not.toContain('42')
+        expect(mockedSecureAxiosRequest).not.toHaveBeenCalled()
+    })
+
+    it('rejects malformed input references and expected artifacts', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const [submitTool] = createJungleGridTools(client, ['submitJob'])
+
+        const badInput = await (submitTool as any)._call({
+            name: 'bad-input',
+            workload_type: 'batch',
+            image: 'python:3.11',
+            input_files: [{ input_id: '' }]
+        })
+        const badArtifact = await (submitTool as any)._call({
+            name: 'bad-artifact',
+            workload_type: 'batch',
+            image: 'python:3.11',
+            expected_artifacts: ['']
+        })
+
+        expect(badInput).toContain('input_files.0.input_id')
+        expect(badArtifact).toContain('expected_artifacts.0')
+        expect(mockedSecureAxiosRequest).not.toHaveBeenCalled()
+    })
+
+    it('validates upload kind and creates only an upload slot', async () => {
+        mockResponse({
+            upload: {
+                input_id: 'inp_123',
+                filename: 'audio.wav',
+                method: 'PUT',
+                upload_url: 'https://signed.example/upload',
+                complete_url: 'https://api.junglegrid.dev/v1/job-inputs/inp_123/complete'
+            }
+        })
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const [uploadTool] = createJungleGridTools(client, ['uploadJobInput'])
+
+        const invalid = await (uploadTool as any)._call({ filename: 'audio.wav', kind: 'artifact' })
+        expect(invalid).toContain('Invalid enum value')
+        expect(mockedSecureAxiosRequest).not.toHaveBeenCalled()
+
+        const valid = await (uploadTool as any)._call({ filename: 'audio.wav', kind: 'input' })
+        expect(valid).toContain('"input_id":"inp_123"')
+        expect(uploadTool.description).toContain('does not upload file bytes')
+        expect(mockedSecureAxiosRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps events separate from logs', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const [eventsTool, logsTool] = createJungleGridTools(client, ['getJobEvents', 'getJobLogs'])
+
+        await (eventsTool as any)._call({ job_id: 'job_123' })
+        await (logsTool as any)._call({ job_id: 'job_123', limit: 50 })
+
+        expect(requestConfig(0).url).toBe('https://api.junglegrid.dev/v1/jobs/job_123/events')
+        expect(requestConfig(0).url).not.toContain('/logs')
+        expect(requestConfig(1).url).toBe('https://api.junglegrid.dev/v1/mcp/jobs/job_123/logs?limit=50')
+        expect(logsTool.description).toContain('may be empty')
+    })
+
+    it('redacts callback tokens, bearer tokens, and signed URLs from tool errors', async () => {
+        mockResponse(
+            {
                 error: {
                     code: 'INVALID_REQUEST',
-                    message: 'callback_auth_token "callback-secret-fixture" is invalid; Authorization: Bearer api-key-fixture'
+                    message:
+                        'callback_auth_token "callback-secret-fixture"; Bearer api-key-fixture; https://storage.test/file?X-Amz-Signature=signed-secret'
                 }
-            }
-        } as any)
+            },
+            400
+        )
         const client = new JungleGridClient({ apiKey: 'test-key' })
         const [submitTool] = createJungleGridTools(client, ['submitJob'])
 
@@ -189,10 +392,80 @@ describe('createJungleGridTools', () => {
         })
 
         expect(result).toContain('INVALID_REQUEST')
-        expect(result).toContain('Bearer [REDACTED]')
-        expect(result).toContain('"callback_auth_token":"[REDACTED]"')
+        expect(result).toContain('[REDACTED]')
         expect(result).not.toContain('super-secret-callback-token')
         expect(result).not.toContain('callback-secret-fixture')
         expect(result).not.toContain('api-key-fixture')
+        expect(result).not.toContain('signed-secret')
+    })
+})
+
+describe('Jungle Grid utilities', () => {
+    it('preserves arrays and non-plain objects while removing nested undefined values', () => {
+        const date = new Date('2026-06-11T00:00:00Z')
+        const value = {
+            keep: [1, undefined, { remove: undefined, keep: 'yes' }],
+            date,
+            remove: undefined
+        }
+
+        const result = removeUndefined(value)
+
+        expect(result).toEqual({ keep: [1, undefined, { keep: 'yes' }], date })
+        expect(result.date).toBe(date)
+    })
+
+    it('handles circular plain data without infinite recursion', () => {
+        const value: any = { name: 'root' }
+        value.self = value
+
+        const result = removeUndefined(value)
+
+        expect(result.self).toBe(result)
+    })
+
+    it('redacts nested secrets, secrets in arrays, URLs, and circular data', () => {
+        const value: any = {
+            nested: [{ api_key: 'secret-key' }, { authorization: 'Bearer abc' }],
+            upload_url: 'https://signed.example/upload',
+            public: 'visible'
+        }
+        value.self = value
+
+        expect(redactSensitiveParams(value)).toEqual({
+            nested: [{ api_key: '[REDACTED]' }, { authorization: '[REDACTED]' }],
+            upload_url: '[REDACTED]',
+            public: 'visible',
+            self: '[Circular]'
+        })
+    })
+
+    it('redacts bearer tokens and temporary signed URLs in strings', () => {
+        const message = 'Bearer abc.def-123 https://storage.test/file?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=secret'
+        const redacted = redactErrorMessage(message)
+
+        expect(redacted).toContain('Bearer [REDACTED]')
+        expect(redacted).toContain('[REDACTED_URL]')
+        expect(redacted).not.toContain('secret')
+    })
+
+    it('normalizes per-job billing without presenting lifetime totals as job cost', () => {
+        expect(
+            normalizeJobStatusResponse({
+                job_id: 'job_123',
+                delayed_start: true,
+                phase_started_at: '2026-06-11T10:00:00Z',
+                total_spent_usd: 900,
+                account_billing: { lifetime_total_spent_usd: 900 },
+                billing: { cost_usd: 1.25, total_spent_usd: 900 }
+            })
+        ).toEqual({
+            job_id: 'job_123',
+            delayed_start: true,
+            phase_started_at: '2026-06-11T10:00:00Z',
+            account_billing: { lifetime_total_spent_usd: 900 },
+            billing: { actual_cost_usd: 1.25 },
+            actual_cost_usd: 1.25
+        })
     })
 })

--- a/packages/components/nodes/tools/JungleGrid/core.test.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.test.ts
@@ -25,45 +25,174 @@ describe('JungleGridClient', () => {
             expect.objectContaining({
                 url: 'https://api.junglegrid.dev/v1/jobs/estimate',
                 method: 'POST',
+                timeout: 30000,
                 headers: expect.objectContaining({
                     Authorization: 'Bearer test-key',
                     'Content-Type': 'application/json'
-                })
+                }),
+                data: {
+                    workload_type: 'inference',
+                    image: 'python:3.11'
+                }
             })
         )
     })
 
-    it('uses verified production routes for lifecycle and artifact operations', async () => {
+    it('normalizes agent-friendly aliases before submit', async () => {
         const client = new JungleGridClient({ apiKey: 'test-key' })
 
-        await client.submitJob({ workload_type: 'batch', image: 'python:3.11', command: 'python', args: ['-c', 'print(42)'] })
-        await client.listJobs({ limit: 20, status: 'running' })
+        await client.submitJob({
+            name: 'flowise-job',
+            workload_type: 'fine_tuning',
+            image: 'python:3.11-slim',
+            routing_mode: 'cost',
+            command: 'python',
+            args: ['-c', 'print(42)'],
+            env: { CODE: 'print(42)', SHARED: 'env-value' },
+            environment: { SHARED: 'environment-value' }
+        })
+
+        expect(mockedSecureAxiosRequest).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: 'https://api.junglegrid.dev/v1/jobs',
+                data: {
+                    name: 'flowise-job',
+                    workload_type: 'fine-tuning',
+                    image: 'python:3.11-slim',
+                    optimize_for: 'cost',
+                    command: 'python',
+                    args: ['-c', 'print(42)'],
+                    environment: {
+                        CODE: 'print(42)',
+                        SHARED: 'environment-value'
+                    }
+                }
+            })
+        )
+    })
+
+    it('uses documented production routes for lifecycle, logs, and artifacts', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+
+        await client.listJobs({ limit: 20, cursor: 42, status: 'running' })
         await client.getJob('job_123')
         await client.getJobRuntime('job_123')
+        await client.getJobLogs('job_123', { tail: 100, cursor: 42, stream: 'stdout' })
         await client.cancelJob('job_123', 'test')
         await client.listJobArtifacts('job_123')
         await client.getArtifactDownloadUrl('job_123', 'artifact_123')
 
         const urls = mockedSecureAxiosRequest.mock.calls.map(([config]) => config.url)
         expect(urls).toEqual([
-            'https://api.junglegrid.dev/v1/jobs',
-            'https://api.junglegrid.dev/v1/jobs?limit=20&status=running',
+            'https://api.junglegrid.dev/v1/jobs?limit=20&cursor=42&status=running',
             'https://api.junglegrid.dev/v1/jobs/job_123',
             'https://api.junglegrid.dev/v1/jobs/job_123/runtime',
+            'https://api.junglegrid.dev/v1/jobs/job_123/logs?tail=100&cursor=42&stream=stdout',
             'https://api.junglegrid.dev/v1/jobs/job_123/cancel',
             'https://api.junglegrid.dev/v1/jobs/job_123/artifacts',
             'https://api.junglegrid.dev/v1/jobs/job_123/artifacts/artifact_123/download'
         ])
     })
+
+    it('formats API errors with Jungle Grid code and message', async () => {
+        mockedSecureAxiosRequest.mockResolvedValueOnce({
+            status: 403,
+            data: {
+                error: {
+                    code: 'FORBIDDEN',
+                    message: 'The token is not authorized for this Jungle Grid action.'
+                }
+            }
+        } as any)
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+
+        await expect(client.getJob('job_123')).rejects.toThrow(
+            'GET /v1/jobs/job_123 failed with status 403: FORBIDDEN: The token is not authorized for this Jungle Grid action.'
+        )
+    })
 })
 
 describe('createJungleGridTools', () => {
-    it('creates agent-facing tools with async job guidance', () => {
-        const client = new JungleGridClient({ apiKey: 'test-key' })
-        const tools = createJungleGridTools(client, ['estimateJob', 'submitJob', 'getJob'])
+    beforeEach(() => {
+        mockedSecureAxiosRequest.mockReset()
+        mockedSecureAxiosRequest.mockResolvedValue({
+            status: 200,
+            data: { ok: true }
+        } as any)
+    })
 
-        expect(tools.map((tool) => tool.name)).toEqual(['jungle_grid_estimate_job', 'jungle_grid_submit_job', 'jungle_grid_get_job'])
+    it('creates agent-facing tools with async job guidance and current artifact names', () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const tools = createJungleGridTools(client, ['estimateJob', 'submitJob', 'getJobLogs', 'listArtifacts', 'getArtifact'])
+
+        expect(tools.map((tool) => tool.name)).toEqual([
+            'jungle_grid_estimate_job',
+            'jungle_grid_submit_job',
+            'jungle_grid_get_job_logs',
+            'jungle_grid_list_artifacts',
+            'jungle_grid_get_artifact'
+        ])
         expect(tools[1].description).toContain('returns a job_id immediately')
         expect(tools[1].description).toContain('does not mean the job has finished')
+    })
+
+    it('validates missing required fields before submit', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const [submitTool] = createJungleGridTools(client, ['submitJob'])
+
+        const result = await (submitTool as any)._call({ workload_type: 'batch' })
+
+        expect(result).toContain('jungle_grid_submit_job failed')
+        expect(result).toContain('name: Required')
+        expect(result).toContain('image: Required')
+        expect(mockedSecureAxiosRequest).not.toHaveBeenCalled()
+    })
+
+    it('runs estimate and submit flows through tool calls', async () => {
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const [estimateTool, submitTool] = createJungleGridTools(client, ['estimateJob', 'submitJob'])
+
+        await (estimateTool as any)._call({ workload_type: 'inference', image: 'python:3.11', model_size_gb: 1 })
+        await (submitTool as any)._call({
+            name: 'flowise-smoke',
+            workload_type: 'batch',
+            image: 'python:3.11',
+            command: 'python',
+            args: ['-c', 'print(42)']
+        })
+
+        expect(mockedSecureAxiosRequest).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ url: expect.stringContaining('/v1/jobs/estimate') })
+        )
+        expect(mockedSecureAxiosRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({ url: expect.stringContaining('/v1/jobs') }))
+    })
+
+    it('redacts callback tokens from tool errors and echoed params', async () => {
+        mockedSecureAxiosRequest.mockResolvedValueOnce({
+            status: 400,
+            data: {
+                error: {
+                    code: 'INVALID_REQUEST',
+                    message: 'callback_auth_token "callback-secret-fixture" is invalid; Authorization: Bearer api-key-fixture'
+                }
+            }
+        } as any)
+        const client = new JungleGridClient({ apiKey: 'test-key' })
+        const [submitTool] = createJungleGridTools(client, ['submitJob'])
+
+        const result = await (submitTool as any)._call({
+            name: 'flowise-smoke',
+            workload_type: 'batch',
+            image: 'python:3.11',
+            callback_auth_token: 'super-secret-callback-token'
+        })
+
+        expect(result).toContain('INVALID_REQUEST')
+        expect(result).toContain('Bearer [REDACTED]')
+        expect(result).toContain('"callback_auth_token":"[REDACTED]"')
+        expect(result).not.toContain('super-secret-callback-token')
+        expect(result).not.toContain('callback-secret-fixture')
+        expect(result).not.toContain('api-key-fixture')
     })
 })

--- a/packages/components/nodes/tools/JungleGrid/core.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.ts
@@ -10,12 +10,13 @@ const jsonHeaders = {
     Accept: 'application/json'
 }
 
-const workloadTypeSchema = z.enum(['inference', 'training', 'fine-tuning', 'batch'])
+const workloadTypeSchema = z.enum(['inference', 'training', 'fine_tuning', 'fine-tuning', 'batch'])
 const optimizeForSchema = z.enum(['balanced', 'cost', 'speed'])
 const prioritySchema = z.enum(['low', 'balanced', 'high'])
 const gpuClassSchema = z.enum(['consumer', 'datacenter'])
 const regionModeSchema = z.enum(['prefer', 'strict'])
 const jobStatusSchema = z.enum(['pending', 'queued', 'assigned', 'running', 'completed', 'failed', 'rejected', 'cancelled'])
+const cursorSchema = z.union([z.string(), z.number()])
 
 const constraintsSchema = z
     .object({
@@ -33,29 +34,34 @@ const constraintsSchema = z
 
 const estimateJobSchema = z.object({
     name: z.string().optional().describe('Optional readable job name for the draft workload.'),
-    workload_type: workloadTypeSchema.describe('Type of workload to estimate.'),
+    workload_type: workloadTypeSchema.describe("Type of workload to estimate. Use 'fine_tuning' or 'fine-tuning' for fine-tuning."),
     image: z.string().min(1).describe('Docker image to run.'),
     command: z.string().optional().describe('Optional container command to include in the estimate draft, for example python.'),
     args: z.array(z.string()).optional().describe('Optional arguments passed to the command.'),
     model_size_gb: z.number().optional().describe('Approximate model size in GB.'),
     disk_gb: z.number().optional().describe('Optional managed-provider local disk override in GB.'),
     optimize_for: optimizeForSchema.optional().describe("Scheduling optimization goal: 'balanced', 'cost', or 'speed'."),
+    routing_mode: optimizeForSchema.optional().describe('Agent-friendly alias for optimize_for. If both are set, they must match.'),
+    template: z.string().optional().describe('Optional Jungle Grid template identifier when submitting a template-backed workload.'),
+    notes: z.string().optional().describe('Optional execution intent notes for the estimator when supported by the API.'),
     latency_priority: prioritySchema.optional().describe("Latency sensitivity: 'low', 'balanced', or 'high'."),
     cost_priority: prioritySchema.optional().describe("Cost sensitivity: 'low', 'balanced', or 'high'."),
     constraints: constraintsSchema.describe('Optional routing constraints.')
 })
 
 const submitJobSchema = estimateJobSchema.extend({
-    command: z.string().min(1).describe('Container command to run, for example python. Submit Job starts asynchronous remote work.'),
+    name: z.string().min(1).describe('Readable job name. Submit Job starts asynchronous remote work and may spend credits.'),
+    command: z.string().optional().describe('Container command to run, for example python. Omit to use the image entrypoint or CMD.'),
     environment: z
         .record(z.string())
         .optional()
         .describe('Environment variables injected into the container. Do not include secrets unless the user explicitly approves.'),
+    env: z.record(z.string()).optional().describe('Agent-friendly alias for environment. If both are set, keys from environment are used.'),
     huggingface_credential_id: z.string().optional().describe('Optional saved Hugging Face credential id.'),
-    webhook_url: z.string().optional().describe('Optional HTTPS URL to receive signed lifecycle event callbacks.'),
     callback_url: z.string().optional().describe('Optional documented callback URL for lifecycle events.'),
     callback_auth_token: z.string().optional().describe('Optional callback authentication token. Never use this for unrelated secrets.'),
-    callback_metadata: z.record(z.any()).optional().describe('Optional metadata included with callbacks.')
+    callback_metadata: z.record(z.any()).optional().describe('Optional metadata included with callbacks.'),
+    metadata: z.record(z.any()).optional().describe('Optional workload metadata when supported by the API.')
 })
 
 const jobIdSchema = z.object({
@@ -65,10 +71,20 @@ const jobIdSchema = z.object({
 const listJobsSchema = z.object({
     limit: z
         .number()
+        .min(1)
+        .max(100)
         .optional()
         .default(20)
-        .describe('Maximum number of jobs to return. The official MCP package defaults to 20 and documents max 100.'),
+        .describe('Maximum number of jobs to return. Jungle Grid documents a maximum of 100.'),
+    cursor: cursorSchema.optional().describe('Optional next_cursor from a previous list_jobs response.'),
     status: jobStatusSchema.optional().describe('Optional status filter.')
+})
+
+const getJobLogsSchema = jobIdSchema.extend({
+    tail: z.number().min(1).max(500).optional().describe('Return the most recent 1..500 log entries.'),
+    limit: z.number().min(1).max(500).optional().describe('Return up to this many log entries, 1..500.'),
+    cursor: cursorSchema.optional().describe('Optional next_cursor from a previous get_job_logs response.'),
+    stream: z.enum(['stdout', 'stderr', 'all']).optional().describe("Filter logs by stream. Defaults to the API's behavior.")
 })
 
 const cancelJobSchema = jobIdSchema.extend({
@@ -76,7 +92,7 @@ const cancelJobSchema = jobIdSchema.extend({
 })
 
 const artifactDownloadSchema = jobIdSchema.extend({
-    artifact_id: z.string().min(1).describe('Artifact ID returned by list_job_artifacts.')
+    artifact_id: z.string().min(1).describe('Artifact ID returned by list_artifacts.')
 })
 
 export interface JungleGridClientOptions {
@@ -95,16 +111,17 @@ export class JungleGridClient {
     }
 
     estimateJob(input: z.infer<typeof estimateJobSchema>): Promise<any> {
-        return this.request('POST', '/v1/jobs/estimate', input)
+        return this.request('POST', '/v1/jobs/estimate', normalizeJobPayload(input))
     }
 
     submitJob(input: z.infer<typeof submitJobSchema>): Promise<any> {
-        return this.request('POST', '/v1/jobs', input)
+        return this.request('POST', '/v1/jobs', normalizeJobPayload(input))
     }
 
     listJobs(input: z.infer<typeof listJobsSchema>): Promise<any> {
         const params = new URLSearchParams()
         if (input.limit !== undefined) params.set('limit', String(input.limit))
+        if (input.cursor !== undefined) params.set('cursor', String(input.cursor))
         if (input.status) params.set('status', input.status)
         const query = params.toString()
         return this.request('GET', query ? `/v1/jobs?${query}` : '/v1/jobs')
@@ -116,6 +133,16 @@ export class JungleGridClient {
 
     getJobRuntime(jobId: string): Promise<any> {
         return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/runtime`)
+    }
+
+    getJobLogs(jobId: string, input: Omit<z.infer<typeof getJobLogsSchema>, 'job_id'> = {}): Promise<any> {
+        const params = new URLSearchParams()
+        if (input.tail !== undefined) params.set('tail', String(input.tail))
+        if (input.limit !== undefined) params.set('limit', String(input.limit))
+        if (input.cursor !== undefined) params.set('cursor', String(input.cursor))
+        if (input.stream) params.set('stream', input.stream)
+        const query = params.toString()
+        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/logs${query ? `?${query}` : ''}`)
     }
 
     cancelJob(jobId: string, reason?: string): Promise<any> {
@@ -140,7 +167,8 @@ export class JungleGridClient {
                 Authorization: `Bearer ${this.apiKey}`,
                 ...jsonHeaders
             },
-            data: body !== undefined ? removeUndefined(body) : undefined
+            data: body !== undefined ? removeUndefined(body) : undefined,
+            timeout: 30000
         })
 
         if (response.status < 200 || response.status >= 300) {
@@ -162,8 +190,8 @@ export type JungleGridAction =
     | 'getJobRuntime'
     | 'cancelJob'
     | 'getJobLogs'
-    | 'listJobArtifacts'
-    | 'getArtifactDownloadUrl'
+    | 'listArtifacts'
+    | 'getArtifact'
 
 export function createJungleGridTools(client: JungleGridClient, actions: JungleGridAction[]): DynamicStructuredTool[] {
     const selectedActions = actions.length > 0 ? actions : (Object.keys(toolFactories) as JungleGridAction[])
@@ -172,6 +200,7 @@ export function createJungleGridTools(client: JungleGridClient, actions: JungleG
 
 class JungleGridTool extends DynamicStructuredTool {
     private readonly handler: (input: any) => Promise<string>
+    private readonly inputSchema: any
 
     constructor(args: { name: string; description: string; schema: any; handler: (input: any) => Promise<string> }) {
         super({
@@ -183,10 +212,16 @@ class JungleGridTool extends DynamicStructuredTool {
             headers: {}
         })
         this.handler = args.handler
+        this.inputSchema = args.schema
     }
 
     async _call(input: any): Promise<string> {
-        return this.handler(input)
+        try {
+            const parsedInput = this.inputSchema?.parse ? this.inputSchema.parse(input ?? {}) : input
+            return this.handler(parsedInput)
+        } catch (error) {
+            return formatToolError(`${this.name} failed: ${formatErrorMessage(error)}`, redactSensitiveParams(input))
+        }
     }
 }
 
@@ -195,7 +230,7 @@ const toolFactories: Record<JungleGridAction, (_client: JungleGridClient) => Dyn
         new JungleGridTool({
             name: 'jungle_grid_estimate_job',
             description:
-                'Estimate a Jungle Grid workload before submission when cost, capacity, routing, or GPU tier matters. Accepts the same verified draft workload fields as submit_job and returns the real production estimate response, including hourly rate/range, runtime, queue/start window, route/capacity, and constraint-relaxation fields when available. Use this before jungle_grid_submit_job if spending credits or capacity selection matters.',
+                'Estimate a Jungle Grid workload before submission. This is read-only and returns route, capacity, cost, queue wait, start window, warning, and screening fields when available. Use this before jungle_grid_submit_job whenever spending credits or capacity selection matters.',
             schema: estimateJobSchema,
             handler: async (input) => safeJsonToolCall('jungle_grid_estimate_job', input, () => client.estimateJob(input))
         }),
@@ -203,14 +238,14 @@ const toolFactories: Record<JungleGridAction, (_client: JungleGridClient) => Dyn
         new JungleGridTool({
             name: 'jungle_grid_submit_job',
             description:
-                'Submit an asynchronous Jungle Grid workload. This starts remote work and returns a job_id immediately; a returned job_id does not mean the job has finished. Poll jungle_grid_get_job and use jungle_grid_get_job_runtime or jungle_grid_get_job_logs until a terminal status is reached. Never put untrusted secrets in environment variables, command, or args without explicit user permission.',
+                'Submit an asynchronous Jungle Grid workload. This may start managed compute and spend credits. It returns a job_id immediately; a returned job_id does not mean the job has finished. Poll jungle_grid_get_job and jungle_grid_get_job_logs until a terminal status is reached. Never put untrusted secrets in environment variables, command, or args without explicit user permission.',
             schema: submitJobSchema,
             handler: async (input) => safeJsonToolCall('jungle_grid_submit_job', input, () => client.submitJob(input))
         }),
     listJobs: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_list_jobs',
-            description: 'List recent Jungle Grid jobs for the authenticated account. Use this to find job IDs and recent statuses.',
+            description: 'List recent Jungle Grid jobs for the authenticated account with limit, cursor, and optional status filtering.',
             schema: listJobsSchema,
             handler: async (input) => safeJsonToolCall('jungle_grid_list_jobs', input, () => client.listJobs(input))
         }),
@@ -242,28 +277,34 @@ const toolFactories: Record<JungleGridAction, (_client: JungleGridClient) => Dyn
         new JungleGridTool({
             name: 'jungle_grid_get_job_logs',
             description:
-                'Retrieve available stdout/stderr tails and exit information for a Jungle Grid job. The official MCP package verifies this as the same production runtime endpoint used by get_job_runtime. Use it after submit_job while polling or after terminal status for diagnostics.',
-            schema: jobIdSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_get_job_logs', input, () => client.getJobRuntime(input.job_id))
+                'Retrieve stored Jungle Grid stdout/stderr log entries for a job. Supports tail, limit, cursor, and stream filters. For live Server-Sent Events use Jungle Grid directly; Flowise tools poll this stored logs endpoint.',
+            schema: getJobLogsSchema,
+            handler: async (input) =>
+                safeJsonToolCall('jungle_grid_get_job_logs', input, () =>
+                    client.getJobLogs(input.job_id, {
+                        tail: input.tail,
+                        limit: input.limit,
+                        cursor: input.cursor,
+                        stream: input.stream
+                    })
+                )
         }),
-    listJobArtifacts: (client) =>
+    listArtifacts: (client) =>
         new JungleGridTool({
-            name: 'jungle_grid_list_job_artifacts',
+            name: 'jungle_grid_list_artifacts',
             description:
                 'List managed artifacts uploaded by a Jungle Grid job. Retrieve artifacts after successful completion unless the API response explicitly shows partial outputs are available. Managed jobs upload regular files written under /workspace/artifacts.',
             schema: jobIdSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_list_job_artifacts', input, () => client.listJobArtifacts(input.job_id))
+            handler: async (input) => safeJsonToolCall('jungle_grid_list_artifacts', input, () => client.listJobArtifacts(input.job_id))
         }),
-    getArtifactDownloadUrl: (client) =>
+    getArtifact: (client) =>
         new JungleGridTool({
-            name: 'jungle_grid_get_artifact_download_url',
+            name: 'jungle_grid_get_artifact',
             description:
-                'Create a temporary signed download URL for a managed Jungle Grid artifact. Call jungle_grid_list_job_artifacts first and use an artifact_id from that response.',
+                'Create temporary download information for a managed Jungle Grid artifact. The signed URL is a temporary secret; do not print it into public logs. Call jungle_grid_list_artifacts first and use an artifact_id from that response.',
             schema: artifactDownloadSchema,
             handler: async (input) =>
-                safeJsonToolCall('jungle_grid_get_artifact_download_url', input, () =>
-                    client.getArtifactDownloadUrl(input.job_id, input.artifact_id)
-                )
+                safeJsonToolCall('jungle_grid_get_artifact', input, () => client.getArtifactDownloadUrl(input.job_id, input.artifact_id))
         })
 }
 
@@ -272,9 +313,35 @@ async function safeJsonToolCall(toolName: string, params: any, call: () => Promi
         const result = await call()
         return JSON.stringify(result)
     } catch (error) {
-        const message = error instanceof Error ? error.message : typeof error === 'string' ? error : 'Unknown Jungle Grid API error'
+        const message = formatErrorMessage(error)
         return formatToolError(`${toolName} failed: ${message}`, redactSensitiveParams(params))
     }
+}
+
+function normalizeJobPayload(input: any): any {
+    const payload = removeUndefined(input)
+
+    if (payload.workload_type === 'fine_tuning') {
+        payload.workload_type = 'fine-tuning'
+    }
+
+    if (payload.routing_mode !== undefined) {
+        if (payload.optimize_for !== undefined && payload.optimize_for !== payload.routing_mode) {
+            throw new Error('optimize_for and routing_mode must match when both are provided')
+        }
+        payload.optimize_for = payload.routing_mode
+        delete payload.routing_mode
+    }
+
+    if (payload.env !== undefined) {
+        payload.environment = {
+            ...payload.env,
+            ...(payload.environment ?? {})
+        }
+        delete payload.env
+    }
+
+    return payload
 }
 
 function normalizeBaseUrl(baseUrl?: string): string {
@@ -299,10 +366,13 @@ function removeUndefined(value: any): any {
 
 function redactSensitiveParams(params: any): any {
     if (!params || typeof params !== 'object') return params
+    if (Array.isArray(params)) return params.map(redactSensitiveParams)
     const output: Record<string, any> = {}
     for (const [key, value] of Object.entries(params)) {
         if (/token|secret|password|api[_-]?key/i.test(key)) {
             output[key] = '[REDACTED]'
+        } else if (Array.isArray(value)) {
+            output[key] = value.map(redactSensitiveParams)
         } else if (value && typeof value === 'object' && !Array.isArray(value)) {
             output[key] = redactSensitiveParams(value)
         } else {
@@ -312,17 +382,40 @@ function redactSensitiveParams(params: any): any {
     return output
 }
 
+function formatErrorMessage(error: any): string {
+    if (error?.issues && Array.isArray(error.issues)) {
+        return error.issues
+            .map((issue: any) => {
+                const path = Array.isArray(issue.path) && issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+                return `${path}${issue.message}`
+            })
+            .join('; ')
+    }
+
+    if (error instanceof Error) return redactErrorMessage(error.message)
+    if (typeof error === 'string') return redactErrorMessage(error)
+    return 'Unknown Jungle Grid API error'
+}
+
+function redactErrorMessage(message: string): string {
+    return message
+        .replace(/jg_[A-Za-z0-9._-]+/g, 'jg_[REDACTED]')
+        .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer [REDACTED]')
+        .replace(/("(?:callback_auth_token|apiKey|api_key|token|secret|password)"\s*:\s*")([^"]+)(")/gi, '$1[REDACTED]$3')
+        .replace(/((?:callback_auth_token|apiKey|api_key|token|secret|password)\s*[:=]?\s*["'])([^"']+)(["'])/gi, '$1[REDACTED]$3')
+}
+
 function responseErrorMessage(response: any, method: string, path: string): string {
     const fallback = `${method} ${path} failed with status ${response.status}`
     const payload = response.data
     if (payload === undefined || payload === null || payload === '') return fallback
     if (typeof payload === 'string') {
         const trimmed = payload.trim()
-        return trimmed ? `${fallback}: ${trimmed}` : fallback
+        return trimmed ? `${fallback}: ${redactErrorMessage(trimmed)}` : fallback
     }
 
     const detail = formatApiError(payload)
-    return detail ? `${fallback}: ${detail}` : fallback
+    return detail ? `${fallback}: ${redactErrorMessage(detail)}` : fallback
 }
 
 function formatApiError(payload: any): string | undefined {

--- a/packages/components/nodes/tools/JungleGrid/core.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.ts
@@ -10,89 +10,108 @@ const jsonHeaders = {
     Accept: 'application/json'
 }
 
+const nonEmptyString = z.string().refine((value) => value.trim().length > 0, 'Must not be empty')
 const workloadTypeSchema = z.enum(['inference', 'training', 'fine_tuning', 'fine-tuning', 'batch'])
-const optimizeForSchema = z.enum(['balanced', 'cost', 'speed'])
+const routingModeSchema = z.enum(['balanced', 'cost', 'speed'])
 const prioritySchema = z.enum(['low', 'balanced', 'high'])
 const gpuClassSchema = z.enum(['consumer', 'datacenter'])
 const regionModeSchema = z.enum(['prefer', 'strict'])
-const jobStatusSchema = z.enum(['pending', 'queued', 'assigned', 'running', 'completed', 'failed', 'rejected', 'cancelled'])
 const cursorSchema = z.union([z.string(), z.number()])
+const commandSchema = z.union([
+    nonEmptyString,
+    z.array(nonEmptyString).min(1).describe('Preferred command-array form. Every entry must be a non-empty string.')
+])
+const environmentSchema = z.record(z.string()).describe('Environment variable values must be strings.')
+const inputReferenceSchema = z.union([
+    nonEmptyString,
+    z
+        .object({
+            input_id: nonEmptyString
+        })
+        .strict()
+])
 
 const constraintsSchema = z
     .object({
-        max_price_per_hour: z.number().optional().describe('Optional maximum hourly price in USD, as documented by Jungle Grid.'),
-        preferred_gpu_family: z.string().optional().describe('Optional preferred GPU family, such as l4.'),
-        avoid_gpu_families: z.array(z.string()).optional().describe('Optional GPU families to avoid.'),
-        gpu_type: z.string().optional().describe('Optional exact GPU override verified by the official Jungle Grid MCP package.'),
-        gpu_class: gpuClassSchema.optional().describe('Optional GPU class preference verified by the official Jungle Grid MCP package.'),
-        region_preference: z.string().optional().describe('Optional preferred region such as us-east or eu-west.'),
-        region_mode: regionModeSchema.optional().describe('Whether the region preference is preferred or strict.'),
-        latency_priority: prioritySchema.optional().describe("Latency sensitivity: 'low', 'balanced', or 'high'."),
-        cost_priority: prioritySchema.optional().describe("Cost sensitivity: 'low', 'balanced', or 'high'.")
+        max_price_per_hour: z.number().optional(),
+        preferred_gpu_family: nonEmptyString.optional(),
+        avoid_gpu_families: z.array(nonEmptyString).optional(),
+        gpu_type: nonEmptyString.optional(),
+        gpu_class: gpuClassSchema.optional(),
+        region_preference: nonEmptyString.optional(),
+        region_mode: regionModeSchema.optional(),
+        latency_priority: prioritySchema.optional(),
+        cost_priority: prioritySchema.optional()
     })
     .optional()
 
 const estimateJobSchema = z.object({
-    name: z.string().optional().describe('Optional readable job name for the draft workload.'),
-    workload_type: workloadTypeSchema.describe("Type of workload to estimate. Use 'fine_tuning' or 'fine-tuning' for fine-tuning."),
-    image: z.string().min(1).describe('Docker image to run.'),
-    command: z.string().optional().describe('Optional container command to include in the estimate draft, for example python.'),
-    args: z.array(z.string()).optional().describe('Optional arguments passed to the command.'),
-    model_size_gb: z.number().optional().describe('Approximate model size in GB.'),
-    disk_gb: z.number().optional().describe('Optional managed-provider local disk override in GB.'),
-    optimize_for: optimizeForSchema.optional().describe("Scheduling optimization goal: 'balanced', 'cost', or 'speed'."),
-    routing_mode: optimizeForSchema.optional().describe('Agent-friendly alias for optimize_for. If both are set, they must match.'),
-    template: z.string().optional().describe('Optional Jungle Grid template identifier when submitting a template-backed workload.'),
-    notes: z.string().optional().describe('Optional execution intent notes for the estimator when supported by the API.'),
-    latency_priority: prioritySchema.optional().describe("Latency sensitivity: 'low', 'balanced', or 'high'."),
-    cost_priority: prioritySchema.optional().describe("Cost sensitivity: 'low', 'balanced', or 'high'."),
-    constraints: constraintsSchema.describe('Optional routing constraints.')
+    name: nonEmptyString.optional().describe('Compatibility field for a readable estimate name.'),
+    workload_type: workloadTypeSchema.describe('Workload type to estimate.'),
+    image: nonEmptyString.optional().describe('Optional container image for the estimate.'),
+    command: commandSchema.optional().describe('Preferred as an array; a legacy command string remains accepted.'),
+    args: z.array(z.string()).optional().describe('Arguments for a legacy command string or additional container arguments.'),
+    model_size_gb: z.number().positive().optional().describe('Approximate model size in GB.'),
+    model_size: z.number().positive().optional().describe('Alias for model_size_gb.'),
+    disk_gb: z.number().positive().optional().describe('Compatibility field for a managed local disk estimate.'),
+    optimize_for: routingModeSchema.optional().describe('Routing optimization goal.'),
+    routing_mode: routingModeSchema.optional().describe('Alias for optimize_for.'),
+    template: nonEmptyString.optional().describe('Optional Jungle Grid template identifier.'),
+    notes: nonEmptyString.optional().describe('Optional estimator notes.'),
+    latency_priority: prioritySchema.optional(),
+    cost_priority: prioritySchema.optional(),
+    constraints: constraintsSchema
 })
 
 const submitJobSchema = estimateJobSchema.extend({
-    name: z.string().min(1).describe('Readable job name. Submit Job starts asynchronous remote work and may spend credits.'),
-    command: z.string().optional().describe('Container command to run, for example python. Omit to use the image entrypoint or CMD.'),
-    environment: z
-        .record(z.string())
+    name: nonEmptyString.describe('Readable job name. Submission may start compute and spend credits.'),
+    image: nonEmptyString.describe('Container image to run.'),
+    environment: environmentSchema.optional(),
+    env: environmentSchema.optional().describe('Compatibility alias for environment.'),
+    input_files: z.array(inputReferenceSchema).optional().describe('Uploaded inputs mounted under /workspace/inputs.'),
+    script_files: z.array(inputReferenceSchema).optional().describe('Uploaded scripts mounted under /workspace/scripts.'),
+    expected_artifacts: z
+        .array(nonEmptyString)
         .optional()
-        .describe('Environment variables injected into the container. Do not include secrets unless the user explicitly approves.'),
-    env: z.record(z.string()).optional().describe('Agent-friendly alias for environment. If both are set, keys from environment are used.'),
-    huggingface_credential_id: z.string().optional().describe('Optional saved Hugging Face credential id.'),
-    callback_url: z.string().optional().describe('Optional documented callback URL for lifecycle events.'),
-    callback_auth_token: z.string().optional().describe('Optional callback authentication token. Never use this for unrelated secrets.'),
-    callback_metadata: z.record(z.any()).optional().describe('Optional metadata included with callbacks.'),
-    metadata: z.record(z.any()).optional().describe('Optional workload metadata when supported by the API.')
+        .describe('Expected files under /workspace/artifacts, for example /workspace/artifacts/result.json.'),
+    metadata: z.record(z.unknown()).optional().describe('Structured workload metadata.'),
+    huggingface_credential_id: nonEmptyString.optional(),
+    callback_url: z.string().url().optional(),
+    callback_auth_token: nonEmptyString.optional(),
+    callback_metadata: z.record(z.string()).optional()
 })
 
+const uploadJobInputSchema = z.object({
+    filename: nonEmptyString.describe('Filename used for the managed mount path.'),
+    content_type: nonEmptyString.optional().describe('Optional MIME content type.'),
+    kind: z.enum(['input', 'script']).optional().describe("Use 'input' or 'script'.")
+})
+
+const emptySchema = z.object({}).strict()
+
 const jobIdSchema = z.object({
-    job_id: z.string().min(1).describe('Jungle Grid job_id returned by submit_job.')
+    job_id: nonEmptyString.describe('Jungle Grid job_id returned by submit_job.')
 })
 
 const listJobsSchema = z.object({
-    limit: z
-        .number()
-        .min(1)
-        .max(100)
-        .optional()
-        .default(20)
-        .describe('Maximum number of jobs to return. Jungle Grid documents a maximum of 100.'),
-    cursor: cursorSchema.optional().describe('Optional next_cursor from a previous list_jobs response.'),
-    status: jobStatusSchema.optional().describe('Optional status filter.')
+    limit: z.number().int().min(1).max(100).optional().default(20),
+    cursor: nonEmptyString.optional(),
+    status: nonEmptyString.optional().describe('Optional current API status filter.')
 })
 
 const getJobLogsSchema = jobIdSchema.extend({
-    tail: z.number().min(1).max(500).optional().describe('Return the most recent 1..500 log entries.'),
-    limit: z.number().min(1).max(500).optional().describe('Return up to this many log entries, 1..500.'),
-    cursor: cursorSchema.optional().describe('Optional next_cursor from a previous get_job_logs response.'),
-    stream: z.enum(['stdout', 'stderr', 'all']).optional().describe("Filter logs by stream. Defaults to the API's behavior.")
+    tail: z.number().int().min(1).max(500).optional(),
+    limit: z.number().int().min(1).max(500).optional(),
+    cursor: cursorSchema.optional(),
+    stream: z.enum(['stdout', 'stderr', 'all']).optional()
 })
 
 const cancelJobSchema = jobIdSchema.extend({
-    reason: z.string().optional().describe('Optional cancellation reason.')
+    reason: nonEmptyString.optional()
 })
 
 const artifactDownloadSchema = jobIdSchema.extend({
-    artifact_id: z.string().min(1).describe('Artifact ID returned by list_artifacts.')
+    artifact_id: nonEmptyString.describe('Artifact ID returned by list_artifacts.')
 })
 
 export interface JungleGridClientOptions {
@@ -100,96 +119,135 @@ export interface JungleGridClientOptions {
     baseUrl?: string
 }
 
+class JungleGridApiError extends Error {
+    readonly status: number
+    readonly code: string
+
+    constructor(status: number, code: string, message: string) {
+        super(message)
+        this.name = 'JungleGridApiError'
+        this.status = status
+        this.code = code
+    }
+}
+
 export class JungleGridClient {
     private readonly apiKey: string
     private readonly baseUrl: string
 
     constructor({ apiKey, baseUrl }: JungleGridClientOptions) {
-        if (!apiKey) throw new Error('Jungle Grid API key is required')
+        if (!apiKey?.trim()) throw new Error('Jungle Grid API key is required')
         this.apiKey = apiKey
         this.baseUrl = normalizeBaseUrl(baseUrl)
     }
 
-    estimateJob(input: z.infer<typeof estimateJobSchema>): Promise<any> {
-        return this.request('POST', '/v1/jobs/estimate', normalizeJobPayload(input))
+    estimateJob(input: z.infer<typeof estimateJobSchema>): Promise<unknown> {
+        return this.request('POST', '/v1/mcp/jobs/estimate', normalizeJobPayload(input))
     }
 
-    submitJob(input: z.infer<typeof submitJobSchema>): Promise<any> {
-        return this.request('POST', '/v1/jobs', normalizeJobPayload(input))
+    submitJob(input: z.infer<typeof submitJobSchema>): Promise<unknown> {
+        return this.request('POST', '/v1/mcp/jobs', normalizeJobPayload(input))
     }
 
-    listJobs(input: z.infer<typeof listJobsSchema>): Promise<any> {
-        const params = new URLSearchParams()
-        if (input.limit !== undefined) params.set('limit', String(input.limit))
-        if (input.cursor !== undefined) params.set('cursor', String(input.cursor))
-        if (input.status) params.set('status', input.status)
-        const query = params.toString()
-        return this.request('GET', query ? `/v1/jobs?${query}` : '/v1/jobs')
+    uploadJobInput(input: z.infer<typeof uploadJobInputSchema>): Promise<unknown> {
+        return this.request('POST', '/v1/job-inputs', input)
     }
 
-    getJob(jobId: string): Promise<any> {
-        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}`)
+    listJobInputs(): Promise<unknown> {
+        return this.request('GET', '/v1/job-inputs')
     }
 
-    getJobRuntime(jobId: string): Promise<any> {
-        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/runtime`)
+    listJobs(input: z.infer<typeof listJobsSchema>): Promise<unknown> {
+        return this.request('GET', withQuery('/v1/mcp/jobs', input))
     }
 
-    getJobLogs(jobId: string, input: Omit<z.infer<typeof getJobLogsSchema>, 'job_id'> = {}): Promise<any> {
-        const params = new URLSearchParams()
-        if (input.tail !== undefined) params.set('tail', String(input.tail))
-        if (input.limit !== undefined) params.set('limit', String(input.limit))
-        if (input.cursor !== undefined) params.set('cursor', String(input.cursor))
-        if (input.stream) params.set('stream', input.stream)
-        const query = params.toString()
-        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/logs${query ? `?${query}` : ''}`)
+    getJob(jobId: string): Promise<unknown> {
+        return this.request('GET', `/v1/mcp/jobs/${encodeURIComponent(jobId)}`).then(normalizeJobStatusResponse)
     }
 
-    cancelJob(jobId: string, reason?: string): Promise<any> {
-        return this.request('POST', `/v1/jobs/${encodeURIComponent(jobId)}/cancel`, {
-            reason: reason ?? 'Cancelled via Flowise'
+    getJobEvents(jobId: string): Promise<unknown> {
+        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/events`)
+    }
+
+    async getJobRuntime(jobId: string): Promise<unknown> {
+        try {
+            return await this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/runtime`)
+        } catch (error) {
+            if (error instanceof JungleGridApiError && error.status === 404 && /runtime not available yet/i.test(error.message)) {
+                return {
+                    job_id: jobId,
+                    runtime_available: false,
+                    message: 'Job runtime information is not available yet.'
+                }
+            }
+            throw error
+        }
+    }
+
+    getJobLogs(jobId: string, input: Omit<z.infer<typeof getJobLogsSchema>, 'job_id'> = {}): Promise<unknown> {
+        return this.request('GET', withQuery(`/v1/mcp/jobs/${encodeURIComponent(jobId)}/logs`, input))
+    }
+
+    cancelJob(jobId: string, reason?: string): Promise<unknown> {
+        return this.request('POST', `/v1/mcp/jobs/${encodeURIComponent(jobId)}/cancel`, {
+            reason: reason?.trim() || 'Cancelled via Flowise'
         })
     }
 
-    listJobArtifacts(jobId: string): Promise<any> {
-        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/artifacts`)
+    listJobArtifacts(jobId: string): Promise<unknown> {
+        return this.request('GET', `/v1/mcp/jobs/${encodeURIComponent(jobId)}/artifacts`)
     }
 
-    getArtifactDownloadUrl(jobId: string, artifactId: string): Promise<any> {
-        return this.request('POST', `/v1/jobs/${encodeURIComponent(jobId)}/artifacts/${encodeURIComponent(artifactId)}/download`)
+    getArtifactDownloadUrl(jobId: string, artifactId: string): Promise<unknown> {
+        return this.request('POST', `/v1/mcp/jobs/${encodeURIComponent(jobId)}/artifacts/${encodeURIComponent(artifactId)}/download`)
     }
 
-    private async request(method: string, path: string, body?: any): Promise<any> {
-        const response = await secureAxiosRequest({
-            url: `${this.baseUrl}${path}`,
-            method,
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                ...jsonHeaders
-            },
-            data: body !== undefined ? removeUndefined(body) : undefined,
-            timeout: 30000
-        })
-
-        if (response.status < 200 || response.status >= 300) {
-            throw new Error(responseErrorMessage(response, method, path))
+    private async request(method: string, path: string, body?: unknown): Promise<unknown> {
+        let response: any
+        try {
+            response = await secureAxiosRequest({
+                url: `${this.baseUrl}${path}`,
+                method,
+                headers: {
+                    Authorization: `Bearer ${this.apiKey}`,
+                    ...jsonHeaders
+                },
+                data: body === undefined ? undefined : removeUndefined(body),
+                timeout: 30000
+            })
+        } catch (error) {
+            throw new Error(requestFailureMessage(error, method, path))
         }
 
-        if (response.status === 204) return { ok: true }
+        if (response.status < 200 || response.status >= 300) {
+            const parsed = parseApiError(response.data, response.status)
+            throw new JungleGridApiError(response.status, parsed.code, `${method} ${path}: ${parsed.code}: ${parsed.message}`)
+        }
 
-        if (response.data === undefined || response.data === null || response.data === '') return { ok: true }
-        return response.data
+        if (response.status === 204 || response.data === undefined || response.data === null || response.data === '') {
+            return { ok: true }
+        }
+
+        const data = unwrapResponseEnvelope(response.data)
+        if (isPlainObject(response.data) && response.data.ok === false) {
+            const parsed = parseApiError(response.data, response.status)
+            throw new JungleGridApiError(response.status, parsed.code, `${method} ${path}: ${parsed.code}: ${parsed.message}`)
+        }
+        return data
     }
 }
 
 export type JungleGridAction =
     | 'estimateJob'
     | 'submitJob'
+    | 'uploadJobInput'
+    | 'listJobInputs'
     | 'listJobs'
     | 'getJob'
+    | 'getJobEvents'
     | 'getJobRuntime'
-    | 'cancelJob'
     | 'getJobLogs'
+    | 'cancelJob'
     | 'listArtifacts'
     | 'getArtifact'
 
@@ -217,7 +275,7 @@ class JungleGridTool extends DynamicStructuredTool {
 
     async _call(input: any): Promise<string> {
         try {
-            const parsedInput = this.inputSchema?.parse ? this.inputSchema.parse(input ?? {}) : input
+            const parsedInput = this.inputSchema.parse(input ?? {})
             return this.handler(parsedInput)
         } catch (error) {
             return formatToolError(`${this.name} failed: ${formatErrorMessage(error)}`, redactSensitiveParams(input))
@@ -225,61 +283,76 @@ class JungleGridTool extends DynamicStructuredTool {
     }
 }
 
-const toolFactories: Record<JungleGridAction, (_client: JungleGridClient) => DynamicStructuredTool> = {
+const toolFactories: Record<JungleGridAction, (client: JungleGridClient) => DynamicStructuredTool> = {
     estimateJob: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_estimate_job',
             description:
-                'Estimate a Jungle Grid workload before submission. This is read-only and returns route, capacity, cost, queue wait, start window, warning, and screening fields when available. Use this before jungle_grid_submit_job whenever spending credits or capacity selection matters.',
+                'Estimate routing, screening, capacity source, expected cost, and submission eligibility without submitting or starting compute. Availability is not a guarantee of immediate runtime startup.',
             schema: estimateJobSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_estimate_job', input, () => client.estimateJob(input))
+            handler: (input) => safeJsonToolCall('jungle_grid_estimate_job', input, () => client.estimateJob(input))
         }),
     submitJob: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_submit_job',
             description:
-                'Submit an asynchronous Jungle Grid workload. This may start managed compute and spend credits. It returns a job_id immediately; a returned job_id does not mean the job has finished. Poll jungle_grid_get_job and jungle_grid_get_job_logs until a terminal status is reached. Never put untrusted secrets in environment variables, command, or args without explicit user permission.',
+                'Submit an asynchronous Jungle Grid workload. This may start managed compute and spend credits. Prefer a command array; legacy command plus args remains supported. Monitor the returned job_id with status, events, runtime, and logs.',
             schema: submitJobSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_submit_job', input, () => client.submitJob(input))
+            handler: (input) => safeJsonToolCall('jungle_grid_submit_job', input, () => client.submitJob(input))
+        }),
+    uploadJobInput: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_upload_job_input',
+            description:
+                'Create a managed upload slot for an input or script. This does not upload file bytes. Upload bytes to upload_url with the returned method and headers, call complete_url, then pass input_id to submit_job. Do not expose temporary URLs or tokens in logs.',
+            schema: uploadJobInputSchema,
+            handler: (input) => safeJsonToolCall('jungle_grid_upload_job_input', input, () => client.uploadJobInput(input))
+        }),
+    listJobInputs: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_list_job_inputs',
+            description: 'List uploaded Jungle Grid inputs and scripts, including readiness and managed mount paths.',
+            schema: emptySchema,
+            handler: (input) => safeJsonToolCall('jungle_grid_list_job_inputs', input, () => client.listJobInputs())
         }),
     listJobs: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_list_jobs',
-            description: 'List recent Jungle Grid jobs for the authenticated account with limit, cursor, and optional status filtering.',
+            description: 'List recent Jungle Grid jobs with limit, cursor, and optional status filtering.',
             schema: listJobsSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_list_jobs', input, () => client.listJobs(input))
+            handler: (input) => safeJsonToolCall('jungle_grid_list_jobs', input, () => client.listJobs(input))
         }),
     getJob: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_get_job',
             description:
-                "Get current Jungle Grid job status and details by job_id. Poll this after submit_job until the job reaches a terminal status such as 'completed', 'failed', 'cancelled', or 'rejected'.",
+                'Get current job status, execution phase, stable phase timing, scheduling delay, routing, cost, failure, and artifact readiness when available. A supported estimate does not guarantee immediate startup.',
             schema: jobIdSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_get_job', input, () => client.getJob(input.job_id))
+            handler: (input) => safeJsonToolCall('jungle_grid_get_job', input, () => client.getJob(input.job_id))
+        }),
+    getJobEvents: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_get_job_events',
+            description:
+                'Get platform lifecycle events for scheduling, capacity lookup, provisioning, input preparation, and startup. Events can exist before workload output; they are not workload logs.',
+            schema: jobIdSchema,
+            handler: (input) => safeJsonToolCall('jungle_grid_get_job_events', input, () => client.getJobEvents(input.job_id))
         }),
     getJobRuntime: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_get_job_runtime',
             description:
-                'Retrieve runtime tails, exit code, timeout flag, diagnostics, and runtime availability for a Jungle Grid job. Use this to monitor or diagnose running, failed, or completed work.',
+                'Get separate runtime diagnostics, output tails, exit code, timeout state, and field availability. Runtime data may be unavailable while a job is waiting or starting.',
             schema: jobIdSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_get_job_runtime', input, () => client.getJobRuntime(input.job_id))
-        }),
-    cancelJob: (client) =>
-        new JungleGridTool({
-            name: 'jungle_grid_cancel_job',
-            description:
-                'Cancel a pending, queued, assigned, or running Jungle Grid job. This uses the verified production cancel route and has no useful effect on already terminal jobs.',
-            schema: cancelJobSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_cancel_job', input, () => client.cancelJob(input.job_id, input.reason))
+            handler: (input) => safeJsonToolCall('jungle_grid_get_job_runtime', input, () => client.getJobRuntime(input.job_id))
         }),
     getJobLogs: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_get_job_logs',
             description:
-                'Retrieve stored Jungle Grid stdout/stderr log entries for a job. Supports tail, limit, cursor, and stream filters. For live Server-Sent Events use Jungle Grid directly; Flowise tools poll this stored logs endpoint.',
+                'Poll paginated persisted logs. Logs may be empty while queued or starting; use get_job_events for platform progress. Polling is not true streaming, and lifecycle events are not fetched through this action.',
             schema: getJobLogsSchema,
-            handler: async (input) =>
+            handler: (input) =>
                 safeJsonToolCall('jungle_grid_get_job_logs', input, () =>
                     client.getJobLogs(input.job_id, {
                         tail: input.tail,
@@ -289,40 +362,50 @@ const toolFactories: Record<JungleGridAction, (_client: JungleGridClient) => Dyn
                     })
                 )
         }),
+    cancelJob: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_cancel_job',
+            description: 'Request cancellation of a Jungle Grid job. This may stop active execution and prevent further outputs.',
+            schema: cancelJobSchema,
+            handler: (input) => safeJsonToolCall('jungle_grid_cancel_job', input, () => client.cancelJob(input.job_id, input.reason))
+        }),
     listArtifacts: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_list_artifacts',
-            description:
-                'List managed artifacts uploaded by a Jungle Grid job. Retrieve artifacts after successful completion unless the API response explicitly shows partial outputs are available. Managed jobs upload regular files written under /workspace/artifacts.',
+            description: 'List managed output artifacts for a job, including artifact IDs, readiness, size, and MIME type.',
             schema: jobIdSchema,
-            handler: async (input) => safeJsonToolCall('jungle_grid_list_artifacts', input, () => client.listJobArtifacts(input.job_id))
+            handler: (input) => safeJsonToolCall('jungle_grid_list_artifacts', input, () => client.listJobArtifacts(input.job_id))
         }),
     getArtifact: (client) =>
         new JungleGridTool({
             name: 'jungle_grid_get_artifact',
             description:
-                'Create temporary download information for a managed Jungle Grid artifact. The signed URL is a temporary secret; do not print it into public logs. Call jungle_grid_list_artifacts first and use an artifact_id from that response.',
+                'Get temporary download information for an artifact ID. The response may contain a short-lived signed URL; it does not permanently embed the file in Flowise.',
             schema: artifactDownloadSchema,
-            handler: async (input) =>
+            handler: (input) =>
                 safeJsonToolCall('jungle_grid_get_artifact', input, () => client.getArtifactDownloadUrl(input.job_id, input.artifact_id))
         })
 }
 
-async function safeJsonToolCall(toolName: string, params: any, call: () => Promise<any>): Promise<string> {
+async function safeJsonToolCall(toolName: string, params: unknown, call: () => Promise<unknown>): Promise<string> {
     try {
-        const result = await call()
-        return JSON.stringify(result)
+        return JSON.stringify(await call())
     } catch (error) {
-        const message = formatErrorMessage(error)
-        return formatToolError(`${toolName} failed: ${message}`, redactSensitiveParams(params))
+        return formatToolError(`${toolName} failed: ${formatErrorMessage(error)}`, redactSensitiveParams(params))
     }
 }
 
 function normalizeJobPayload(input: any): any {
     const payload = removeUndefined(input)
 
-    if (payload.workload_type === 'fine_tuning') {
-        payload.workload_type = 'fine-tuning'
+    if (payload.workload_type === 'fine_tuning') payload.workload_type = 'fine-tuning'
+
+    if (payload.model_size !== undefined) {
+        if (payload.model_size_gb !== undefined && payload.model_size_gb !== payload.model_size) {
+            throw new Error('model_size and model_size_gb must match when both are provided')
+        }
+        payload.model_size_gb = payload.model_size
+        delete payload.model_size
     }
 
     if (payload.routing_mode !== undefined) {
@@ -341,49 +424,139 @@ function normalizeJobPayload(input: any): any {
         delete payload.env
     }
 
+    for (const key of ['input_files', 'script_files']) {
+        if (payload[key] !== undefined) {
+            payload[key] = payload[key].map((item: string | { input_id: string }) => ({
+                input_id: (typeof item === 'string' ? item : item.input_id).trim()
+            }))
+        }
+    }
+
     return payload
 }
 
-function normalizeBaseUrl(baseUrl?: string): string {
-    const raw = (baseUrl || DEFAULT_JUNGLE_GRID_BASE_URL).trim()
-    if (!raw) return DEFAULT_JUNGLE_GRID_BASE_URL
+export function normalizeBaseUrl(baseUrl?: string): string {
+    const raw = (baseUrl || DEFAULT_JUNGLE_GRID_BASE_URL).trim() || DEFAULT_JUNGLE_GRID_BASE_URL
+    let parsed: URL
+    try {
+        parsed = new URL(raw)
+    } catch {
+        throw new Error('Jungle Grid API base URL must be a valid HTTP or HTTPS URL')
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+        throw new Error('Jungle Grid API base URL must be a valid HTTP or HTTPS URL without embedded credentials')
+    }
     return raw.replace(/\/+$/, '')
 }
 
-function removeUndefined(value: any): any {
-    if (Array.isArray(value)) {
-        return value.map(removeUndefined)
+function withQuery(path: string, values: Record<string, unknown>): string {
+    const params = new URLSearchParams()
+    for (const [key, value] of Object.entries(values)) {
+        if (value !== undefined && value !== null && value !== '') params.set(key, String(value))
     }
-    if (value != null && typeof value === 'object' && (value.constructor === Object || Object.getPrototypeOf(value) === null)) {
+    const query = params.toString()
+    return query ? `${path}?${query}` : path
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+    if (value === null || typeof value !== 'object') return false
+    const prototype = Object.getPrototypeOf(value)
+    return prototype === Object.prototype || prototype === null
+}
+
+export function removeUndefined(value: any, seen = new WeakMap<object, any>()): any {
+    if (Array.isArray(value)) {
+        if (seen.has(value)) return seen.get(value)
+        const output: any[] = []
+        seen.set(value, output)
+        for (const item of value) output.push(removeUndefined(item, seen))
+        return output
+    }
+    if (isPlainObject(value)) {
+        if (seen.has(value)) return seen.get(value)
         const output: Record<string, any> = {}
+        seen.set(value, output)
         for (const [key, child] of Object.entries(value)) {
-            if (child !== undefined) output[key] = removeUndefined(child)
+            if (child !== undefined) output[key] = removeUndefined(child, seen)
         }
         return output
     }
     return value
 }
 
-function redactSensitiveParams(params: any): any {
-    if (!params || typeof params !== 'object') return params
-    if (Array.isArray(params)) return params.map(redactSensitiveParams)
+export function redactSensitiveParams(value: any, seen = new WeakSet<object>()): any {
+    if (value === null || typeof value !== 'object') return value
+    if (!Array.isArray(value) && !isPlainObject(value)) return value
+    if (seen.has(value)) return '[Circular]'
+    seen.add(value)
+    if (Array.isArray(value)) return value.map((item) => redactSensitiveParams(item, seen))
+
     const output: Record<string, any> = {}
-    for (const [key, value] of Object.entries(params)) {
-        if (/token|secret|password|api[_-]?key/i.test(key)) {
-            output[key] = '[REDACTED]'
-        } else if (Array.isArray(value)) {
-            output[key] = value.map(redactSensitiveParams)
-        } else if (value && typeof value === 'object' && !Array.isArray(value)) {
-            output[key] = redactSensitiveParams(value)
-        } else {
-            output[key] = value
-        }
+    for (const [key, child] of Object.entries(value)) {
+        output[key] = /token|secret|password|api[_-]?key|authorization|upload_url|download_url|complete_url|signed_url/i.test(key)
+            ? '[REDACTED]'
+            : redactSensitiveParams(child, seen)
     }
     return output
 }
 
+export function normalizeJobStatusResponse(data: unknown): unknown {
+    if (!isPlainObject(data)) return data
+    const normalized: Record<string, unknown> = { ...data }
+    delete normalized.total_spent_usd
+
+    if (isPlainObject(data.billing)) {
+        const billing: Record<string, unknown> = { ...data.billing }
+        delete billing.total_spent_usd
+        if (typeof billing.actual_cost_usd !== 'number') {
+            if (typeof billing.final_cost_usd === 'number') billing.actual_cost_usd = billing.final_cost_usd
+            else if (typeof billing.cost_usd === 'number') billing.actual_cost_usd = billing.cost_usd
+        }
+        delete billing.cost_usd
+        normalized.billing = billing
+        if (typeof normalized.actual_cost_usd !== 'number') {
+            normalized.actual_cost_usd = typeof billing.actual_cost_usd === 'number' ? billing.actual_cost_usd : null
+        }
+    } else if (!Object.prototype.hasOwnProperty.call(normalized, 'actual_cost_usd')) {
+        normalized.actual_cost_usd = null
+    }
+    return normalized
+}
+
+function unwrapResponseEnvelope(data: unknown): unknown {
+    if (isPlainObject(data) && data.ok === true && Object.prototype.hasOwnProperty.call(data, 'data')) return data.data
+    return data
+}
+
+function parseApiError(data: unknown, status: number): { code: string; message: string } {
+    const fallback = statusError(status)
+    if (!isPlainObject(data)) {
+        const text = typeof data === 'string' ? data.trim() : ''
+        return { code: fallback.code, message: text ? redactErrorMessage(text) : fallback.message }
+    }
+    const source = isPlainObject(data.error) ? data.error : data
+    const code = cleanString(source.code) || fallback.code
+    const message = cleanString(source.message) || fallback.message
+    return { code, message: redactErrorMessage(message) }
+}
+
+function statusError(status: number): { code: string; message: string } {
+    if (status === 401) return { code: 'UNAUTHORIZED', message: 'Authentication is required or the API key is invalid.' }
+    if (status === 403) return { code: 'FORBIDDEN', message: 'The API key is not authorized for this action.' }
+    if (status === 404) return { code: 'NOT_FOUND', message: 'The requested Jungle Grid resource was not found.' }
+    if (status === 429) return { code: 'RATE_LIMITED', message: 'Jungle Grid API rate limit exceeded.' }
+    if (status >= 500) return { code: 'UPSTREAM_ERROR', message: 'Jungle Grid API is temporarily unavailable.' }
+    return { code: 'API_ERROR', message: `Jungle Grid API request failed with status ${status}.` }
+}
+
+function requestFailureMessage(error: unknown, method: string, path: string): string {
+    const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : 'Network request failed'
+    const timeout = /timeout|timed out|ECONNABORTED/i.test(raw)
+    return `${method} ${path} failed: ${timeout ? 'Jungle Grid API request timed out' : redactErrorMessage(raw)}`
+}
+
 function formatErrorMessage(error: any): string {
-    if (error?.issues && Array.isArray(error.issues)) {
+    if (Array.isArray(error?.issues)) {
         return error.issues
             .map((issue: any) => {
                 const path = Array.isArray(issue.path) && issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
@@ -391,50 +564,24 @@ function formatErrorMessage(error: any): string {
             })
             .join('; ')
     }
-
     if (error instanceof Error) return redactErrorMessage(error.message)
     if (typeof error === 'string') return redactErrorMessage(error)
     return 'Unknown Jungle Grid API error'
 }
 
-function redactErrorMessage(message: string): string {
+export function redactErrorMessage(message: string): string {
     return message
+        .replace(/https?:\/\/[^\s"'<>]+(?:[?&](?:X-Amz-[^=\s]+|token|signature|sig)=[^\s"'<>]*)+/gi, '[REDACTED_URL]')
         .replace(/jg_[A-Za-z0-9._-]+/g, 'jg_[REDACTED]')
-        .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer [REDACTED]')
-        .replace(/("(?:callback_auth_token|apiKey|api_key|token|secret|password)"\s*:\s*")([^"]+)(")/gi, '$1[REDACTED]$3')
+        .replace(/Bearer\s+[A-Za-z0-9._~+/-]+=*/gi, 'Bearer [REDACTED]')
+        .replace(
+            /("(?:callback_auth_token|apiKey|api_key|token|secret|password|upload_url|download_url|complete_url)"\s*:\s*")([^"]+)(")/gi,
+            '$1[REDACTED]$3'
+        )
         .replace(/((?:callback_auth_token|apiKey|api_key|token|secret|password)\s*[:=]?\s*["'])([^"']+)(["'])/gi, '$1[REDACTED]$3')
 }
 
-function responseErrorMessage(response: any, method: string, path: string): string {
-    const fallback = `${method} ${path} failed with status ${response.status}`
-    const payload = response.data
-    if (payload === undefined || payload === null || payload === '') return fallback
-    if (typeof payload === 'string') {
-        const trimmed = payload.trim()
-        return trimmed ? `${fallback}: ${redactErrorMessage(trimmed)}` : fallback
-    }
-
-    const detail = formatApiError(payload)
-    return detail ? `${fallback}: ${redactErrorMessage(detail)}` : fallback
-}
-
-function formatApiError(payload: any): string | undefined {
-    if (!payload || typeof payload !== 'object') return undefined
-    if (typeof payload.error === 'string' && payload.error.trim()) return payload.error.trim()
-    if (payload.error && typeof payload.error === 'object') {
-        const code = stringField(payload.error.code)
-        const message = stringField(payload.error.message)
-        if (code && message) return `${code}: ${message}`
-        return message ?? code
-    }
-
-    const code = stringField(payload.code)
-    const message = stringField(payload.message)
-    if (code && message) return `${code}: ${message}`
-    return message ?? code
-}
-
-function stringField(value: any): string | undefined {
+function cleanString(value: unknown): string | undefined {
     if (typeof value !== 'string') return undefined
     const trimmed = value.trim()
     return trimmed || undefined

--- a/packages/components/nodes/tools/JungleGrid/core.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.ts
@@ -144,7 +144,7 @@ export class JungleGridClient {
         })
 
         if (response.status < 200 || response.status >= 300) {
-            throw new Error(await responseErrorMessage(response, method, path))
+            throw new Error(responseErrorMessage(response, method, path))
         }
 
         if (response.status === 204) return { ok: true }

--- a/packages/components/nodes/tools/JungleGrid/core.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.ts
@@ -287,7 +287,7 @@ function removeUndefined(value: any): any {
     if (Array.isArray(value)) {
         return value.map(removeUndefined)
     }
-    if (value && typeof value === 'object') {
+    if (value != null && typeof value === 'object' && (value.constructor === Object || Object.getPrototypeOf(value) === null)) {
         const output: Record<string, any> = {}
         for (const [key, child] of Object.entries(value)) {
             if (child !== undefined) output[key] = removeUndefined(child)

--- a/packages/components/nodes/tools/JungleGrid/core.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.ts
@@ -312,7 +312,7 @@ function redactSensitiveParams(params: any): any {
     return output
 }
 
-async function responseErrorMessage(response: any, method: string, path: string): Promise<string> {
+function responseErrorMessage(response: any, method: string, path: string): string {
     const fallback = `${method} ${path} failed with status ${response.status}`
     const payload = response.data
     if (payload === undefined || payload === null || payload === '') return fallback

--- a/packages/components/nodes/tools/JungleGrid/core.ts
+++ b/packages/components/nodes/tools/JungleGrid/core.ts
@@ -1,0 +1,348 @@
+import { z } from 'zod/v3'
+import { DynamicStructuredTool } from '../OpenAPIToolkit/core'
+import { formatToolError } from '../../../src/agents'
+import { secureAxiosRequest } from '../../../src/httpSecurity'
+
+export const DEFAULT_JUNGLE_GRID_BASE_URL = 'https://api.junglegrid.dev'
+
+const jsonHeaders = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+}
+
+const workloadTypeSchema = z.enum(['inference', 'training', 'fine-tuning', 'batch'])
+const optimizeForSchema = z.enum(['balanced', 'cost', 'speed'])
+const prioritySchema = z.enum(['low', 'balanced', 'high'])
+const gpuClassSchema = z.enum(['consumer', 'datacenter'])
+const regionModeSchema = z.enum(['prefer', 'strict'])
+const jobStatusSchema = z.enum(['pending', 'queued', 'assigned', 'running', 'completed', 'failed', 'rejected', 'cancelled'])
+
+const constraintsSchema = z
+    .object({
+        max_price_per_hour: z.number().optional().describe('Optional maximum hourly price in USD, as documented by Jungle Grid.'),
+        preferred_gpu_family: z.string().optional().describe('Optional preferred GPU family, such as l4.'),
+        avoid_gpu_families: z.array(z.string()).optional().describe('Optional GPU families to avoid.'),
+        gpu_type: z.string().optional().describe('Optional exact GPU override verified by the official Jungle Grid MCP package.'),
+        gpu_class: gpuClassSchema.optional().describe('Optional GPU class preference verified by the official Jungle Grid MCP package.'),
+        region_preference: z.string().optional().describe('Optional preferred region such as us-east or eu-west.'),
+        region_mode: regionModeSchema.optional().describe('Whether the region preference is preferred or strict.'),
+        latency_priority: prioritySchema.optional().describe("Latency sensitivity: 'low', 'balanced', or 'high'."),
+        cost_priority: prioritySchema.optional().describe("Cost sensitivity: 'low', 'balanced', or 'high'.")
+    })
+    .optional()
+
+const estimateJobSchema = z.object({
+    name: z.string().optional().describe('Optional readable job name for the draft workload.'),
+    workload_type: workloadTypeSchema.describe('Type of workload to estimate.'),
+    image: z.string().min(1).describe('Docker image to run.'),
+    command: z.string().optional().describe('Optional container command to include in the estimate draft, for example python.'),
+    args: z.array(z.string()).optional().describe('Optional arguments passed to the command.'),
+    model_size_gb: z.number().optional().describe('Approximate model size in GB.'),
+    disk_gb: z.number().optional().describe('Optional managed-provider local disk override in GB.'),
+    optimize_for: optimizeForSchema.optional().describe("Scheduling optimization goal: 'balanced', 'cost', or 'speed'."),
+    latency_priority: prioritySchema.optional().describe("Latency sensitivity: 'low', 'balanced', or 'high'."),
+    cost_priority: prioritySchema.optional().describe("Cost sensitivity: 'low', 'balanced', or 'high'."),
+    constraints: constraintsSchema.describe('Optional routing constraints.')
+})
+
+const submitJobSchema = estimateJobSchema.extend({
+    command: z.string().min(1).describe('Container command to run, for example python. Submit Job starts asynchronous remote work.'),
+    environment: z
+        .record(z.string())
+        .optional()
+        .describe('Environment variables injected into the container. Do not include secrets unless the user explicitly approves.'),
+    huggingface_credential_id: z.string().optional().describe('Optional saved Hugging Face credential id.'),
+    webhook_url: z.string().optional().describe('Optional HTTPS URL to receive signed lifecycle event callbacks.'),
+    callback_url: z.string().optional().describe('Optional documented callback URL for lifecycle events.'),
+    callback_auth_token: z.string().optional().describe('Optional callback authentication token. Never use this for unrelated secrets.'),
+    callback_metadata: z.record(z.any()).optional().describe('Optional metadata included with callbacks.')
+})
+
+const jobIdSchema = z.object({
+    job_id: z.string().min(1).describe('Jungle Grid job_id returned by submit_job.')
+})
+
+const listJobsSchema = z.object({
+    limit: z
+        .number()
+        .optional()
+        .default(20)
+        .describe('Maximum number of jobs to return. The official MCP package defaults to 20 and documents max 100.'),
+    status: jobStatusSchema.optional().describe('Optional status filter.')
+})
+
+const cancelJobSchema = jobIdSchema.extend({
+    reason: z.string().optional().describe('Optional cancellation reason.')
+})
+
+const artifactDownloadSchema = jobIdSchema.extend({
+    artifact_id: z.string().min(1).describe('Artifact ID returned by list_job_artifacts.')
+})
+
+export interface JungleGridClientOptions {
+    apiKey: string
+    baseUrl?: string
+}
+
+export class JungleGridClient {
+    private readonly apiKey: string
+    private readonly baseUrl: string
+
+    constructor({ apiKey, baseUrl }: JungleGridClientOptions) {
+        if (!apiKey) throw new Error('Jungle Grid API key is required')
+        this.apiKey = apiKey
+        this.baseUrl = normalizeBaseUrl(baseUrl)
+    }
+
+    estimateJob(input: z.infer<typeof estimateJobSchema>): Promise<any> {
+        return this.request('POST', '/v1/jobs/estimate', input)
+    }
+
+    submitJob(input: z.infer<typeof submitJobSchema>): Promise<any> {
+        return this.request('POST', '/v1/jobs', input)
+    }
+
+    listJobs(input: z.infer<typeof listJobsSchema>): Promise<any> {
+        const params = new URLSearchParams()
+        if (input.limit !== undefined) params.set('limit', String(input.limit))
+        if (input.status) params.set('status', input.status)
+        const query = params.toString()
+        return this.request('GET', query ? `/v1/jobs?${query}` : '/v1/jobs')
+    }
+
+    getJob(jobId: string): Promise<any> {
+        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}`)
+    }
+
+    getJobRuntime(jobId: string): Promise<any> {
+        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/runtime`)
+    }
+
+    cancelJob(jobId: string, reason?: string): Promise<any> {
+        return this.request('POST', `/v1/jobs/${encodeURIComponent(jobId)}/cancel`, {
+            reason: reason ?? 'Cancelled via Flowise'
+        })
+    }
+
+    listJobArtifacts(jobId: string): Promise<any> {
+        return this.request('GET', `/v1/jobs/${encodeURIComponent(jobId)}/artifacts`)
+    }
+
+    getArtifactDownloadUrl(jobId: string, artifactId: string): Promise<any> {
+        return this.request('POST', `/v1/jobs/${encodeURIComponent(jobId)}/artifacts/${encodeURIComponent(artifactId)}/download`)
+    }
+
+    private async request(method: string, path: string, body?: any): Promise<any> {
+        const response = await secureAxiosRequest({
+            url: `${this.baseUrl}${path}`,
+            method,
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                ...jsonHeaders
+            },
+            data: body !== undefined ? removeUndefined(body) : undefined
+        })
+
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error(await responseErrorMessage(response, method, path))
+        }
+
+        if (response.status === 204) return { ok: true }
+
+        if (response.data === undefined || response.data === null || response.data === '') return { ok: true }
+        return response.data
+    }
+}
+
+export type JungleGridAction =
+    | 'estimateJob'
+    | 'submitJob'
+    | 'listJobs'
+    | 'getJob'
+    | 'getJobRuntime'
+    | 'cancelJob'
+    | 'getJobLogs'
+    | 'listJobArtifacts'
+    | 'getArtifactDownloadUrl'
+
+export function createJungleGridTools(client: JungleGridClient, actions: JungleGridAction[]): DynamicStructuredTool[] {
+    const selectedActions = actions.length > 0 ? actions : (Object.keys(toolFactories) as JungleGridAction[])
+    return selectedActions.map((action) => toolFactories[action](client))
+}
+
+class JungleGridTool extends DynamicStructuredTool {
+    private readonly handler: (input: any) => Promise<string>
+
+    constructor(args: { name: string; description: string; schema: any; handler: (input: any) => Promise<string> }) {
+        super({
+            name: args.name,
+            description: args.description,
+            schema: args.schema,
+            baseUrl: '',
+            method: 'GET',
+            headers: {}
+        })
+        this.handler = args.handler
+    }
+
+    async _call(input: any): Promise<string> {
+        return this.handler(input)
+    }
+}
+
+const toolFactories: Record<JungleGridAction, (_client: JungleGridClient) => DynamicStructuredTool> = {
+    estimateJob: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_estimate_job',
+            description:
+                'Estimate a Jungle Grid workload before submission when cost, capacity, routing, or GPU tier matters. Accepts the same verified draft workload fields as submit_job and returns the real production estimate response, including hourly rate/range, runtime, queue/start window, route/capacity, and constraint-relaxation fields when available. Use this before jungle_grid_submit_job if spending credits or capacity selection matters.',
+            schema: estimateJobSchema,
+            handler: async (input) => safeJsonToolCall('jungle_grid_estimate_job', input, () => client.estimateJob(input))
+        }),
+    submitJob: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_submit_job',
+            description:
+                'Submit an asynchronous Jungle Grid workload. This starts remote work and returns a job_id immediately; a returned job_id does not mean the job has finished. Poll jungle_grid_get_job and use jungle_grid_get_job_runtime or jungle_grid_get_job_logs until a terminal status is reached. Never put untrusted secrets in environment variables, command, or args without explicit user permission.',
+            schema: submitJobSchema,
+            handler: async (input) => safeJsonToolCall('jungle_grid_submit_job', input, () => client.submitJob(input))
+        }),
+    listJobs: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_list_jobs',
+            description: 'List recent Jungle Grid jobs for the authenticated account. Use this to find job IDs and recent statuses.',
+            schema: listJobsSchema,
+            handler: async (input) => safeJsonToolCall('jungle_grid_list_jobs', input, () => client.listJobs(input))
+        }),
+    getJob: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_get_job',
+            description:
+                "Get current Jungle Grid job status and details by job_id. Poll this after submit_job until the job reaches a terminal status such as 'completed', 'failed', 'cancelled', or 'rejected'.",
+            schema: jobIdSchema,
+            handler: async (input) => safeJsonToolCall('jungle_grid_get_job', input, () => client.getJob(input.job_id))
+        }),
+    getJobRuntime: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_get_job_runtime',
+            description:
+                'Retrieve runtime tails, exit code, timeout flag, diagnostics, and runtime availability for a Jungle Grid job. Use this to monitor or diagnose running, failed, or completed work.',
+            schema: jobIdSchema,
+            handler: async (input) => safeJsonToolCall('jungle_grid_get_job_runtime', input, () => client.getJobRuntime(input.job_id))
+        }),
+    cancelJob: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_cancel_job',
+            description:
+                'Cancel a pending, queued, assigned, or running Jungle Grid job. This uses the verified production cancel route and has no useful effect on already terminal jobs.',
+            schema: cancelJobSchema,
+            handler: async (input) => safeJsonToolCall('jungle_grid_cancel_job', input, () => client.cancelJob(input.job_id, input.reason))
+        }),
+    getJobLogs: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_get_job_logs',
+            description:
+                'Retrieve available stdout/stderr tails and exit information for a Jungle Grid job. The official MCP package verifies this as the same production runtime endpoint used by get_job_runtime. Use it after submit_job while polling or after terminal status for diagnostics.',
+            schema: jobIdSchema,
+            handler: async (input) => safeJsonToolCall('jungle_grid_get_job_logs', input, () => client.getJobRuntime(input.job_id))
+        }),
+    listJobArtifacts: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_list_job_artifacts',
+            description:
+                'List managed artifacts uploaded by a Jungle Grid job. Retrieve artifacts after successful completion unless the API response explicitly shows partial outputs are available. Managed jobs upload regular files written under /workspace/artifacts.',
+            schema: jobIdSchema,
+            handler: async (input) => safeJsonToolCall('jungle_grid_list_job_artifacts', input, () => client.listJobArtifacts(input.job_id))
+        }),
+    getArtifactDownloadUrl: (client) =>
+        new JungleGridTool({
+            name: 'jungle_grid_get_artifact_download_url',
+            description:
+                'Create a temporary signed download URL for a managed Jungle Grid artifact. Call jungle_grid_list_job_artifacts first and use an artifact_id from that response.',
+            schema: artifactDownloadSchema,
+            handler: async (input) =>
+                safeJsonToolCall('jungle_grid_get_artifact_download_url', input, () =>
+                    client.getArtifactDownloadUrl(input.job_id, input.artifact_id)
+                )
+        })
+}
+
+async function safeJsonToolCall(toolName: string, params: any, call: () => Promise<any>): Promise<string> {
+    try {
+        const result = await call()
+        return JSON.stringify(result)
+    } catch (error) {
+        const message = error instanceof Error ? error.message : typeof error === 'string' ? error : 'Unknown Jungle Grid API error'
+        return formatToolError(`${toolName} failed: ${message}`, redactSensitiveParams(params))
+    }
+}
+
+function normalizeBaseUrl(baseUrl?: string): string {
+    const raw = (baseUrl || DEFAULT_JUNGLE_GRID_BASE_URL).trim()
+    if (!raw) return DEFAULT_JUNGLE_GRID_BASE_URL
+    return raw.replace(/\/+$/, '')
+}
+
+function removeUndefined(value: any): any {
+    if (Array.isArray(value)) {
+        return value.map(removeUndefined)
+    }
+    if (value && typeof value === 'object') {
+        const output: Record<string, any> = {}
+        for (const [key, child] of Object.entries(value)) {
+            if (child !== undefined) output[key] = removeUndefined(child)
+        }
+        return output
+    }
+    return value
+}
+
+function redactSensitiveParams(params: any): any {
+    if (!params || typeof params !== 'object') return params
+    const output: Record<string, any> = {}
+    for (const [key, value] of Object.entries(params)) {
+        if (/token|secret|password|api[_-]?key/i.test(key)) {
+            output[key] = '[REDACTED]'
+        } else if (value && typeof value === 'object' && !Array.isArray(value)) {
+            output[key] = redactSensitiveParams(value)
+        } else {
+            output[key] = value
+        }
+    }
+    return output
+}
+
+async function responseErrorMessage(response: any, method: string, path: string): Promise<string> {
+    const fallback = `${method} ${path} failed with status ${response.status}`
+    const payload = response.data
+    if (payload === undefined || payload === null || payload === '') return fallback
+    if (typeof payload === 'string') {
+        const trimmed = payload.trim()
+        return trimmed ? `${fallback}: ${trimmed}` : fallback
+    }
+
+    const detail = formatApiError(payload)
+    return detail ? `${fallback}: ${detail}` : fallback
+}
+
+function formatApiError(payload: any): string | undefined {
+    if (!payload || typeof payload !== 'object') return undefined
+    if (typeof payload.error === 'string' && payload.error.trim()) return payload.error.trim()
+    if (payload.error && typeof payload.error === 'object') {
+        const code = stringField(payload.error.code)
+        const message = stringField(payload.error.message)
+        if (code && message) return `${code}: ${message}`
+        return message ?? code
+    }
+
+    const code = stringField(payload.code)
+    const message = stringField(payload.message)
+    if (code && message) return `${code}: ${message}`
+    return message ?? code
+}
+
+function stringField(value: any): string | undefined {
+    if (typeof value !== 'string') return undefined
+    const trimmed = value.trim()
+    return trimmed || undefined
+}

--- a/packages/components/nodes/tools/JungleGrid/junglegrid.svg
+++ b/packages/components/nodes/tools/JungleGrid/junglegrid.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Jungle Grid">
+  <rect width="64" height="64" rx="12" fill="#12372A"/>
+  <path d="M14 18h36v28H14z" fill="none" stroke="#6EE7B7" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M26 18v28M38 18v28M14 32h36" stroke="#6EE7B7" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="26" cy="32" r="5" fill="#F8FAFC"/>
+  <circle cx="38" cy="32" r="5" fill="#F8FAFC"/>
+</svg>

--- a/packages/components/src/httpSecurity.ts
+++ b/packages/components/src/httpSecurity.ts
@@ -336,11 +336,7 @@ function createPinnedAgent(target: ResolvedTarget, options?: { ca?: string | str
     const Agent = target.protocol === 'https' ? https.Agent : http.Agent
 
     return new Agent({
-        lookup: (_host, opts, cb) => {
-            if (typeof opts === 'object' && opts?.all) {
-                cb(null, [{ address: target.ip, family: target.family }])
-                return
-            }
+        lookup: (_host, _opts, cb) => {
             cb(null, target.ip, target.family)
         },
         ...options

--- a/packages/components/src/httpSecurity.ts
+++ b/packages/components/src/httpSecurity.ts
@@ -336,7 +336,11 @@ function createPinnedAgent(target: ResolvedTarget, options?: { ca?: string | str
     const Agent = target.protocol === 'https' ? https.Agent : http.Agent
 
     return new Agent({
-        lookup: (_host, _opts, cb) => {
+        lookup: (_host, opts, cb) => {
+            if (typeof opts === 'object' && opts?.all) {
+                cb(null, [{ address: target.ip, family: target.family }])
+                return
+            }
             cb(null, target.ip, target.family)
         },
         ...options


### PR DESCRIPTION
## Summary

Adds a production-ready Jungle Grid Tool integration for asynchronous AI workload execution from Flowise agents.

## What changed

- Adds estimate and submission tools aligned with the current Jungle Grid MCP registry and REST API.
- Supports preferred command arrays while preserving legacy command-plus-args flows.
- Supports `env` / `environment`, uploaded input and script references, expected artifacts, routing aliases, templates, and structured metadata.
- Adds managed job-input upload slot creation and uploaded-input listing.
- Adds lifecycle events for scheduling, capacity lookup, provisioning, input preparation, and startup progress.
- Preserves status and delayed-start fields, separate runtime diagnostics, paginated logs, cancellation, and managed artifacts.
- Uses the configured Jungle Grid API base URL and bearer credential for every request.
- Adds payload validation, response-envelope handling, billing normalization, and recursive error redaction.
- Expands focused Jest coverage and updates the production workflow documentation.

## Production workflow

```text
Estimate
  -> prepare inputs/scripts
  -> submit
  -> inspect status/events
  -> poll logs
  -> retrieve artifacts
```

When files are needed, `Create Job Input Upload` creates a managed slot. The client must upload bytes to the returned temporary URL, complete the upload through the returned completion URL, and then pass the resulting `input_id` to `Submit Job`.

## Safety

- Estimates do not submit workloads or start compute.
- Submissions may spend Jungle Grid credits.
- API keys remain in Flowise credentials and are sent with bearer authentication.
- Secret-like fields, bearer tokens, callback tokens, and signed URLs are redacted from errors.
- Tests use mocked API requests and CI does not run paid workloads.
- Temporary upload and download URLs are returned only as required tool results and are not written to integration logs.

## Backward compatibility

- Existing internal action identifiers remain available.
- Legacy command plus args remains supported.
- `fine_tuning` and the existing `fine-tuning` compatibility value remain accepted.
- `routing_mode` continues to map to `optimize_for`.
- `env` continues to map to `environment`.
- Existing Jungle Grid credential configuration remains valid.
- Existing flows are not intentionally broken.

## Testing

Passed locally:

- `COREPACK_HOME=/tmp/corepack corepack pnpm@10.26.0 --filter flowise-components exec eslint credentials/JungleGridApi.credential.ts nodes/tools/JungleGrid/JungleGrid.ts nodes/tools/JungleGrid/JungleGrid.test.ts nodes/tools/JungleGrid/core.ts nodes/tools/JungleGrid/core.test.ts --ext ts --report-unused-disable-directives --max-warnings 0`
- `NODE_OPTIONS=--max-old-space-size=4096 COREPACK_HOME=/tmp/corepack corepack pnpm@10.26.0 --filter flowise-components exec jest nodes/tools/JungleGrid/core.test.ts nodes/tools/JungleGrid/JungleGrid.test.ts --runInBand` - 2 suites, 27 tests passed
- `NODE_OPTIONS=--max-old-space-size=4096 COREPACK_HOME=/tmp/corepack corepack pnpm@10.26.0 --filter flowise-components build`
- Focused Prettier check for all changed TypeScript and Markdown files
- `git diff --check upstream/main...HEAD`
- Production secret-pattern scan of all changed Jungle Grid files

No live or billable workload was submitted for this update.

## Shared Flowise changes

The earlier `packages/components/src/httpSecurity.ts` modification was removed. The final PR diff is isolated to the Jungle Grid credential, Tool node, shared Jungle Grid client, tests, documentation, and existing icon.
