### PR TITLE
fix: prevent duplicate chatflow creation on repeated save clicks

### DIFF
--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -217,6 +217,7 @@ const AgentflowCanvas = () => {
     }
 
     const handleSaveFlow = (chatflowName) => {
+        if (createNewChatflowApi.loading) return
         if (reactFlowInstance) {
             const nodes = reactFlowInstance.getNodes().map((node) => {
                 const nodeData = cloneDeep(node.data)
@@ -707,6 +708,7 @@ const AgentflowCanvas = () => {
                         <CanvasHeader
                             chatflow={chatflow}
                             handleSaveFlow={handleSaveFlow}
+                            isSaving={createNewChatflowApi.loading}
                             handleDeleteFlow={handleDeleteFlow}
                             handleLoadFlow={handleLoadFlow}
                             isAgentCanvas={true}

--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -120,7 +120,7 @@ const LockedScheduleSwitch = styled(ScheduleSwitch, { shouldForwardProp: (prop) 
 
 // ==============================|| CANVAS HEADER ||============================== //
 
-const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, handleDeleteFlow, handleLoadFlow }) => {
+const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, handleDeleteFlow, handleLoadFlow, isSaving }) => {
     const theme = useTheme()
     const dispatch = useDispatch()
     const navigate = useNavigate()
@@ -319,11 +319,13 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
     }
 
     const onSaveChatflowClick = () => {
+        if (isSaving) return
         if (chatflow.id) handleSaveFlow(flowName)
         else setFlowDialogOpen(true)
     }
 
     const onConfirmSaveName = (flowName) => {
+        if (isSaving) return
         setFlowDialogOpen(false)
         setSavePermission(isAgentCanvas ? 'agentflows:update' : 'chatflows:update')
         handleSaveFlow(flowName)
@@ -593,7 +595,7 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                         </ButtonBase>
                     )}
                     <Available permission={savePermission}>
-                        <ButtonBase title={`Save ${title}`} sx={{ borderRadius: '50%', mr: 2 }}>
+                        <ButtonBase title={`Save ${title}`} disabled={isSaving} sx={{ borderRadius: '50%', mr: 2 }}>
                             <Avatar
                                 variant='rounded'
                                 sx={{

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -209,6 +209,7 @@ const Canvas = () => {
     }
 
     const handleSaveFlow = async (chatflowName) => {
+        if (createNewChatflowApi.loading) return
         if (reactFlowInstance) {
             const nodes = reactFlowInstance.getNodes().map((node) => {
                 const nodeData = cloneDeep(node.data)
@@ -574,6 +575,7 @@ const Canvas = () => {
                         <CanvasHeader
                             chatflow={chatflow}
                             handleSaveFlow={handleSaveFlow}
+                            isSaving={createNewChatflowApi.loading}
                             handleDeleteFlow={handleDeleteFlow}
                             handleLoadFlow={handleLoadFlow}
                             isAgentCanvas={isAgentCanvas}


### PR DESCRIPTION
## Problem

Rapidly clicking the Save button on the canvas (or pressing the keyboard shortcut multiple times) fires multiple concurrent `createNewChatflow` API calls, resulting in duplicate chatflows being created. This affects both the regular canvas and the AgentFlow V2 canvas.

## Fix

Add a loading-state guard at three levels to prevent re-entrant save operations:

1. **`handleSaveFlow`** in both `Canvas` and `AgentflowCanvas` — early-return if a save request is already in flight
2. **`CanvasHeader`** — receive `isSaving` prop, disable the save button visually, and guard both `onSaveChatflowClick` and `onConfirmSaveName` handlers

```diff
  const handleSaveFlow = (chatflowName) => {
+     if (createNewChatflowApi.loading) return
      if (reactFlowInstance) { ... }
  }
```

```diff
- <ButtonBase title={`Save ${title}`} sx={{ borderRadius: '50%', mr: 2 }}>
+ <ButtonBase title={`Save ${title}`} disabled={isSaving} sx={{ borderRadius: '50%', mr: 2 }}>
```

## Scope

- `packages/ui/src/views/canvas/index.jsx` (modified, +2/-0)
- `packages/ui/src/views/canvas/CanvasHeader.jsx` (modified, +4/-2)
- `packages/ui/src/views/agentflowsv2/Canvas.jsx` (modified, +2/-0)

## Testing

- Verified that clicking Save multiple times in quick succession only creates one chatflow.
- Verified that the Save button is visually disabled while a save request is in progress.
- Verified that normal single-click save still works as expected.
