### PR TITLE
fix(document-store): sync top-level credential on confluence loader update

### DIFF
--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -785,8 +785,12 @@ const saveProcessingLoader = async (
             if (!data.splitterId) data.splitterId = found.splitterId
             if (!data.splitterName) data.splitterName = found.splitterName
             if (!data.splitterConfig) data.splitterConfig = found.splitterConfig
-            if (found.credential) {
-                data.credential = found.credential
+            // Only fall back to the existing credential if no new credential was provided
+            // either directly or inside loaderConfig
+            if (!data.credential && !data.loaderConfig?.credential && !data.loaderConfig?.FLOWISE_CREDENTIAL_ID) {
+                if (found.credential) {
+                    data.credential = found.credential
+                }
             }
 
             let loader: IDocumentStoreLoader = {
@@ -801,7 +805,12 @@ const saveProcessingLoader = async (
                 totalChars: 0,
                 status: DocumentStoreStatus.SYNCING
             }
-            if (data.credential) {
+            // Sync top-level credential from loaderConfig if present,
+            // ensuring it stays in sync when the user updates credentials via the UI
+            const credentialFromConfig = data.loaderConfig?.credential || data.loaderConfig?.FLOWISE_CREDENTIAL_ID
+            if (credentialFromConfig) {
+                loader.credential = credentialFromConfig
+            } else if (data.credential) {
                 loader.credential = data.credential
             }
 
@@ -820,7 +829,11 @@ const saveProcessingLoader = async (
                 totalChars: 0,
                 status: DocumentStoreStatus.SYNCING
             }
-            if (data.credential) {
+            // Sync top-level credential from loaderConfig if present
+            const newCredentialFromConfig = data.loaderConfig?.credential || data.loaderConfig?.FLOWISE_CREDENTIAL_ID
+            if (newCredentialFromConfig) {
+                loader.credential = newCredentialFromConfig
+            } else if (data.credential) {
                 loader.credential = data.credential
             }
             existingLoaders.push(loader)


### PR DESCRIPTION
## Description
Closes #6550 

**Problem Statement:**
When a user updates the credentials for a document loader (e.g., Confluence) via the Flowise UI, the system maintains two separate credential references inside the `document_store` database table's `loaders` JSON column: `loaderConfig.credential` and the top-level `credential`. The UI correctly updated `loaderConfig.credential`, but the top-level `credential` retained the old, stale UUID. Because downstream operations like `/refresh` and `/process` read the top-level `credential`, users received 403/404 authorization errors after changing credentials.

**Root Cause:**
In `packages/server/src/services/documentstore/index.ts` (`saveProcessingLoader`):
1. The code unconditionally overwrote `data.credential` with the old DB value (`found.credential`).
2. The top-level `loader.credential` was never explicitly synced from `loaderConfig.credential` or `loaderConfig.FLOWISE_CREDENTIAL_ID`.

**The Fix:**
* Changed the fallback logic to only use the existing DB credential if no new credential was provided either directly or inside `loaderConfig`.
* Explicitly synced `loader.credential` from `loaderConfig` on both the loader update and loader creation paths.

## How to Test
1. Create two different Confluence API credentials (Cred A and Cred B).
2. Create a new Confluence Document Store and attach Cred A. Save it.
3. Check the database `loaders` column: verify all credential fields sync to Cred A.
4. Edit the document store in the UI, swap the credential to Cred B, and save again.
5. Check the database `loaders` column: verify the top-level `credential` is now correctly synced to Cred B instead of remaining stuck on Cred A.
6. Trigger a sync/refresh of the document store. Verify it utilizes Cred B and no longer throws a 403/404 mismatch error.