### PR TITLE
fix: prevent marketplace filter layout shift

### DIFF
--- a/packages/ui/src/views/marketplaces/index.jsx
+++ b/packages/ui/src/views/marketplaces/index.jsx
@@ -481,7 +481,8 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            minWidth: 120
+                                            minWidth: 120,
+                                            maxWidth: 120
                                         }}
                                     >
                                         <InputLabel size='small' id='filter-badge-label'>
@@ -517,7 +518,8 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            minWidth: 120
+                                            minWidth: 120,
+                                            maxWidth: 120
                                         }}
                                     >
                                         <InputLabel size='small' id='type-badge-label'>
@@ -553,7 +555,8 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            minWidth: 120
+                                            minWidth: 120,
+                                            maxWidth: 120
                                         }}
                                     >
                                         <InputLabel size='small' id='type-fw-label'>


### PR DESCRIPTION
### Dropdown selection changes component width and causes layout wrapping #6518

Hey, Its a simple UI issue. Fixed dropdown width expansion by setting maxWidth equal to minWidth on the FormControl components.
<img width="1359" height="683" alt="Screenshot 2026-06-15 125426" src="https://github.com/user-attachments/assets/48932cd5-a620-446d-b8db-1d1ad23c5244" />
