### PR TITLE
feat(chatopenai): add Model Kwargs input for extra request-body params

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -305,7 +305,11 @@ class ChatOpenAI_ChatModels implements INode {
 
         if (modelKwargs) {
             try {
-                obj.modelKwargs = typeof modelKwargs === 'object' ? modelKwargs : JSON.parse(modelKwargs)
+                const parsed = typeof modelKwargs === 'object' ? modelKwargs : JSON.parse(modelKwargs)
+                if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                    throw new Error('Model Kwargs must be a JSON object')
+                }
+                obj.modelKwargs = parsed
             } catch (exception) {
                 throw new Error("Invalid JSON in the ChatOpenAI's Model Kwargs: " + exception)
             }

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -303,9 +303,10 @@ class ChatOpenAI_ChatModels implements INode {
             }
         }
 
-        if (modelKwargs) {
+        const trimmedModelKwargs = typeof modelKwargs === 'string' ? modelKwargs.trim() : modelKwargs
+        if (trimmedModelKwargs) {
             try {
-                const parsed = typeof modelKwargs === 'object' ? modelKwargs : JSON.parse(modelKwargs)
+                const parsed = typeof trimmedModelKwargs === 'object' ? trimmedModelKwargs : JSON.parse(trimmedModelKwargs)
                 if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
                     throw new Error('Model Kwargs must be a JSON object')
                 }

--- a/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAI/ChatOpenAI.ts
@@ -207,6 +207,15 @@ class ChatOpenAI_ChatModels implements INode {
                 optional: true,
                 description: 'Default headers to include with every request to the API.',
                 additionalParams: true
+            },
+            {
+                label: 'Model Kwargs',
+                name: 'modelKwargs',
+                type: 'json',
+                optional: true,
+                description:
+                    'Additional parameters merged into the request body sent to the model API — e.g. provider-specific options not exposed as dedicated fields (such as prompt-caching directives). Use with caution.',
+                additionalParams: true
             }
         ]
     }
@@ -231,6 +240,7 @@ class ChatOpenAI_ChatModels implements INode {
         const strictToolCalling = nodeData.inputs?.strictToolCalling as boolean
         const basePath = nodeData.inputs?.basepath as string
         const baseOptions = nodeData.inputs?.baseOptions
+        const modelKwargs = nodeData.inputs?.modelKwargs
         const reasoningEffort = nodeData.inputs?.reasoningEffort as OpenAIClient.ReasoningEffort | null
         const reasoningSummary = nodeData.inputs?.reasoningSummary as 'auto' | 'concise' | 'detailed' | null
         const allowImageUploads = nodeData.inputs?.allowImageUploads as boolean
@@ -290,6 +300,14 @@ class ChatOpenAI_ChatModels implements INode {
             obj.configuration = {
                 baseURL: basePath,
                 defaultHeaders: parsedBaseOptions
+            }
+        }
+
+        if (modelKwargs) {
+            try {
+                obj.modelKwargs = typeof modelKwargs === 'object' ? modelKwargs : JSON.parse(modelKwargs)
+            } catch (exception) {
+                throw new Error("Invalid JSON in the ChatOpenAI's Model Kwargs: " + exception)
             }
         }
 


### PR DESCRIPTION
## Problem

The **ChatOpenAI** node has no way to pass arbitrary **request-body** parameters to the model API. The existing `Base Options` input only sets HTTP `defaultHeaders` (client/transport config), and there is no `modelKwargs` input — even though LangChain's `ChatOpenAI` supports `modelKwargs` (and other nodes such as `Deepseek` already set it internally for provider-specific options like `thinking`).

This blocks any provider-specific body parameter that isn't exposed as a dedicated field. A concrete example: enabling **Anthropic prompt caching** when ChatOpenAI points at an OpenAI-compatible proxy (e.g. LiteLLM → Vertex/Anthropic), which is triggered by a body param such as `cache_control_injection_points`. There's currently no UI path to send it.

## Change

Add an optional **`Model Kwargs`** JSON input (under *Additional Parameters*, mirroring `Base Options`). It is parsed and assigned to `obj.modelKwargs`, which LangChain merges into the request body.

- Optional and additive — no behavior change when left empty.
- Generic: works for any extra body param (prompt-cache directives, `logit_bias`, provider-specific flags, …).
- Invalid JSON throws a clear error, consistent with the existing `Base Options` handling.

## Example

```json
{ "cache_control_injection_points": [{ "location": "message", "role": "system" }] }
```

…lets a proxy add Anthropic `cache_control` to the system prompt, enabling prompt caching (large repeated system prompts then bill cached reads at ~0.1×).

_1 file, +18/−0._
