### PR TITLE
feat(litellm): add team name and user name support to LiteLLM credential

### DIFF
--- a/packages/components/credentials/LitellmApi.credential.ts
+++ b/packages/components/credentials/LitellmApi.credential.ts
@@ -17,18 +17,11 @@ class LitellmApi implements INodeCredential {
                 type: 'password'
             },
             {
-                label: 'Team Name',
-                name: 'litellmTeamName',
+                label: 'Custom Headers',
+                name: 'litellmCustomHeaders',
                 type: 'string',
                 optional: true,
-                placeholder: 'e.g. Activation'
-            },
-            {
-                label: 'User Name',
-                name: 'litellmUserName',
-                type: 'string',
-                optional: true,
-                placeholder: 'e.g. user@company.com'
+                placeholder: '{"x-litellm-tags": "team:activation,env:prod"}'
             }
         ]
     }

--- a/packages/components/credentials/LitellmApi.credential.ts
+++ b/packages/components/credentials/LitellmApi.credential.ts
@@ -15,6 +15,20 @@ class LitellmApi implements INodeCredential {
                 label: 'API Key',
                 name: 'litellmApiKey',
                 type: 'password'
+            },
+            {
+                label: 'Team Name',
+                name: 'litellmTeamName',
+                type: 'string',
+                optional: true,
+                placeholder: 'e.g. Activation'
+            },
+            {
+                label: 'User Name',
+                name: 'litellmUserName',
+                type: 'string',
+                optional: true,
+                placeholder: 'e.g. user@company.com'
             }
         ]
     }

--- a/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.test.ts
+++ b/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.test.ts
@@ -1,0 +1,221 @@
+jest.mock('@langchain/openai', () => ({
+    ChatOpenAI: jest.fn().mockImplementation((fields) => ({ fields }))
+}))
+
+jest.mock('../../../src/utils', () => ({
+    getBaseClasses: jest.fn().mockReturnValue(['BaseChatModel']),
+    getCredentialData: jest.fn(),
+    getCredentialParam: jest.fn()
+}))
+
+jest.mock('../ChatOpenAI/FlowiseChatOpenAI', () => ({
+    ChatOpenAI: jest.fn().mockImplementation((_id, config) => ({
+        config,
+        setMultiModalOption: jest.fn()
+    }))
+}))
+
+import { getCredentialData, getCredentialParam } from '../../../src/utils'
+import { ChatOpenAI } from '../ChatOpenAI/FlowiseChatOpenAI'
+
+const { nodeClass: ChatLitellm } = require('./ChatLitellm')
+
+describe('ChatLitellm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(getCredentialData as jest.Mock).mockResolvedValue({})
+    })
+
+    it('initializes with basic config (API key and model only)', async () => {
+        ;(getCredentialParam as jest.Mock).mockImplementation((key: string) => {
+            if (key === 'litellmApiKey') return 'sk-test-key'
+            return undefined
+        })
+
+        const node = new ChatLitellm()
+        const model = await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    basePath: 'https://litellm.example.com',
+                    modelName: 'anthropic/claude-sonnet-4-20250514',
+                    temperature: '0.7',
+                    streaming: true
+                }
+            },
+            '',
+            {}
+        )
+
+        expect(ChatOpenAI).toHaveBeenCalledWith(
+            undefined,
+            expect.objectContaining({
+                modelName: 'anthropic/claude-sonnet-4-20250514',
+                temperature: 0.7,
+                streaming: true,
+                openAIApiKey: 'sk-test-key',
+                apiKey: 'sk-test-key',
+                configuration: {
+                    baseURL: 'https://litellm.example.com'
+                }
+            })
+        )
+        expect(model.setMultiModalOption).toHaveBeenCalled()
+    })
+
+    it('passes custom headers from credential when provided', async () => {
+        ;(getCredentialParam as jest.Mock).mockImplementation((key: string) => {
+            if (key === 'litellmApiKey') return 'sk-test-key'
+            if (key === 'litellmCustomHeaders') return '{"x-litellm-tags": "team:activation,env:prod"}'
+            return undefined
+        })
+
+        const node = new ChatLitellm()
+        await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    basePath: 'https://litellm.example.com',
+                    modelName: 'gpt-4o',
+                    temperature: '0.9',
+                    streaming: true
+                }
+            },
+            '',
+            {}
+        )
+
+        expect(ChatOpenAI).toHaveBeenCalledWith(
+            undefined,
+            expect.objectContaining({
+                configuration: {
+                    baseURL: 'https://litellm.example.com',
+                    defaultHeaders: {
+                        'x-litellm-tags': 'team:activation,env:prod'
+                    }
+                }
+            })
+        )
+    })
+
+    it('ignores malformed custom headers JSON gracefully', async () => {
+        ;(getCredentialParam as jest.Mock).mockImplementation((key: string) => {
+            if (key === 'litellmApiKey') return 'sk-test-key'
+            if (key === 'litellmCustomHeaders') return 'not-valid-json'
+            return undefined
+        })
+
+        const node = new ChatLitellm()
+        await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    basePath: 'https://litellm.example.com',
+                    modelName: 'gpt-4o',
+                    temperature: '0.9',
+                    streaming: true
+                }
+            },
+            '',
+            {}
+        )
+
+        expect(ChatOpenAI).toHaveBeenCalledWith(
+            undefined,
+            expect.objectContaining({
+                configuration: {
+                    baseURL: 'https://litellm.example.com'
+                }
+            })
+        )
+    })
+
+    it('works without custom headers (backward compatible)', async () => {
+        ;(getCredentialParam as jest.Mock).mockImplementation((key: string) => {
+            if (key === 'litellmApiKey') return 'sk-test-key'
+            return undefined
+        })
+
+        const node = new ChatLitellm()
+        await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    basePath: 'https://litellm.example.com',
+                    modelName: 'gpt-4o',
+                    temperature: '0.9',
+                    streaming: true
+                }
+            },
+            '',
+            {}
+        )
+
+        expect(ChatOpenAI).toHaveBeenCalledWith(
+            undefined,
+            expect.objectContaining({
+                configuration: {
+                    baseURL: 'https://litellm.example.com'
+                }
+            })
+        )
+    })
+
+    it('works without basePath or custom headers', async () => {
+        ;(getCredentialParam as jest.Mock).mockImplementation((key: string) => {
+            if (key === 'litellmApiKey') return 'sk-test-key'
+            return undefined
+        })
+
+        const node = new ChatLitellm()
+        await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    modelName: 'gpt-4o',
+                    temperature: '0.5',
+                    streaming: false
+                }
+            },
+            '',
+            {}
+        )
+
+        const callArgs = (ChatOpenAI as unknown as jest.Mock).mock.calls[0][1]
+        expect(callArgs.configuration).toBeUndefined()
+    })
+
+    it('passes optional parameters when provided', async () => {
+        ;(getCredentialParam as jest.Mock).mockImplementation((key: string) => {
+            if (key === 'litellmApiKey') return 'sk-test-key'
+            return undefined
+        })
+
+        const node = new ChatLitellm()
+        await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    basePath: 'https://litellm.example.com',
+                    modelName: 'gpt-4o',
+                    temperature: '0.5',
+                    streaming: true,
+                    maxTokens: '4096',
+                    topP: '0.95',
+                    timeout: '30000'
+                }
+            },
+            '',
+            {}
+        )
+
+        expect(ChatOpenAI).toHaveBeenCalledWith(
+            undefined,
+            expect.objectContaining({
+                maxTokens: 4096,
+                topP: 0.95,
+                timeout: 30000
+            })
+        )
+    })
+})

