### PR TITLE
feat: add MuAPI image generation tool node

### DIFF
--- a/packages/components/credentials/MuApiApi.credential.ts
+++ b/packages/components/credentials/MuApiApi.credential.ts
@@ -1,0 +1,24 @@
+import { INodeParams, INodeCredential } from '../src/Interface'
+
+class MuApiApi implements INodeCredential {
+    label: string
+    name: string
+    version: number
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'MuAPI API'
+        this.name = 'muApiApi'
+        this.version = 1.0
+        this.inputs = [
+            {
+                label: 'MuAPI API Key',
+                name: 'muApiKey',
+                type: 'password',
+                description: 'Get your API key at https://muapi.ai/dashboard/api-keys'
+            }
+        ]
+    }
+}
+
+module.exports = { credClass: MuApiApi }

--- a/packages/components/nodes/tools/MuAPIImage/MuAPIImage.ts
+++ b/packages/components/nodes/tools/MuAPIImage/MuAPIImage.ts
@@ -28,6 +28,10 @@ const IMAGE_MODELS = [
 ] as const
 
 async function submitAndPoll(apiKey: string, endpoint: string, payload: object): Promise<string> {
+    if (!apiKey) {
+        throw new Error('MuAPI API key is not configured. Please set it in the credential.')
+    }
+
     const submitResp = await fetch(`${BASE_URL}/${endpoint}`, {
         method: 'POST',
         headers: { 'x-api-key': apiKey, 'Content-Type': 'application/json' },
@@ -37,7 +41,11 @@ async function submitAndPoll(apiKey: string, endpoint: string, payload: object):
         const err = await submitResp.text()
         throw new Error(`MuAPI submit error (${submitResp.status}): ${err}`)
     }
-    const { request_id } = await submitResp.json()
+    const submitData = await submitResp.json()
+    const request_id: string | undefined = submitData?.request_id
+    if (!request_id) {
+        throw new Error(`MuAPI did not return a request_id. Response: ${JSON.stringify(submitData)}`)
+    }
 
     const deadline = Date.now() + 300_000
     while (Date.now() < deadline) {
@@ -47,6 +55,7 @@ async function submitAndPoll(apiKey: string, endpoint: string, payload: object):
         })
         if (!pollResp.ok) throw new Error(`MuAPI poll error (${pollResp.status})`)
         const data = await pollResp.json()
+        if (!data) throw new Error('MuAPI poll returned an empty response')
         if (data.status === 'completed') {
             const outputs: string[] = data.outputs ?? []
             if (!outputs.length) throw new Error('Generation completed but returned no outputs')
@@ -118,6 +127,10 @@ class MuAPIImage_Tools implements INode {
     async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const apiKey = getCredentialParam('muApiKey', credentialData, nodeData)
+
+        if (!apiKey) {
+            throw new Error('MuAPI API key is missing. Please configure it in the credential settings.')
+        }
 
         const model = (nodeData.inputs?.model as string) ?? 'flux-schnell'
         const toolName = (nodeData.inputs?.toolName as string) ?? 'generate_image'

--- a/packages/components/nodes/tools/MuAPIImage/MuAPIImage.ts
+++ b/packages/components/nodes/tools/MuAPIImage/MuAPIImage.ts
@@ -1,0 +1,151 @@
+import { DynamicStructuredTool } from '@langchain/core/tools'
+import { z } from 'zod'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+
+const BASE_URL = 'https://api.muapi.ai/api/v1'
+
+const IMAGE_MODELS = [
+    'flux-schnell',
+    'flux-dev',
+    'flux-kontext-dev',
+    'flux-kontext-pro',
+    'flux-kontext-max',
+    'hidream-fast',
+    'hidream-dev',
+    'hidream-full',
+    'midjourney',
+    'gpt4o',
+    'gpt-image-2',
+    'imagen4',
+    'imagen4-fast',
+    'seedream',
+    'reve',
+    'ideogram',
+    'hunyuan',
+    'wan2.1',
+    'qwen'
+] as const
+
+async function submitAndPoll(apiKey: string, endpoint: string, payload: object): Promise<string> {
+    const submitResp = await fetch(`${BASE_URL}/${endpoint}`, {
+        method: 'POST',
+        headers: { 'x-api-key': apiKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    })
+    if (!submitResp.ok) {
+        const err = await submitResp.text()
+        throw new Error(`MuAPI submit error (${submitResp.status}): ${err}`)
+    }
+    const { request_id } = await submitResp.json()
+
+    const deadline = Date.now() + 300_000
+    while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 3000))
+        const pollResp = await fetch(`${BASE_URL}/predictions/${request_id}/result`, {
+            headers: { 'x-api-key': apiKey }
+        })
+        if (!pollResp.ok) throw new Error(`MuAPI poll error (${pollResp.status})`)
+        const data = await pollResp.json()
+        if (data.status === 'completed') {
+            const outputs: string[] = data.outputs ?? []
+            if (!outputs.length) throw new Error('Generation completed but returned no outputs')
+            return outputs[0]
+        }
+        if (data.status === 'failed' || data.status === 'cancelled') {
+            throw new Error(`Generation ${data.status}: ${data.error ?? ''}`)
+        }
+    }
+    throw new Error('MuAPI generation timed out after 5 minutes')
+}
+
+class MuAPIImage_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'MuAPI Image Generation'
+        this.name = 'muAPIImage'
+        this.version = 1.0
+        this.type = 'MuAPIImage'
+        this.icon = 'muapi.svg'
+        this.category = 'Tools'
+        this.description =
+            'Generate images from text prompts using muapi.ai — a unified API for 400+ models including Flux, Midjourney, GPT-4o Image, Imagen 4, Seedream, HiDream, and more.'
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['muApiApi']
+        }
+        this.inputs = [
+            {
+                label: 'Model',
+                name: 'model',
+                type: 'options',
+                options: IMAGE_MODELS.map((m) => ({ label: m, name: m })),
+                default: 'flux-schnell',
+                description: 'The image generation model to use'
+            },
+            {
+                label: 'Tool Name',
+                name: 'toolName',
+                type: 'string',
+                default: 'generate_image',
+                description: 'Name of the tool as exposed to the LLM agent'
+            },
+            {
+                label: 'Tool Description',
+                name: 'toolDescription',
+                type: 'string',
+                rows: 3,
+                default:
+                    'Generate an image from a text description using muapi.ai. Returns the URL of the generated image.',
+                description: 'Description shown to the LLM to guide tool use'
+            }
+        ]
+        this.baseClasses = [this.type, ...getBaseClasses(DynamicStructuredTool)]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const apiKey = getCredentialParam('muApiKey', credentialData, nodeData)
+
+        const model = (nodeData.inputs?.model as string) ?? 'flux-schnell'
+        const toolName = (nodeData.inputs?.toolName as string) ?? 'generate_image'
+        const toolDescription =
+            (nodeData.inputs?.toolDescription as string) ??
+            'Generate an image from a text description using muapi.ai. Returns the URL of the generated image.'
+
+        return new DynamicStructuredTool({
+            name: toolName,
+            description: toolDescription,
+            schema: z.object({
+                prompt: z.string().describe('Text description of the image to generate'),
+                width: z.number().optional().describe('Image width in pixels'),
+                height: z.number().optional().describe('Image height in pixels')
+            }),
+            func: async ({ prompt, width, height }) => {
+                const payload: Record<string, unknown> = { prompt }
+                if (width) payload.width = width
+                if (height) payload.height = height
+                try {
+                    const url = await submitAndPoll(apiKey, model, payload)
+                    return JSON.stringify({ image_url: url, model, prompt })
+                } catch (e: any) {
+                    return `Error: ${e.message}`
+                }
+            }
+        })
+    }
+}
+
+module.exports = { nodeClass: MuAPIImage_Tools }

