### PR TITLE
fix(ui): keep sidebar highlight in sync when navigating via the logo (#6510)

### DIFF
--- a/packages/ui/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.jsx
+++ b/packages/ui/src/layout/MainLayout/Sidebar/MenuList/NavItem/index.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { forwardRef, useEffect } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 
 // material-ui
@@ -21,6 +21,7 @@ const NavItem = ({ item, level, navType, onClick, onUploadFile }) => {
     const dispatch = useDispatch()
     const customization = useSelector((state) => state.customization)
     const matchesSM = useMediaQuery(theme.breakpoints.down('lg'))
+    const location = useLocation()
 
     const Icon = item.icon
     const itemIcon = item?.icon ? (
@@ -77,23 +78,24 @@ const NavItem = ({ item, level, navType, onClick, onUploadFile }) => {
         }
     }
 
-    // active menu item on page load
+    // sync the active menu item with the current route, including client-side
+    // navigations such as clicking the logo (re-runs whenever the path changes)
     useEffect(() => {
         if (navType === 'MENU') {
-            const currentIndex = document.location.pathname
+            const currentIndex = location.pathname
                 .toString()
                 .split('/')
                 .findIndex((id) => id === item.id)
             if (currentIndex > -1) {
                 dispatch({ type: MENU_OPEN, id: item.id })
             }
-            if (!document.location.pathname.toString().split('/')[1]) {
+            if (!location.pathname.toString().split('/')[1]) {
                 itemHandler('chatflows')
             }
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [navType])
+    }, [navType, location.pathname])
 
     return (
         <ListItemButton


### PR DESCRIPTION
## Description
Fixes #6510 — after clicking a sidebar item then clicking the Flowise logo to return to Chatflows, the previously selected item stays highlighted instead of Chatflows.

## Root cause
The active sidebar item is derived from Redux `customization.isOpen`. `NavItem` only synced that state to the current route in a **mount-time** effect with deps `[navType]`. Navigating via the logo is a client-side route change that does **not** remount `NavItem` and does not change `navType`, so the effect never re-ran and the stale highlight persisted (and Chatflows was not re-selected).

## Fix
Use react-router's `useLocation()` and add `location.pathname` to the effect's dependency array, so the active item re-syncs on every navigation (including logo clicks). `MENU_OPEN` already replaces `isOpen` with `[id]`, so the previous highlight is cleared correctly.

```diff
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
...
+    const location = useLocation()
...
-    }, [navType])
+    }, [navType, location.pathname])
```

## Testing
- `eslint` and `prettier --check` pass on the changed file (also enforced by the pre-commit hook).
- Manual: select Credentials/Tools → click the logo → Chatflows is now highlighted and the old item is cleared.