### PR TITLE
feat(components): add Forge embeddings node

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -2757,6 +2757,23 @@
             ]
         },
         {
+            "name": "forgeEmbeddings",
+            "models": [
+                {
+                    "label": "forge-turbo (1024d)",
+                    "name": "forge-turbo"
+                },
+                {
+                    "label": "forge-pro (2560d)",
+                    "name": "forge-pro"
+                },
+                {
+                    "label": "forge-ultra-4k (4096d)",
+                    "name": "forge-ultra-4k"
+                }
+            ]
+        },
+        {
             "name": "mistralAIEmbeddings",
             "models": [
                 {

--- a/packages/components/nodes/embeddings/ForgeEmbedding/ForgeEmbedding.test.ts
+++ b/packages/components/nodes/embeddings/ForgeEmbedding/ForgeEmbedding.test.ts
@@ -1,0 +1,73 @@
+jest.mock('@langchain/openai', () => ({
+    OpenAIEmbeddings: jest.fn().mockImplementation((fields) => ({ fields }))
+}))
+
+jest.mock('../../../src/utils', () => ({
+    getBaseClasses: jest.fn().mockReturnValue(['Embeddings']),
+    getCredentialData: jest.fn(),
+    getCredentialParam: jest.fn()
+}))
+
+import { getCredentialData, getCredentialParam } from '../../../src/utils'
+
+const { nodeClass: ForgeEmbedding } = require('./ForgeEmbedding')
+
+describe('ForgeEmbedding', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('exposes the expected node metadata', () => {
+        const node = new ForgeEmbedding()
+
+        expect(node.label).toBe('Forge Embedding')
+        expect(node.name).toBe('forgeEmbeddings')
+        expect(node.type).toBe('ForgeEmbeddings')
+        expect(node.icon).toBe('forge.svg')
+        expect(node.category).toBe('Embeddings')
+        expect(node.credential.credentialNames).toEqual(['openAIApi'])
+    })
+
+    it('initializes an embeddings instance pinned to the Forge base URL', async () => {
+        ;(getCredentialData as jest.Mock).mockResolvedValue({ openAIApiKey: 'forge-key' })
+        ;(getCredentialParam as jest.Mock).mockImplementation((key, credentialData) => credentialData[key])
+
+        const node = new ForgeEmbedding()
+        const model = await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    modelName: 'forge-ultra-4k',
+                    dimensions: '4096',
+                    batchSize: '8',
+                    timeout: '15000',
+                    stripNewLines: true
+                }
+            },
+            '',
+            {}
+        )
+
+        expect(model.fields).toMatchObject({
+            openAIApiKey: 'forge-key',
+            modelName: 'forge-ultra-4k',
+            dimensions: 4096,
+            batchSize: 8,
+            timeout: 15000,
+            stripNewLines: true,
+            configuration: {
+                baseURL: 'https://api.voxell.ai/v1'
+            }
+        })
+    })
+
+    it('defaults the base URL even when only the api key is provided', async () => {
+        ;(getCredentialData as jest.Mock).mockResolvedValue({ openAIApiKey: 'forge-key' })
+        ;(getCredentialParam as jest.Mock).mockImplementation((key, credentialData) => credentialData[key])
+
+        const node = new ForgeEmbedding()
+        const model = await node.init({ credential: 'cred-1', inputs: {} }, '', {})
+
+        expect(model.fields.configuration.baseURL).toBe('https://api.voxell.ai/v1')
+    })
+})