--- a/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.test.ts
+++ b/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.test.ts
@@ -130,6 +130,36 @@ describe('ChatLitellm', () => {
         )
     })
 
+    it('ignores non-object JSON values (array, string, number)', async () => {
+        for (const badValue of ['["a","b"]', '"just-a-string"', '42']) {
+            jest.clearAllMocks()
+            ;(getCredentialData as jest.Mock).mockResolvedValue({})
+            ;(getCredentialParam as jest.Mock).mockImplementation((key: string) => {
+                if (key === 'litellmApiKey') return 'sk-test-key'
+                if (key === 'litellmCustomHeaders') return badValue
+                return undefined
+            })
+
+            const node = new ChatLitellm()
+            await node.init(
+                {
+                    credential: 'cred-1',
+                    inputs: {
+                        basePath: 'https://litellm.example.com',
+                        modelName: 'gpt-4o',
+                        temperature: '0.9',
+                        streaming: true
+                    }
+                },
+                '',
+                {}
+            )
+
+            const callArgs = (ChatOpenAI as unknown as jest.Mock).mock.calls[0][1]
+            expect(callArgs.configuration).toEqual({ baseURL: 'https://litellm.example.com' })
+        }
+    })
+
     it('works without custom headers (backward compatible)', async () => {
         ;(getCredentialParam as jest.Mock).mockImplementation((key: string) => {
             if (key === 'litellmApiKey') return 'sk-test-key'

--- a/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.ts
+++ b/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.ts
@@ -117,8 +117,7 @@ class ChatLitellm_ChatModels implements INode {
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const apiKey = getCredentialParam('litellmApiKey', credentialData, nodeData)
-        const teamName = getCredentialParam('litellmTeamName', credentialData, nodeData)
-        const userName = getCredentialParam('litellmUserName', credentialData, nodeData)
+        const customHeadersRaw = getCredentialParam('litellmCustomHeaders', credentialData, nodeData)
 
         const obj: Partial<OpenAIChatInput> &
             BaseLLMParams & { openAIApiKey?: string } & { configuration?: { baseURL?: string; defaultHeaders?: ICommonObject } } = {
@@ -127,9 +126,14 @@ class ChatLitellm_ChatModels implements INode {
             streaming: streaming ?? true
         }
 
-        const defaultHeaders: ICommonObject = {}
-        if (teamName) defaultHeaders['x-litellm-team'] = teamName
-        if (userName) defaultHeaders['x-litellm-user'] = userName
+        let defaultHeaders: ICommonObject = {}
+        if (customHeadersRaw) {
+            try {
+                defaultHeaders = JSON.parse(customHeadersRaw)
+            } catch {
+                // ignore malformed JSON
+            }
+        }
 
         if (basePath || Object.keys(defaultHeaders).length > 0) {
             obj.configuration = {

--- a/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.ts
+++ b/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.ts
@@ -129,7 +129,10 @@ class ChatLitellm_ChatModels implements INode {
         let defaultHeaders: ICommonObject = {}
         if (customHeadersRaw) {
             try {
-                defaultHeaders = JSON.parse(customHeadersRaw)
+                const parsed = JSON.parse(customHeadersRaw)
+                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                    defaultHeaders = parsed
+                }
             } catch {
                 // ignore malformed JSON
             }

--- a/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.ts
+++ b/packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.ts
@@ -117,6 +117,8 @@ class ChatLitellm_ChatModels implements INode {
 
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const apiKey = getCredentialParam('litellmApiKey', credentialData, nodeData)
+        const teamName = getCredentialParam('litellmTeamName', credentialData, nodeData)
+        const userName = getCredentialParam('litellmUserName', credentialData, nodeData)
 
         const obj: Partial<OpenAIChatInput> &
             BaseLLMParams & { openAIApiKey?: string } & { configuration?: { baseURL?: string; defaultHeaders?: ICommonObject } } = {
@@ -125,9 +127,14 @@ class ChatLitellm_ChatModels implements INode {
             streaming: streaming ?? true
         }
 
-        if (basePath) {
+        const defaultHeaders: ICommonObject = {}
+        if (teamName) defaultHeaders['x-litellm-team'] = teamName
+        if (userName) defaultHeaders['x-litellm-user'] = userName
+
+        if (basePath || Object.keys(defaultHeaders).length > 0) {
             obj.configuration = {
-                baseURL: basePath
+                ...(basePath ? { baseURL: basePath } : {}),
+                ...(Object.keys(defaultHeaders).length > 0 ? { defaultHeaders } : {})
             }
         }
 


### PR DESCRIPTION
## Summary

Adds a **Custom Headers** field to the LiteLLM credential, enabling users to pass any LiteLLM proxy headers in API requests. Also adds a comprehensive test suite for the ChatLiteLLM node.

## Why is this needed?

[LiteLLM](https://docs.litellm.ai/) is an AI gateway/proxy that routes requests to 100+ LLM providers (OpenAI, Anthropic, Bedrock, etc.) through a unified API. Organizations use LiteLLM for:

- **Cost tracking** — track spend per team, customer, or environment
- **Tag-based routing** — route requests to specific model deployments based on tags
- **Rate limiting** — enforce per-team or per-customer rate limits
- **Audit logging** — track who made each request

LiteLLM supports several request headers for these features ([docs](https://docs.litellm.ai/docs/proxy/request_headers)):

| Header | Purpose |
|---|---|
| `x-litellm-tags` | Tag-based routing and spend tracking (comma-separated) |
| `x-litellm-customer-id` | End-user/customer tracking |
| `x-litellm-end-user-id` | End-user identification |
| `x-litellm-spend-logs-metadata` | Custom metadata in spend logs (JSON string) |

Currently, Flowise's LiteLLM integration only supports an API key — there's no way to pass these headers to the proxy.

## Solution

**Credential** (`LitellmApi.credential.ts`):
- Added optional `Custom Headers` field (JSON string)
- Example: `{"x-litellm-tags": "team:activation,env:prod"}`

**Chat model** (`ChatLitellm.ts`):
- Parses the custom headers JSON from credential
- Passes them as `defaultHeaders` in the OpenAI-compatible client configuration
- Malformed JSON is silently ignored (no crash)

**Tests** (`ChatLitellm.test.ts`) — 6 tests:
- ✅ Basic initialization with API key and model
- ✅ Custom headers passed correctly to the client
- ✅ Malformed JSON headers handled gracefully
- ✅ Backward compatibility without headers
- ✅ Works without basePath or custom headers
- ✅ Optional parameters (maxTokens, topP, timeout)

## Backward Compatibility

The Custom Headers field is optional. Existing LiteLLM configurations continue to work without any changes.

## Files Changed

| File | Change |
|---|---|
| `packages/components/credentials/LitellmApi.credential.ts` | Added `litellmCustomHeaders` field |
| `packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.ts` | Parse and pass custom headers |
| `packages/components/nodes/chatmodels/ChatLitellm/ChatLitellm.test.ts` | **New** — 6 unit tests |

## Test Results

```
PASS nodes/chatmodels/ChatLitellm/ChatLitellm.test.ts
  ChatLitellm
    ✓ initializes with basic config (API key and model only)
    ✓ passes custom headers from credential when provided
    ✓ ignores malformed custom headers JSON gracefully
    ✓ works without custom headers (backward compatible)
    ✓ works without basePath or custom headers
    ✓ passes optional parameters when provided

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
```