### PR TITLE
fix: honor stop option for ChatOpenAI Custom BaseOptions

### DIFF
--- a/packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.test.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.test.ts
@@ -1,0 +1,75 @@
+jest.mock('@langchain/openai', () => ({
+    ChatOpenAI: jest.fn().mockImplementation((fields) => ({ fields }))
+}))
+
+jest.mock('../../../src/utils', () => ({
+    getBaseClasses: jest.fn().mockReturnValue(['BaseChatModel']),
+    getCredentialData: jest.fn(),
+    getCredentialParam: jest.fn()
+}))
+
+import { getCredentialData, getCredentialParam } from '../../../src/utils'
+
+const { nodeClass: ChatOpenAICustom } = require('./ChatOpenAICustom')
+
+describe('ChatOpenAICustom', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(getCredentialData as jest.Mock).mockResolvedValue({
+            openAIApiKey: 'sk-test'
+        })
+        ;(getCredentialParam as jest.Mock).mockImplementation((key, credentialData) => credentialData[key])
+    })
+
+    it('passes stop from BaseOptions as a model option instead of a default header', async () => {
+        const node = new ChatOpenAICustom()
+        const model = await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    modelName: 'custom-model',
+                    temperature: '0.2',
+                    streaming: false,
+                    baseOptions: {
+                        stop: ['<|im_end|>']
+                    }
+                }
+            },
+            '',
+            {}
+        )
+
+        expect(model.fields.stop).toEqual(['<|im_end|>'])
+        expect(model.fields.configuration?.defaultHeaders).toBeUndefined()
+    })
+
+    it('keeps explicit client configuration in BaseOptions under configuration', async () => {
+        const node = new ChatOpenAICustom()
+        const model = await node.init(
+            {
+                credential: 'cred-1',
+                inputs: {
+                    modelName: 'custom-model',
+                    temperature: '0.2',
+                    baseOptions: {
+                        baseURL: 'https://example.test/v1',
+                        defaultHeaders: {
+                            'x-flowise-test': 'yes'
+                        },
+                        stop: ['DONE']
+                    }
+                }
+            },
+            '',
+            {}
+        )
+
+        expect(model.fields.stop).toEqual(['DONE'])
+        expect(model.fields.configuration).toEqual({
+            baseURL: 'https://example.test/v1',
+            defaultHeaders: {
+                'x-flowise-test': 'yes'
+            }
+        })
+    })
+})

--- a/packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.ts
+++ b/packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.ts
@@ -113,7 +113,7 @@ class ChatOpenAICustom_ChatModels implements INode {
                 name: 'baseOptions',
                 type: 'json',
                 optional: true,
-                description: 'Default headers to include with every request to the API.',
+                description: 'JSON options for the OpenAI-compatible client. Use defaultHeaders for request headers.',
                 additionalParams: true
             }
         ]
