### PR TITLE
feat(components): add modelKwargs parameter to OpenAI & Custom OpenAI nodes

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -207,6 +207,15 @@ class ChatOpenAI_ChatModels implements INode {
                 optional: true,
                 description: 'Default headers to include with every request to the API.',
                 additionalParams: true
+            },
+            {
+                label: 'Model Kwargs',
+                name: 'modelKwargs',
+                type: 'json',
+                optional: true,
+                description:
+                    'Additional parameters to pass to the model body, e.g. {"parallel_tool_calls": false} or {"logit_bias": {50256: -100}}',
+                additionalParams: true
             }
         ]
     }
@@ -234,6 +243,7 @@ class ChatOpenAI_ChatModels implements INode {
         const reasoningEffort = nodeData.inputs?.reasoningEffort as OpenAIClient.ReasoningEffort | null
         const reasoningSummary = nodeData.inputs?.reasoningSummary as 'auto' | 'concise' | 'detailed' | null
         const allowImageUploads = nodeData.inputs?.allowImageUploads as boolean
+        const modelKwargs = nodeData.inputs?.modelKwargs
 
         if (nodeData.inputs?.credentialId) {
             nodeData.credential = nodeData.inputs?.credentialId
@@ -262,6 +272,15 @@ class ChatOpenAI_ChatModels implements INode {
             obj.stop = stopSequenceArray
         }
         if (strictToolCalling) obj.supportsStrictToolCalling = strictToolCalling
+
+        if (modelKwargs) {
+            try {
+                const parsedModelKwargs = typeof modelKwargs === 'object' ? modelKwargs : JSON.parse(modelKwargs)
+                obj.modelKwargs = parsedModelKwargs
+            } catch (exception) {
+                throw new Error("Invalid JSON in the ChatOpenAI's Model Kwargs: " + exception)
+            }
+        }
 
         if (isReasoningModelOpenAI(modelName)) {
             delete obj.temperature

--- a/packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.ts
@@ -115,6 +115,15 @@ class ChatOpenAICustom_ChatModels implements INode {
                 optional: true,
                 description: 'Default headers to include with every request to the API.',
                 additionalParams: true
+            },
+            {
+                label: 'Model Kwargs',
+                name: 'modelKwargs',
+                type: 'json',
+                optional: true,
+                description:
+                    'Additional parameters to pass to the model body, e.g. {"parallel_tool_calls": false} or {"logit_bias": {50256: -100}}',
+                additionalParams: true
             }
         ]
     }
@@ -131,6 +140,7 @@ class ChatOpenAICustom_ChatModels implements INode {
         const basePath = nodeData.inputs?.basepath as string
         const baseOptions = nodeData.inputs?.baseOptions
         const cache = nodeData.inputs?.cache as BaseCache
+        const modelKwargs = nodeData.inputs?.modelKwargs
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const openAIApiKey = getCredentialParam('openAIApiKey', credentialData, nodeData)
@@ -149,6 +159,15 @@ class ChatOpenAICustom_ChatModels implements INode {
         if (presencePenalty) obj.presencePenalty = parseFloat(presencePenalty)
         if (timeout) obj.timeout = parseInt(timeout, 10)
         if (cache) obj.cache = cache
+
+        if (modelKwargs) {
+            try {
+                const parsedModelKwargs = typeof modelKwargs === 'object' ? modelKwargs : JSON.parse(modelKwargs)
+                obj.modelKwargs = parsedModelKwargs
+            } catch (exception) {
+                throw new Error("Invalid JSON in the ChatOpenAI's Model Kwargs: " + exception)
+            }
+        }
 
         let parsedBaseOptions: any | undefined = undefined
 

--- a/packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.ts
@@ -165,7 +165,7 @@ class ChatOpenAICustom_ChatModels implements INode {
                 const parsedModelKwargs = typeof modelKwargs === 'object' ? modelKwargs : JSON.parse(modelKwargs)
                 obj.modelKwargs = parsedModelKwargs
             } catch (exception) {
-                throw new Error("Invalid JSON in the ChatOpenAI's Model Kwargs: " + exception)
+                throw new Error("Invalid JSON in the ChatOpenAICustom's Model Kwargs: " + exception)
             }
         }
 


### PR DESCRIPTION
### Description
This PR adds support for custom request parameters (`modelKwargs`) to both the standard **OpenAI** and **OpenAI Custom Model** chat nodes. 

### Why is this needed?
Users employing OpenAI-compatible local/custom backends (such as vLLM, LM Studio, Ollama, etc.) often need to pass custom body parameters (like `repetition_penalty`, `guided_json`, `parallel_tool_calls`, or `logit_bias`) that are not standard, first-class fields on the Flowise model card. 

Adding the `Model Kwargs` JSON input under "Additional Parameters" provides a clean, flexible way to supply these custom configurations directly to the model's constructor without cluttering the main node UI.

### Verification
- Built the packages successfully.
- Code style has been verified and formatted by the built-in pre-commit `pretty-quick` and `eslint` scripts.