### PR TITLE
Fix marketplace filter select width

### DIFF
--- a/packages/ui/src/views/marketplaces/index.jsx
+++ b/packages/ui/src/views/marketplaces/index.jsx
@@ -71,6 +71,22 @@ const MenuProps = {
     }
 }
 
+const getSelectStyles = (borderColor, isDarkMode) => ({
+    width: '100%',
+    '& .MuiOutlinedInput-notchedOutline': {
+        borderRadius: 2,
+        borderColor: borderColor
+    },
+    '& .MuiSelect-select': {
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap'
+    },
+    '& .MuiSvgIcon-root': {
+        color: isDarkMode ? '#fff' : 'inherit'
+    }
+})
+
 // ==============================|| Marketplace ||============================== //
 
 const Marketplace = () => {
@@ -129,22 +145,6 @@ const Marketplace = () => {
         setShareTemplateDialogProps(dialogProps)
         setShowShareTemplateDialog(true)
     }
-
-    const getSelectStyles = (borderColor, isDarkMode) => ({
-        width: '100%',
-        '& .MuiOutlinedInput-notchedOutline': {
-            borderRadius: 2,
-            borderColor: borderColor
-        },
-        '& .MuiSelect-select': {
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap'
-        },
-        '& .MuiSvgIcon-root': {
-            color: isDarkMode ? '#fff' : 'inherit'
-        }
-    })
 
     const handleTabChange = (event, newValue) => {
         if (newValue === 1 && !getAllCustomTemplatesApi.data) {
@@ -487,7 +487,7 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            width: 160
+                                            width: MenuProps.PaperProps.style.width
                                         }}
                                     >
                                         <InputLabel size='small' id='filter-badge-label'>
@@ -523,7 +523,7 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            width: 160
+                                            width: MenuProps.PaperProps.style.width
                                         }}
                                     >
                                         <InputLabel size='small' id='type-badge-label'>
@@ -559,7 +559,7 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            width: 160
+                                            width: MenuProps.PaperProps.style.width
                                         }}
                                     >
                                         <InputLabel size='small' id='type-fw-label'>

--- a/packages/ui/src/views/marketplaces/index.jsx
+++ b/packages/ui/src/views/marketplaces/index.jsx
@@ -131,9 +131,15 @@ const Marketplace = () => {
     }
 
     const getSelectStyles = (borderColor, isDarkMode) => ({
+        width: '100%',
         '& .MuiOutlinedInput-notchedOutline': {
             borderRadius: 2,
             borderColor: borderColor
+        },
+        '& .MuiSelect-select': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
         },
         '& .MuiSvgIcon-root': {
             color: isDarkMode ? '#fff' : 'inherit'
@@ -481,7 +487,7 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            minWidth: 120
+                                            width: 160
                                         }}
                                     >
                                         <InputLabel size='small' id='filter-badge-label'>
@@ -517,7 +523,7 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            minWidth: 120
+                                            width: 160
                                         }}
                                     >
                                         <InputLabel size='small' id='type-badge-label'>
@@ -553,7 +559,7 @@ const Marketplace = () => {
                                             display: 'flex',
                                             flexDirection: 'column',
                                             justifyContent: 'end',
-                                            minWidth: 120
+                                            width: 160
                                         }}
                                     >
                                         <InputLabel size='small' id='type-fw-label'>


### PR DESCRIPTION
Summary
- Give marketplace filter selects a stable fixed width.
- Truncate long selected values inside the select instead of letting them expand the control.
- Prevent long tag/type/framework selections from shifting adjacent filters.

Tests
- pnpm --dir packages/ui build

Notes
- Fixes #6518.