@@ -150,7 +150,7 @@ class ChatOpenAICustom_ChatModels implements INode {
         if (timeout) obj.timeout = parseInt(timeout, 10)
         if (cache) obj.cache = cache
 
-        let parsedBaseOptions: any | undefined = undefined
+        let parsedBaseOptions: ICommonObject | undefined = undefined
 
         if (baseOptions) {
             try {
@@ -160,10 +160,27 @@ class ChatOpenAICustom_ChatModels implements INode {
             }
         }
 
-        if (basePath || parsedBaseOptions) {
+        let baseOptionsBaseURL: string | undefined
+        let baseOptionsDefaultHeaders: ICommonObject | undefined
+
+        if (parsedBaseOptions) {
+            const { stop, baseURL, defaultHeaders, ...remainingBaseOptions } = parsedBaseOptions
+
+            if (stop) obj.stop = stop
+            if (baseURL) baseOptionsBaseURL = baseURL
+
+            const remainingDefaultHeaders = Object.keys(remainingBaseOptions).length ? remainingBaseOptions : undefined
+            if (defaultHeaders && remainingDefaultHeaders) {
+                baseOptionsDefaultHeaders = { ...remainingDefaultHeaders, ...defaultHeaders }
+            } else {
+                baseOptionsDefaultHeaders = defaultHeaders ?? remainingDefaultHeaders
+            }
+        }
+
+        if (basePath || baseOptionsBaseURL || baseOptionsDefaultHeaders) {
             obj.configuration = {
-                baseURL: basePath,
-                defaultHeaders: parsedBaseOptions
+                baseURL: basePath || baseOptionsBaseURL,
+                defaultHeaders: baseOptionsDefaultHeaders
             }
         }
 


### PR DESCRIPTION
## Summary
- Fixes `ChatOpenAI Custom` so `BaseOptions.stop` is passed to LangChain `ChatOpenAI` as a model option instead of being sent as an HTTP default header.
- Keeps client configuration behavior intact for `baseURL` and `defaultHeaders`.
- Adds a focused regression test for the reported issue path.

## Submission convention followed
- PR title convention: `fix: ...` for bug-fix PRs.
- Current PR title: `fix: honor stop option for ChatOpenAI Custom BaseOptions`
- Commit subject convention: bug-fix subject with a `fix:` prefix is preferred for future commits in this repo; this branch currently has one already-pushed commit created before the convention audit was added to the Alaxise skill.
- Branch convention: `bugfix/<short-slug>`, matching Flowise `CONTRIBUTING.md`.
- Evidence: recent merged Flowise bug-fix PRs include `fix: FLOWISE-553, 598, 616` (#6464), `fix: FLOWISE-400, 543, 551` (#6417), `fix: flowise 370` (#6409), `fix(models): correct chatMistralAI and chatCohere pricing by 1000x` (#6393), and `fix: access to invited workspace` (#6360). Flowise `CONTRIBUTING.md` asks bug-fix branches to use `bugfix/<Your New Bugfix>`.

## Problem
Issue #2499 reports that Additional Parameters did not take effect for ChatOpenAI Custom when a user entered:

```json
{
  "stop": ["<|im_end|>"]
}
```

The current node parsed `baseOptions` and assigned the entire object to `obj.configuration.defaultHeaders`. That meant `stop` became a request header and never reached `ChatOpenAIFields.stop`.

## Why this matters
Flowise is positioned as a visual AI-agent builder. Chat model configuration is a core user path, especially for custom or OpenAI-compatible models. When advanced model parameters are accepted by the node UI but silently routed to the wrong place, users cannot reliably control model output and maintainers get support reports that are hard to diagnose.

The change is meaningful because it fixes a concrete user-reported bug with a small, reviewable diff and a regression test.

## Roadmap / mission alignment
The repository README describes Flowise as "Build AI Agents, Visually." This fix supports that mission by making one of the visual chat model nodes honor a model-control parameter that users configure through the node.

Issue alignment is direct: #2499 is open and labeled `enhancement`, `good first issue`, and `help wanted`. Maintainer/community discussion also points at this area of the ChatOpenAI nodes.

## What changed
- `packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.ts`: parses `BaseOptions` into model options and client configuration instead of treating every key as a default header.
- `packages/components/nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.test.ts`: adds regression coverage for `stop`, `baseURL`, and `defaultHeaders`.

## How it works
`baseOptions` is still parsed the same way as before. After parsing:

- `stop` is assigned to `obj.stop`, which is the LangChain `ChatOpenAIFields` path.
- `baseURL` and `defaultHeaders` are preserved under `obj.configuration`.
- Unknown keys remain in the default-header bucket for backward compatibility.

This keeps the reported fix narrow. It does not attempt to promote every arbitrary `BaseOptions` key into model fields.

## Local deployment evidence
- Command or script used: `pnpm.cmd install --frozen-lockfile`, `pnpm.cmd build`, `PORT=3000 pnpm.cmd start`
- URL, endpoint, CLI invocation, or service checked: `http://localhost:3000`, `http://localhost:3000/api/v1/ping`
- Before behavior: focused regression test failed because `model.fields.stop` was `undefined`.
- After behavior: local server started successfully, root returned HTTP 200, `/api/v1/ping` returned `pong`, and the focused regression test passed.
- Blockers or substitutes: protected node metadata routes returned HTTP 401 without an authenticated session, so the exact node behavior is verified with a constructor-level Jest test instead of an authenticated UI node-edit flow.

## Verification
- [x] `pnpm.cmd --filter flowise-components test -- ChatOpenAICustom.test.ts --runInBand`: 2 tests passed.
- [x] `pnpm.cmd --filter flowise-components exec tsc --noEmit --pretty false`: passed.
- [x] `pnpm.cmd --filter flowise-components exec eslint nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.ts nodes/chatmodels/ChatOpenAICustom/ChatOpenAICustom.test.ts --ext ts --report-unused-disable-directives --max-warnings 0`: passed.
- [x] `pnpm.cmd --filter flowise-components build`: passed.
- [x] `pnpm.cmd build`: passed.
- [x] `PORT=3000 pnpm.cmd start`: server started and responded locally.
- [x] `git diff --check`: passed before commit.
- [ ] Authenticated UI node-edit flow: not run because local API/UI auth was not configured for this verification pass.
- [ ] Live OpenAI-compatible API request: not run because the fix can be proven without external secrets or network calls to a model provider.

## Risks considered
- Backward compatibility for custom headers: unknown BaseOptions keys remain request headers.
- Scope creep: only `stop` is promoted as a model option because it is the reported parameter.
- Duplicate solution risk: there is another open PR discussing a Stop Sequence input. This PR intentionally targets the reported BaseOptions path and avoids a UI schema change.

## Risks not fully covered
- Other model options in BaseOptions may still not be promoted. That is intentional to avoid changing more behavior than the issue requires.
- Authenticated UI flow was not tested, so reviewers may still want to confirm the node form serialization path in a local account-enabled setup.
- A live OpenAI-compatible request was not sent, so provider-specific handling of `stop` should still be covered by existing LangChain/OpenAI behavior.

## Review focus
- Whether promoting `stop` from `BaseOptions` is acceptable without adding a dedicated `Stop Sequence` field to ChatOpenAI Custom.
- Whether preserving unknown keys as default headers is the right compatibility choice.
- Whether the wording of the Base Options description is clear enough for users.

## Follow-ups intentionally left out
- Adding a dedicated `Stop Sequence` UI input to ChatOpenAI Custom.
- Promoting additional OpenAI model options from `BaseOptions`.
- Refactoring shared BaseOptions parsing across all OpenAI-compatible chat model nodes.

## Ownership report
Generated locally for contributor handoff and intentionally not linked from this public PR because it is not part of the repository diff.

Fixes #2499
