### PR TITLE
fix(nodes): decode base64 embeddings to prevent vector store crashes

### DIFF
--- a/packages/components/nodes/embeddings/OpenAIEmbedding/OpenAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/OpenAIEmbedding/OpenAIEmbedding.ts
@@ -3,6 +3,20 @@ import { ICommonObject, INode, INodeData, INodeOptionsValue, INodeParams } from 
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 import { MODEL_TYPE, getModels } from '../../../src/modelLoader'
 
+/**
+ * Decodes a base64-encoded embedding string into a number[].
+ * OpenAI's base64 encoding uses little-endian IEEE 754 float32 (4 bytes per float).
+ *
+ * This is needed because LangChain's OpenAIEmbeddings does not decode base64 responses —
+ * it passes the raw base64 string through as the embedding value, which causes downstream
+ * vector stores (e.g. Chroma) to crash with "TypeError: e.every is not a function".
+ */
+function decodeBase64Embedding(base64String: string): number[] {
+    const binaryBuffer = Buffer.from(base64String, 'base64')
+    const float32Array = new Float32Array(binaryBuffer.buffer, binaryBuffer.byteOffset, binaryBuffer.byteLength / 4)
+    return Array.from(float32Array)
+}
+
 class OpenAIEmbedding_Embeddings implements INode {
     label: string
     name: string
@@ -154,6 +168,24 @@ class OpenAIEmbedding_Embeddings implements INode {
         }
 
         const model = new OpenAIEmbeddings(obj)
+
+        // If encoding format is base64, wrap the embedding methods to decode base64 responses
+        // into proper number[] arrays. LangChain's OpenAIEmbeddings does not handle this —
+        // it passes raw base64 strings through, causing vector stores to crash.
+        if (encodingFormat === 'base64') {
+            const originalEmbedDocuments = model.embedDocuments.bind(model)
+            model.embedDocuments = async (texts: string[]): Promise<number[][]> => {
+                const results = await originalEmbedDocuments(texts)
+                return results.map((embedding: any) => (typeof embedding === 'string' ? decodeBase64Embedding(embedding) : embedding))
+            }
+
+            const originalEmbedQuery = model.embedQuery.bind(model)
+            model.embedQuery = async (text: string): Promise<number[]> => {
+                const result = await originalEmbedQuery(text)
+                return typeof result === 'string' ? decodeBase64Embedding(result as any) : result
+            }
+        }
+
         return model
     }
 }

--- a/packages/components/nodes/embeddings/OpenAIEmbedding/OpenAIEmbedding.ts
+++ b/packages/components/nodes/embeddings/OpenAIEmbedding/OpenAIEmbedding.ts
@@ -13,7 +13,8 @@ import { MODEL_TYPE, getModels } from '../../../src/modelLoader'
  */
 function decodeBase64Embedding(base64String: string): number[] {
     const binaryBuffer = Buffer.from(base64String, 'base64')
-    const float32Array = new Float32Array(binaryBuffer.buffer, binaryBuffer.byteOffset, binaryBuffer.byteLength / 4)
+    const arrayBuffer = binaryBuffer.buffer.slice(binaryBuffer.byteOffset, binaryBuffer.byteOffset + binaryBuffer.byteLength)
+    const float32Array = new Float32Array(arrayBuffer)
     return Array.from(float32Array)
 }
 

--- a/packages/components/nodes/embeddings/OpenAIEmbeddingCustom/OpenAIEmbeddingCustom.ts
+++ b/packages/components/nodes/embeddings/OpenAIEmbeddingCustom/OpenAIEmbeddingCustom.ts
@@ -2,6 +2,17 @@ import { ClientOptions, OpenAIEmbeddings, OpenAIEmbeddingsParams } from '@langch
 import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 
+/**
+ * Decodes OpenAI base64 embeddings into `number[]`.
+ * Required because LangChain returns the raw base64 string,
+ * while vector stores expect a numeric embedding array.
+ */
+function decodeBase64Embedding(base64String: string): number[] {
+    const binaryBuffer = Buffer.from(base64String, 'base64')
+    const float32Array = new Float32Array(binaryBuffer.buffer, binaryBuffer.byteOffset, binaryBuffer.byteLength / 4)
+    return Array.from(float32Array)
+}
+
 class OpenAIEmbeddingCustom_Embeddings implements INode {
     label: string
     name: string
@@ -141,6 +152,24 @@ class OpenAIEmbeddingCustom_Embeddings implements INode {
         }
 
         const model = new OpenAIEmbeddings(obj)
+
+        // If encoding format is base64, wrap the embedding methods to decode base64 responses
+        // into proper number[] arrays. LangChain's OpenAIEmbeddings does not handle this —
+        // it passes raw base64 strings through, causing vector stores to crash.
+        if (encodingFormat === 'base64') {
+            const originalEmbedDocuments = model.embedDocuments.bind(model)
+            model.embedDocuments = async (texts: string[]): Promise<number[][]> => {
+                const results = await originalEmbedDocuments(texts)
+                return results.map((embedding: any) => (typeof embedding === 'string' ? decodeBase64Embedding(embedding) : embedding))
+            }
+
+            const originalEmbedQuery = model.embedQuery.bind(model)
+            model.embedQuery = async (text: string): Promise<number[]> => {
+                const result = await originalEmbedQuery(text)
+                return typeof result === 'string' ? decodeBase64Embedding(result as any) : result
+            }
+        }
+
         return model
     }
 }

--- a/packages/components/nodes/embeddings/OpenAIEmbeddingCustom/OpenAIEmbeddingCustom.ts
+++ b/packages/components/nodes/embeddings/OpenAIEmbeddingCustom/OpenAIEmbeddingCustom.ts
@@ -9,7 +9,8 @@ import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../
  */
 function decodeBase64Embedding(base64String: string): number[] {
     const binaryBuffer = Buffer.from(base64String, 'base64')
-    const float32Array = new Float32Array(binaryBuffer.buffer, binaryBuffer.byteOffset, binaryBuffer.byteLength / 4)
+    const arrayBuffer = binaryBuffer.buffer.slice(binaryBuffer.byteOffset, binaryBuffer.byteOffset + binaryBuffer.byteLength)
+    const float32Array = new Float32Array(arrayBuffer)
     return Array.from(float32Array)
 }
 


### PR DESCRIPTION
## Description
**Fixes Issue:** #6524 

Presently, when the "Encoding Format" is set to `base64` in the OpenAI Embedding nodes, the application crashes with `TypeError: e.every is not a function` while inserting documents into vector stores like Chroma.

**Root Cause:**
LangChain's `OpenAIEmbeddings` returns the raw base64 string without decoding it. However, vector stores require an array of numbers (`number[][]`). When the system tries to validate the raw string as an array, it throws an error.

**Fix Implemented:**
I have added a decoder function in `OpenAIEmbeddingCustom.ts` and `OpenAIEmbedding.ts`. If the format is `base64`, the raw string is now properly decoded into a `Float32Array` (array of numbers) before passing it down the pipeline.