--- a/packages/components/nodes/tools/MuAPIImage/muapi.svg
+++ b/packages/components/nodes/tools/MuAPIImage/muapi.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <rect width="40" height="40" rx="8" fill="#6366F1"/>
+  <text x="20" y="26" font-family="Arial" font-size="14" font-weight="bold" fill="white" text-anchor="middle">M</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds a **MuAPI Image Generation** tool node — backed by [muapi.ai](https://muapi.ai), a unified API for 400+ generative media models.

### What this adds

- `packages/components/nodes/tools/MuAPIImage/MuAPIImage.ts` — `MuAPIImage_Tools` node
- `packages/components/credentials/MuApiApi.credential.ts` — `MuApiApi` credential

### Features

- Wraps muapi.ai's submit → poll pattern in a `DynamicStructuredTool`
- Configurable model selector: `flux-schnell`, `flux-dev`, `flux-kontext-dev/pro/max`, `hidream-fast/dev/full`, `midjourney`, `gpt4o`, `gpt-image-2`, `imagen4`, `seedream`, `reve`, `ideogram`, `hunyuan`, `wan2.1`, `qwen`
- Tool name and description are editable in the UI (so agents know when to call it)
- Credential managed via Flowise's secure credential store
- No new npm dependencies — uses `@langchain/core/tools` (`DynamicStructuredTool`) and `zod`, already in the bundle

### Usage

1. Add **MuAPI Image Generation** node to your canvas
2. Connect your MuAPI API credential (get one at [muapi.ai/dashboard/api-keys](https://muapi.ai/dashboard/api-keys))
3. Select a model (default: `flux-schnell`)
4. Connect to an Agent node — the agent will call it when asked to generate images