### PR TITLE
ci: pin GitHub Actions to commit SHAs (supply-chain hardening)

### DIFF
--- a/.github/workflows/docker-image-dockerhub.yml
+++ b/.github/workflows/docker-image-dockerhub.yml
@@ -27,16 +27,16 @@ jobs:
                   echo "tag_version=${{ github.event.inputs.tag_version || 'latest' }}" >> $GITHUB_OUTPUT
 
             - name: Checkout
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v4.0.0
+              uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4.0.0
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
             - name: Login to Docker Hub
-              uses: docker/login-action@v4
+              uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
             # Build and push main image
             # -------------------------
             - name: Build and push main image
-              uses: docker/build-push-action@v6.19.2
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
               with:
                   context: .
                   file: ./docker/Dockerfile
@@ -60,7 +60,7 @@ jobs:
             # Build and push worker image
             # -------------------------
             - name: Build and push worker image
-              uses: docker/build-push-action@v6.19.2
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
               with:
                   context: .
                   file: docker/worker/Dockerfile

--- a/.github/workflows/docker-image-ecr.yml
+++ b/.github/workflows/docker-image-ecr.yml
@@ -40,13 +40,13 @@ jobs:
                   echo "tag_version=${{ github.event.inputs.tag_version || 'latest' }}" >> $GITHUB_OUTPUT
 
             - name: Checkout
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v4.0.0
+              uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4.0.0
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
             - name: Configure AWS OIDC Credentials
               uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
@@ -57,13 +57,13 @@ jobs:
                   unset-current-credentials: true
 
             - name: Login to Amazon ECR
-              uses: aws-actions/amazon-ecr-login@v2
+              uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
             # -------------------------
             # Build and push main image
             # -------------------------
             - name: Build and push main image
-              uses: docker/build-push-action@v6.19.2
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
               with:
                   context: .
                   file: Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,12 @@ jobs:
         env:
             PUPPETEER_SKIP_DOWNLOAD: true
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v4
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
               with:
                   version: 10.26.0
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'pnpm'
@@ -38,12 +38,12 @@ jobs:
             - name: Cypress install
               run: pnpm cypress install
             - name: Install dependencies (Cypress Action)
-              uses: cypress-io/github-action@v7.1.5
+              uses: cypress-io/github-action@bc22e01685c56e89e7813fd8e26f33dc47f87e15 # v7.1.5
               with:
                   working-directory: ./
                   runTests: false
             - name: Cypress test
-              uses: cypress-io/github-action@v7.1.5
+              uses: cypress-io/github-action@bc22e01685c56e89e7813fd8e26f33dc47f87e15 # v7.1.5
               with:
                   install: false
                   working-directory: packages/server

--- a/.github/workflows/proprietary-path-guard.yml
+++ b/.github/workflows/proprietary-path-guard.yml
@@ -35,7 +35,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -45,13 +45,13 @@ jobs:
         outputs:
             version: ${{ steps.resolve-version.outputs.version }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
               with:
                   version: 10.26.0
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '20.20.2'
                   registry-url: 'https://registry.npmjs.org'
@@ -120,13 +120,13 @@ jobs:
             contents: write
             pull-requests: write
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
               with:
                   version: 10.26.0
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '20.20.2'
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -15,5 +15,5 @@ jobs:
         env:
             PUPPETEER_SKIP_DOWNLOAD: true
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - run: docker build --no-cache -t flowise .


### PR DESCRIPTION
## Summary

Pins every third-party GitHub Action used in `.github/workflows/` to a full commit SHA, matching the format already used for `aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0` in [`docker-image-ecr.yml`](https://github.com/FlowiseAI/Flowise/blob/main/.github/workflows/docker-image-ecr.yml).

24 action references across 6 workflow files are converted from floating tags (e.g. `@v6`, `@v4.0.0`) to immutable commit SHAs with a trailing version comment.

## Why this matters

Floating Git tags can be force-moved by a compromised maintainer or a successful supply-chain attack on the action's repository. If `actions/checkout@v6` is repointed to a malicious commit, every workflow run that resolves the tag at run-time will execute the attacker's code with full access to repository secrets and the `GITHUB_TOKEN`.

This is not theoretical:

- **CVE-2025-30066 (`tj-actions/changed-files`)** — March 2025: malicious code added to existing tags; thousands of repositories exposed CI secrets.
- **CVE-2025-30154 (`reviewdog/action-setup`)** — March 2025: same pattern, different action.
- **GitHub Security Lab** and **OpenSSF Scorecard** both recommend SHA pinning as the only durable mitigation.

Pinning by SHA freezes the executable content of every action; tag movement is no-op.

## What changed

- 11 unique `action@version` references resolved to commit SHAs at the latest stable tag matching the existing version constraint.
- 24 occurrences updated across:
  - `docker-image-dockerhub.yml` (6 pins)
  - `docker-image-ecr.yml` (5 pins)
  - `main.yml` (5 pins)
  - `proprietary-path-guard.yml` (1 pin)
  - `publish-package.yml` (6 pins)
  - `test_docker_build.yml` (1 pin)
- No functional change. Same versions, same behavior, immutable references.
- Resolution table (newest tag matching the existing constraint at PR time):

| Action | Previous ref | New ref |
|---|---|---|
| `actions/checkout` | `@v6` | `@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3` |
| `actions/checkout` | `@v6.0.2` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` |
| `actions/setup-node` | `@v6` | `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0` |
| `aws-actions/amazon-ecr-login` | `@v2` | `@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6` |
| `cypress-io/github-action` | `@v7.1.5` | `@bc22e01685c56e89e7813fd8e26f33dc47f87e15 # v7.1.5` |
| `docker/build-push-action` | `@v6.19.2` | `@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2` |
| `docker/login-action` | `@v4` | `@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0` |
| `docker/setup-buildx-action` | `@v4.0.0` | `@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0` |
| `docker/setup-qemu-action` | `@v4.0.0` | `@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0` |
| `pnpm/action-setup` | `@v4` | `@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0` |
| `pnpm/action-setup` | `@v6` | `@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9` |

The version comment after each `# vX.Y.Z` keeps the file readable and makes Dependabot's auto-bump diff trivial to review.

## What I left alone

- `aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0` — already pinned (this PR follows that pattern).
- `./.github/workflows/publish-package.yml` — local reusable workflow, not an external action.
- `publish-agentflow.yml` and `publish-observe.yml` — only contain local workflow references, no third-party actions.

## Compatibility

- SHAs resolved on **2026-06-20** from each action's public Git refs.
- Each SHA points to the same commit that the corresponding semver tag points to today — no behavior change.
- Dependabot's `github-actions` ecosystem already handles SHA-pinned dependencies; if enabled, it will auto-PR updates against these.

## Follow-on (out of scope for this PR)

Once SHAs are in, a single-line addition to `.github/dependabot.yml` enables automatic updates:

```yaml
- package-ecosystem: "github-actions"
  directory: "/"
  schedule:
    interval: "weekly"
```

Happy to send that as a separate PR if useful.

---

Generated against `main` at commit `d07186844263bad057008863037466aff7c3390f`. Open to any naming / commit-squash preference the maintainers want.