### PR TITLE
fix(chatopenai): support stop in base options

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -280,28 +280,23 @@ class ChatOpenAI_ChatModels implements INode {
 
         if (baseOptions) {
             try {
-                parsedBaseOptions = typeof baseOptions === 'object' ? baseOptions : JSON.parse(baseOptions)
+                parsedBaseOptions = typeof baseOptions === 'object' ? { ...baseOptions } : JSON.parse(baseOptions)
             } catch (exception) {
                 throw new Error("Invalid JSON in the ChatOpenAI's BaseOptions: " + exception)
             }
         }
 
         if (parsedBaseOptions?.stop) {
-            const stop = parsedBaseOptions.stop
+            const { stop, ...restBaseOptions } = parsedBaseOptions
+            parsedBaseOptions = Object.keys(restBaseOptions).length ? restBaseOptions : undefined
 
-            if (!obj.stop) {
+            if (!isReasoningModelOpenAI(modelName) && !obj.stop) {
                 obj.stop = Array.isArray(stop)
                     ? stop.map((item) => String(item).trim()).filter(Boolean)
                     : String(stop)
                           .split(',')
                           .map((item) => item.trim())
                           .filter(Boolean)
-            }
-
-            delete parsedBaseOptions.stop
-
-            if (Object.keys(parsedBaseOptions).length === 0) {
-                parsedBaseOptions = undefined
             }
         }
 

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -286,6 +286,25 @@ class ChatOpenAI_ChatModels implements INode {
             }
         }
 
+        if (parsedBaseOptions?.stop) {
+            const stop = parsedBaseOptions.stop
+
+            if (!obj.stop) {
+                obj.stop = Array.isArray(stop)
+                    ? stop.map((item) => String(item).trim()).filter(Boolean)
+                    : String(stop)
+                          .split(',')
+                          .map((item) => item.trim())
+                          .filter(Boolean)
+            }
+
+            delete parsedBaseOptions.stop
+
+            if (Object.keys(parsedBaseOptions).length === 0) {
+                parsedBaseOptions = undefined
+            }
+        }
+
         if (basePath || parsedBaseOptions) {
             obj.configuration = {
                 baseURL: basePath,


### PR DESCRIPTION
## Summary

- Support `stop` when provided through ChatOpenAI Base Options.
- Extract `stop` from parsed base options and apply it to the model options instead of sending it as a default header.
- Preserve the existing `Stop Sequence` field behavior by only using Base Options `stop` when `obj.stop` is not already set.

Fixes #2499

## Tests

- `git diff --check`