### PR TITLE
fix(agentflow): preserve usage_metadata when LLM node uses structured output

### DIFF
--- a/packages/components/nodes/agentflow/LLM/LLM.ts
+++ b/packages/components/nodes/agentflow/LLM/LLM.ts
@@ -454,7 +454,7 @@ class LLM_Agentflow implements INode {
             // Configure structured output if specified
             const isStructuredOutput = _llmStructuredOutput && Array.isArray(_llmStructuredOutput) && _llmStructuredOutput.length > 0
             if (isStructuredOutput) {
-                llmNodeInstance = configureStructuredOutput(llmNodeInstance, _llmStructuredOutput)
+                llmNodeInstance = configureStructuredOutput(llmNodeInstance, _llmStructuredOutput, true)
             }
 
             // Initialize response and determine if streaming is possible
@@ -515,7 +515,7 @@ class LLM_Agentflow implements INode {
                     // throw on a non-object. Attach as NON-enumerable so the structured-field copy / content
                     // serialization below isn't polluted, while prepareOutputObject can still read
                     // response.usage_metadata / .response_metadata.
-                    if (response && typeof response === 'object') {
+                    if (response && typeof response === 'object' && Object.isExtensible(response)) {
                         if (rawMessage?.usage_metadata) {
                             Object.defineProperty(response, 'usage_metadata', {
                                 value: rawMessage.usage_metadata,

--- a/packages/components/nodes/agentflow/LLM/LLM.ts
+++ b/packages/components/nodes/agentflow/LLM/LLM.ts
@@ -511,23 +511,27 @@ class LLM_Agentflow implements INode {
                         throw (response as any).parsing_error ?? new Error('Structured output parsing failed')
                     }
                     response = (response as any).parsed
-                    // Attach as NON-enumerable so the structured-field copy / content serialization below isn't
-                    // polluted, while prepareOutputObject can still read response.usage_metadata / .response_metadata.
-                    if (rawMessage?.usage_metadata) {
-                        Object.defineProperty(response, 'usage_metadata', {
-                            value: rawMessage.usage_metadata,
-                            enumerable: false,
-                            writable: true,
-                            configurable: true
-                        })
-                    }
-                    if (rawMessage?.response_metadata) {
-                        Object.defineProperty(response, 'response_metadata', {
-                            value: rawMessage.response_metadata,
-                            enumerable: false,
-                            writable: true,
-                            configurable: true
-                        })
+                    // Guard: a structured schema could resolve to a primitive — Object.defineProperty would
+                    // throw on a non-object. Attach as NON-enumerable so the structured-field copy / content
+                    // serialization below isn't polluted, while prepareOutputObject can still read
+                    // response.usage_metadata / .response_metadata.
+                    if (response && typeof response === 'object') {
+                        if (rawMessage?.usage_metadata) {
+                            Object.defineProperty(response, 'usage_metadata', {
+                                value: rawMessage.usage_metadata,
+                                enumerable: false,
+                                writable: true,
+                                configurable: true
+                            })
+                        }
+                        if (rawMessage?.response_metadata) {
+                            Object.defineProperty(response, 'response_metadata', {
+                                value: rawMessage.response_metadata,
+                                enumerable: false,
+                                writable: true,
+                                configurable: true
+                            })
+                        }
                     }
                 }
 

--- a/packages/components/nodes/agentflow/LLM/LLM.ts
+++ b/packages/components/nodes/agentflow/LLM/LLM.ts
@@ -494,8 +494,10 @@ class LLM_Agentflow implements INode {
                 response = await llmNodeInstance.invoke(messages, { signal: abortController?.signal })
 
                 // With structured output, withStructuredOutput({ includeRaw: true }) returns { raw, parsed }.
-                // Normalize back to the parsed value (preserving existing behavior) and re-attach the
-                // underlying AIMessage's usage_metadata so token usage / cost is still surfaced downstream.
+                // Continue with the parsed structured object (as before), but re-attach the raw AIMessage's
+                // usage_metadata and response_metadata so token usage/cost tracking and downstream metadata
+                // features keep working. Do NOT fall back to the raw message as the response value — the
+                // structured-field copy below would then pollute the output with internal LangChain props.
                 if (
                     isStructuredOutput &&
                     response &&
@@ -504,9 +506,16 @@ class LLM_Agentflow implements INode {
                     'raw' in response
                 ) {
                     const rawMessage = (response as any).raw
-                    response = (response as any).parsed ?? rawMessage
-                    if (rawMessage?.usage_metadata && response && typeof response === 'object') {
+                    if ((response as any).parsed == null) {
+                        // structured parsing failed — surface the error (matches prior throw-on-parse-failure)
+                        throw (response as any).parsing_error ?? new Error('Structured output parsing failed')
+                    }
+                    response = (response as any).parsed
+                    if (rawMessage?.usage_metadata) {
                         ;(response as any).usage_metadata = rawMessage.usage_metadata
+                    }
+                    if (rawMessage?.response_metadata) {
+                        ;(response as any).response_metadata = rawMessage.response_metadata
                     }
                 }
 

--- a/packages/components/nodes/agentflow/LLM/LLM.ts
+++ b/packages/components/nodes/agentflow/LLM/LLM.ts
@@ -511,11 +511,23 @@ class LLM_Agentflow implements INode {
                         throw (response as any).parsing_error ?? new Error('Structured output parsing failed')
                     }
                     response = (response as any).parsed
+                    // Attach as NON-enumerable so the structured-field copy / content serialization below isn't
+                    // polluted, while prepareOutputObject can still read response.usage_metadata / .response_metadata.
                     if (rawMessage?.usage_metadata) {
-                        ;(response as any).usage_metadata = rawMessage.usage_metadata
+                        Object.defineProperty(response, 'usage_metadata', {
+                            value: rawMessage.usage_metadata,
+                            enumerable: false,
+                            writable: true,
+                            configurable: true
+                        })
                     }
                     if (rawMessage?.response_metadata) {
-                        ;(response as any).response_metadata = rawMessage.response_metadata
+                        Object.defineProperty(response, 'response_metadata', {
+                            value: rawMessage.response_metadata,
+                            enumerable: false,
+                            writable: true,
+                            configurable: true
+                        })
                     }
                 }
 

--- a/packages/components/nodes/agentflow/LLM/LLM.ts
+++ b/packages/components/nodes/agentflow/LLM/LLM.ts
@@ -493,6 +493,23 @@ class LLM_Agentflow implements INode {
             } else {
                 response = await llmNodeInstance.invoke(messages, { signal: abortController?.signal })
 
+                // With structured output, withStructuredOutput({ includeRaw: true }) returns { raw, parsed }.
+                // Normalize back to the parsed value (preserving existing behavior) and re-attach the
+                // underlying AIMessage's usage_metadata so token usage / cost is still surfaced downstream.
+                if (
+                    isStructuredOutput &&
+                    response &&
+                    typeof response === 'object' &&
+                    'parsed' in response &&
+                    'raw' in response
+                ) {
+                    const rawMessage = (response as any).raw
+                    response = (response as any).parsed ?? rawMessage
+                    if (rawMessage?.usage_metadata && response && typeof response === 'object') {
+                        ;(response as any).usage_metadata = rawMessage.usage_metadata
+                    }
+                }
+
                 // Stream whole response back to UI if this is the last node
                 if (isLastNode && options.sseStreamer) {
                     const sseStreamer: IServerSideEventStreamer = options.sseStreamer as IServerSideEventStreamer

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -2120,7 +2120,11 @@ export async function parseWithTypeConversion<T extends z.ZodTypeAny>(schema: T,
  * @param {any[]} structuredOutput - Array of structured output schema definitions
  * @returns {BaseChatModel} - The configured LLM instance
  */
-export const configureStructuredOutput = (llmNodeInstance: BaseChatModel, structuredOutput: any[]): BaseChatModel => {
+export const configureStructuredOutput = (
+    llmNodeInstance: BaseChatModel,
+    structuredOutput: any[],
+    includeRaw?: boolean
+): BaseChatModel => {
     try {
         const zodObj: ICommonObject = {}
         for (const sch of structuredOutput) {
@@ -2168,7 +2172,7 @@ export const configureStructuredOutput = (llmNodeInstance: BaseChatModel, struct
         // usage/cost can never be reported. The LLM Agentflow node re-attaches it after invoke().
         return llmNodeInstance.withStructuredOutput(structuredOutputSchema, {
             method: 'functionCalling',
-            includeRaw: true
+            includeRaw: includeRaw ?? false
         })
     } catch (exception) {
         console.error(exception)

--- a/packages/components/src/utils.ts
+++ b/packages/components/src/utils.ts
@@ -2163,8 +2163,12 @@ export const configureStructuredOutput = (llmNodeInstance: BaseChatModel, struct
         const structuredOutputSchema = z.object(zodObj)
 
         // @ts-ignore
+        // includeRaw returns { raw, parsed } so callers can recover the underlying AIMessage's
+        // usage_metadata (token usage / cost). Without it, structured output discards the AIMessage and
+        // usage/cost can never be reported. The LLM Agentflow node re-attaches it after invoke().
         return llmNodeInstance.withStructuredOutput(structuredOutputSchema, {
-            method: 'functionCalling'
+            method: 'functionCalling',
+            includeRaw: true
         })
     } catch (exception) {
         console.error(exception)


### PR DESCRIPTION
## Problem

The AgentFlow **LLM** node already reports token usage/cost — `prepareOutputObject` sets `output.usageMetadata` from `response.usage_metadata`, and `calculateUsageCost` derives cost from it.

But when **JSON Structured Output** is enabled on the node, `configureStructuredOutput()` (`packages/components/src/utils.ts`) wraps the model with:

```ts
llm.withStructuredOutput(schema, { method: 'functionCalling' })
```

so `.invoke()` resolves to **only the parsed object** — the underlying `AIMessage` (which carries `usage_metadata`) is discarded. By the time `prepareOutputObject` runs, `response.usage_metadata` is `undefined`, so **`usageMetadata` is never emitted**.

**Net effect:** any AgentFlow LLM node using structured output reports **no token usage and no cost** (missing from `agentFlowExecutedData`, analytics, etc.).

## Repro

1. Build an AgentFlow with an LLM node and enable **JSON Structured Output** (any schema).
2. Run a prediction and inspect the LLM node in `agentFlowExecutedData`.
3. `output.usageMetadata` is **absent**. Disable structured output → it reappears.

## Fix

- `configureStructuredOutput`: add `includeRaw: true`, so `withStructuredOutput` returns `{ raw, parsed }`.
- `LLM_Agentflow.run()`: immediately after the structured `invoke()`, normalize `{ raw, parsed }` back to the parsed value (preserving existing behavior) and re-attach `raw.usage_metadata`.

Existing behavior (content extraction, the structured-field copy in `prepareOutputObject`) is unchanged — only usage is recovered. This also restores `cache_read_input_tokens` / `cache_creation_input_tokens`, enabling prompt-cache accounting.

_2 files, +22/−1._
