### PR TITLE
feat: use model dropdown for ChatXAI and add Grok models to catalog

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -2194,6 +2194,36 @@
             ]
         },
         {
+            "name": "chatXAI",
+            "models": [
+                {
+                    "label": "grok-4",
+                    "name": "grok-4",
+                    "description": "Most capable Grok model with advanced reasoning"
+                },
+                {
+                    "label": "grok-3",
+                    "name": "grok-3",
+                    "description": "Flagship model for enterprise and general-purpose tasks"
+                },
+                {
+                    "label": "grok-3-mini",
+                    "name": "grok-3-mini",
+                    "description": "Lightweight Grok model, faster and more cost-effective"
+                },
+                {
+                    "label": "grok-2-vision-1212",
+                    "name": "grok-2-vision-1212",
+                    "description": "Grok 2 with image understanding"
+                },
+                {
+                    "label": "grok-2-1212",
+                    "name": "grok-2-1212",
+                    "description": "Grok 2 text model"
+                }
+            ]
+        },
+        {
             "name": "chatMistralAI",
             "models": [
                 {

--- a/packages/components/nodes/chatmodels/ChatXAI/ChatXAI.ts
+++ b/packages/components/nodes/chatmodels/ChatXAI/ChatXAI.ts
@@ -1,7 +1,8 @@
 import { BaseCache } from '@langchain/core/caches'
 import { ChatXAIInput } from '@langchain/xai'
-import { ICommonObject, IMultiModalOption, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { ICommonObject, IMultiModalOption, INode, INodeData, INodeOptionsValue, INodeParams } from '../../../src/Interface'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { getModels, MODEL_TYPE } from '../../../src/modelLoader'
 import { ChatXAI } from './FlowiseChatXAI'
 
 class ChatXAI_ChatModels implements INode {
@@ -19,7 +20,7 @@ class ChatXAI_ChatModels implements INode {
     constructor() {
         this.label = 'xAI Grok'
         this.name = 'chatXAI'
-        this.version = 2.0
+        this.version = 2.1
         this.type = 'ChatXAI'
         this.icon = 'xai.png'
         this.category = 'Chat Models'
@@ -39,10 +40,11 @@ class ChatXAI_ChatModels implements INode {
                 optional: true
             },
             {
-                label: 'Model',
+                label: 'Model Name',
                 name: 'modelName',
-                type: 'string',
-                placeholder: 'grok-beta'
+                type: 'asyncOptions',
+                loadMethod: 'listModels',
+                default: 'grok-3'
             },
             {
                 label: 'Temperature',
@@ -76,16 +78,14 @@ class ChatXAI_ChatModels implements INode {
                 step: 1,
                 optional: true,
                 additionalParams: true
-            },
-            {
-                label: 'Max Tokens',
-                name: 'maxTokens',
-                type: 'number',
-                step: 1,
-                optional: true,
-                additionalParams: true
             }
         ]
+    }
+
+    loadMethods = {
+        async listModels(_: INodeData, __?: ICommonObject): Promise<INodeOptionsValue[]> {
+            return await getModels(MODEL_TYPE.CHAT, 'chatXAI')
+        }
     }
 
     async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {

--- a/packages/components/nodes/chatmodels/ChatXAI/ChatXAI.ts
+++ b/packages/components/nodes/chatmodels/ChatXAI/ChatXAI.ts
@@ -44,7 +44,8 @@ class ChatXAI_ChatModels implements INode {
                 name: 'modelName',
                 type: 'asyncOptions',
                 loadMethod: 'listModels',
-                default: 'grok-3'
+                default: 'grok-3-mini',
+                freeSolo: true
             },
             {
                 label: 'Temperature',


### PR DESCRIPTION
Align the xAI Grok (ChatXAI) node with the standard chat model nodes by loading its model list from the central `models.json` instead of a free-text input.

### Changes
- **ChatXAI node**: change the `Model` input from a free-text `string` to an `asyncOptions` dropdown (`loadMethod: listModels`), matching ChatAnthropic, ChatOpenAI, ChatCerebras, etc.
- **models.json**: add a `chatXAI` entry to the `chat` catalog with the current Grok models (grok-4, grok-3, grok-3-mini, grok-2-vision-1212, grok-2-1212).
- **Bugfix**: remove a duplicated `Max Tokens` input that was defined twice in the node.
- Bump node version `2.0 → 2.1`.

### Notes
- Backward compatible: `modelName` is still stored/read as a string, so existing flows keep working. The version bump handles node upgrade detection.
- Pricing fields are intentionally omitted (same pattern as the existing `chatCerebras` entry) to avoid committing inaccurate cost values; they can be added in a follow-up once verified.

<img width="321" height="706" alt="image" src="https://github.com/user-attachments/assets/13cfe176-b524-4095-b1fe-b69aa1061a0f" />
