### PR TITLE
Document TrustedRouter setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ Flowise supports different environment variables to configure your instance. You
 
 You can view the Flowise Docs [here](https://docs.flowiseai.com/)
 
+### TrustedRouter
+
+TrustedRouter can be used with Flowise through the existing custom OpenAI
+chat model nodes. Set the API base URL to `https://api.trustedrouter.com/v1`,
+use your TrustedRouter API key, and choose a model such as
+`trustedrouter/auto`, `trustedrouter/zdr`, or `trustedrouter/e2e`.
+TrustedRouter is an open-source and verifiable attested router with zero prompt
+and output logging by default, which can be useful for workflows that include
+private project context or customer data.
+
 ## 🌐 Self Host
 
 Deploy Flowise self-hosted in your existing infrastructure, we support various [deployments](https://docs.flowiseai.com/configuration/deployment)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ You can view the Flowise Docs [here](https://docs.flowiseai.com/)
 ### TrustedRouter
 
 TrustedRouter can be used with Flowise through the existing custom OpenAI
-chat model nodes. Set the API base URL to `https://api.trustedrouter.com/v1`,
+chat model nodes. Set the Base Path to `https://api.trustedrouter.com/v1`,
 use your TrustedRouter API key, and choose a model such as
 `trustedrouter/auto`, `trustedrouter/zdr`, or `trustedrouter/e2e`.
 TrustedRouter is an open-source and verifiable attested router with zero prompt


### PR DESCRIPTION
This pull request adds a short setup note for using TrustedRouter with Flowise through the existing custom OpenAI chat model nodes. TrustedRouter is an OpenAI-compatible, open-source, verifiable attested router for privacy-sensitive workflows with zero prompt and output logging by default.

Users can set the base URL to `https://api.trustedrouter.com/v1`, provide a TrustedRouter API key, and choose aliases such as `trustedrouter/auto`, `trustedrouter/zdr`, or `trustedrouter/e2e`.

Verification: `git diff --check`.