### PR TITLE
fix: detect uploaded file type for uppercase file extensions

### DIFF
--- a/packages/components/src/utils.test.ts
+++ b/packages/components/src/utils.test.ts
@@ -313,4 +313,10 @@ describe('mapExtToInputField', () => {
     it('falls back to txtFile for unknown extensions', () => {
         expect(mapExtToInputField('.unknown')).toBe('txtFile')
     })
+
+    it('falls back to txtFile for empty or nullish extensions', () => {
+        expect(mapExtToInputField('')).toBe('txtFile')
+        expect(mapExtToInputField(undefined)).toBe('txtFile')
+        expect(mapExtToInputField(null as unknown as string)).toBe('txtFile')
+    })
 })

--- a/packages/components/src/utils.test.ts
+++ b/packages/components/src/utils.test.ts
@@ -3,7 +3,8 @@ import {
     convertRequireToImport,
     COMMONJS_REQUIRE_REGEX,
     IMPORT_EXTRACTION_REGEX,
-    executeJavaScriptCode
+    executeJavaScriptCode,
+    mapExtToInputField
 } from './utils'
 
 describe('removeInvalidImageMarkdown', () => {
@@ -286,4 +287,30 @@ describe('NodeVM sandbox — availableDependencies allowlist', () => {
         const result = await executeJavaScriptCode(`const { Client } = require('pg'); return typeof Client`, {}, { timeout: 10000 })
         expect(result).toBe('function')
     }, 15000)
+})
+
+describe('mapExtToInputField', () => {
+    it('maps known lowercase extensions to their input field', () => {
+        expect(mapExtToInputField('.pdf')).toBe('pdfFile')
+        expect(mapExtToInputField('.txt')).toBe('txtFile')
+        expect(mapExtToInputField('.json')).toBe('jsonFile')
+        expect(mapExtToInputField('.csv')).toBe('csvFile')
+        expect(mapExtToInputField('.docx')).toBe('docxFile')
+    })
+
+    it('maps uppercase extensions to the same input field (case-insensitive)', () => {
+        expect(mapExtToInputField('.PDF')).toBe('pdfFile')
+        expect(mapExtToInputField('.TXT')).toBe('txtFile')
+        expect(mapExtToInputField('.JSON')).toBe('jsonFile')
+        expect(mapExtToInputField('.DOCX')).toBe('docxFile')
+    })
+
+    it('maps mixed-case extensions to the same input field', () => {
+        expect(mapExtToInputField('.Pdf')).toBe('pdfFile')
+        expect(mapExtToInputField('.Csv')).toBe('csvFile')
+    })
+
+    it('falls back to txtFile for unknown extensions', () => {
+        expect(mapExtToInputField('.unknown')).toBe('txtFile')
+    })
 })

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -1059,11 +1059,11 @@ export const getVersion: () => Promise<{ version: string }> = async () => {
 
 /**
  * Map Ext to InputField
- * @param {string} ext
+ * @param {string} [ext] File extension (case-insensitive), e.g. ".pdf"
  * @returns {string}
  */
-export const mapExtToInputField = (ext: string) => {
-    switch (ext.toLowerCase()) {
+export const mapExtToInputField = (ext?: string) => {
+    switch (ext?.toLowerCase()) {
         case '.txt':
             return 'txtFile'
         case '.pdf':

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -1063,7 +1063,7 @@ export const getVersion: () => Promise<{ version: string }> = async () => {
  * @returns {string}
  */
 export const mapExtToInputField = (ext: string) => {
-    switch (ext) {
+    switch (ext.toLowerCase()) {
         case '.txt':
             return 'txtFile'
         case '.pdf':

--- a/packages/server/src/utils/createAttachment.ts
+++ b/packages/server/src/utils/createAttachment.ts
@@ -177,7 +177,7 @@ export const createFileAttachment = async (req: Request) => {
             if (fileInputFieldFromExt !== 'txtFile') {
                 fileInputField = fileInputFieldFromExt
             } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                fileInputField = fileInputFieldFromExt
+                fileInputField = fileInputFieldFromMimeType
             }
 
             await removeSpecificFileFromUpload(file.path ?? file.key)


### PR DESCRIPTION
## Description

Uploading a file whose name ends with an uppercase extension (e.g. `report.PDF`) does not work — the file is processed by the plain-text loader instead of the correct one (the PDF loader), producing garbled/empty content. Renaming the file to a lowercase extension (`report.pdf`) works around it.

### Root cause

`mapExtToInputField` (in `packages/components/src/utils.ts`) matches the extension with a **case-sensitive** `switch`. `path.extname('report.PDF')` returns `'.PDF'`, which does not match the `'.pdf'` case and falls through to the default `'txtFile'`, so the wrong file loader input field is selected.

The MIME-type fallback in `createFileAttachment` that should have caught this was also broken by a copy-paste bug: in the `else if (fileInputFieldFromMimeType !== 'txtFile')` branch it assigned `fileInputFieldFromExt` (which is always `'txtFile'` in that branch) instead of `fileInputFieldFromMimeType`, so the MIME-derived field was never used.

### Changes

- `mapExtToInputField`: lowercase the extension before matching, making file-type detection case-insensitive. This is the shared helper used by full file upload, the document store, and chat uploads, so the fix applies consistently across all of them.
- `createFileAttachment`: use `fileInputFieldFromMimeType` in the MIME-type fallback branch so the field derived from the MIME type is actually selected when the extension is unrecognized.
- Added unit tests for `mapExtToInputField` covering lowercase, uppercase, mixed-case, and unknown extensions.

Note: the upload security validator (`validateMimeTypeAndExtensionMatch`) already normalizes the extension to lowercase, so uppercase files were not rejected — only mis-routed. No change to validation behavior.

Fixes #5029

## How to reproduce / verify

1. Enable full file upload on a chatflow.
2. Upload a PDF whose filename ends in `.PDF` (uppercase).
3. Before: the content is parsed as plain text (broken). After: it is parsed by the PDF loader, same as a `.pdf` file.