--- a/packages/components/nodes/embeddings/ForgeEmbedding/ForgeEmbedding.ts
+++ b/packages/components/nodes/embeddings/ForgeEmbedding/ForgeEmbedding.ts
@@ -1,0 +1,118 @@
+import { ClientOptions, OpenAIEmbeddings, OpenAIEmbeddingsParams } from '@langchain/openai'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+
+class ForgeEmbedding_Embeddings implements INode {
+    label: string
+    name: string
+    version: number
+    type: string
+    icon: string
+    category: string
+    description: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'Forge Embedding'
+        this.name = 'forgeEmbeddings'
+        this.version = 1.0
+        this.type = 'ForgeEmbeddings'
+        this.icon = 'forge.svg'
+        this.category = 'Embeddings'
+        this.description = 'Voxell Forge OpenAI-compatible API to generate embeddings for a given text'
+        this.baseClasses = [this.type, ...getBaseClasses(OpenAIEmbeddings)]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['openAIApi']
+        }
+        this.inputs = [
+            {
+                label: 'Strip New Lines',
+                name: 'stripNewLines',
+                type: 'boolean',
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Batch Size',
+                name: 'batchSize',
+                type: 'number',
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Timeout',
+                name: 'timeout',
+                type: 'number',
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Model Name',
+                name: 'modelName',
+                type: 'string',
+                default: 'forge-pro',
+                optional: true
+            },
+            {
+                label: 'Dimensions',
+                name: 'dimensions',
+                type: 'number',
+                optional: true,
+                additionalParams: true
+            },
+            {
+                label: 'Encoding Format',
+                name: 'encodingFormat',
+                type: 'options',
+                options: [
+                    {
+                        label: 'float',
+                        name: 'float'
+                    },
+                    {
+                        label: 'base64',
+                        name: 'base64'
+                    }
+                ],
+                optional: true,
+                additionalParams: true
+            }
+        ]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const stripNewLines = nodeData.inputs?.stripNewLines as boolean
+        const batchSize = nodeData.inputs?.batchSize as string
+        const timeout = nodeData.inputs?.timeout as string
+        const modelName = nodeData.inputs?.modelName as string
+        const dimensions = nodeData.inputs?.dimensions as string
+        const encodingFormat = nodeData.inputs?.encodingFormat as 'float' | 'base64' | undefined
+
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const openAIApiKey = getCredentialParam('openAIApiKey', credentialData, nodeData)
+
+        const obj: Partial<OpenAIEmbeddingsParams> & { openAIApiKey?: string; configuration?: ClientOptions } = {
+            openAIApiKey,
+            configuration: {
+                baseURL: 'https://api.voxell.ai/v1'
+            }
+        }
+
+        if (stripNewLines) obj.stripNewLines = stripNewLines
+        if (batchSize) obj.batchSize = parseInt(batchSize, 10)
+        if (timeout) obj.timeout = parseInt(timeout, 10)
+        if (modelName) obj.modelName = modelName
+        if (dimensions) obj.dimensions = parseInt(dimensions, 10)
+        if (encodingFormat) obj.encodingFormat = encodingFormat
+
+        const model = new OpenAIEmbeddings(obj)
+        return model
+    }
+}
+
+module.exports = { nodeClass: ForgeEmbedding_Embeddings }

--- a/packages/components/nodes/embeddings/ForgeEmbedding/forge.svg
+++ b/packages/components/nodes/embeddings/ForgeEmbedding/forge.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 2 3 7v10l9 5 9-5V7z" />
+    <path d="M12 22V12" />
+    <path d="M3 7l9 5 9-5" />
+</svg>


### PR DESCRIPTION
## What changed

This PR adds a new Forge embeddings node to Flowise.

Changes included:
- add a new `Forge Embedding` node under `packages/components`
- wrap `@langchain/openai` `OpenAIEmbeddings`, since Forge exposes an OpenAI-compatible embeddings API (`POST /v1/embeddings`, OpenAI request/response shape)
- pin the base URL to the Forge endpoint via `configuration.baseURL = 'https://api.voxell.ai/v1'`
- reuse the existing `openAIApi` credential (users put their Forge API key in the OpenAI API key field — no new credential schema)
- default `modelName` to `forge-pro`; supported models also surfaced in `models.json`:
  - `forge-turbo` (1024d)
  - `forge-pro` (2560d)
  - `forge-ultra-4k` (4096d)
- expose the usual optional embedding parameters: `stripNewLines`, `batchSize`, `timeout`, `dimensions`, `encodingFormat`
- add focused unit tests for node metadata and parameter mapping

## Why this change is needed

Forge is an OpenAI-compatible embeddings provider. Today users can reach it through the OpenAI Custom Embedding node by manually overriding the base path, but there is no first-class node. This adds a small, self-contained node that follows the existing embeddings pattern (closely mirrors `OpenAIEmbeddingCustom`) so the endpoint, default model, and model list are preconfigured.

## User impact

Users can now:
- create embeddings with Forge directly inside Flowise without manually setting a base URL
- pick a Forge model from the shared model list
- configure the standard embedding options (`dimensions`, `batchSize`, etc.) without code changes

## Tests / validation

Validated locally with:
- `pnpm install`
- `pnpm --filter flowise-components build` (tsc + gulp; icon copied to dist)
- targeted unit tests for the new node (3 tests, all passing):
  - `pnpm --filter flowise-components test -- ForgeEmbedding`
- `prettier --check` on the new files and `models.json`

Note: validation covers build and unit tests only; no live call to the Forge API was made as part of this PR.

## Notes for reviewers

This PR intentionally keeps scope small:
- no server-side changes
- no new credential schema (reuses `openAIApi`)
- no new dependencies
- the node reuses the `openAIApi` credential, so the API key is entered in the OpenAI API key field — flagging since that credential-reuse UX is slightly unusual