### PR TITLE
fix: skip S3 directory marker objects

### DIFF
--- a/packages/components/nodes/documentloaders/S3Directory/S3Directory.test.ts
+++ b/packages/components/nodes/documentloaders/S3Directory/S3Directory.test.ts
@@ -1,0 +1,20 @@
+const { isS3FileKey } = require('./S3Directory')
+
+describe('S3Directory', () => {
+    describe('isS3FileKey', () => {
+        it('skips S3 directory marker keys', () => {
+            expect(isS3FileKey('docs/')).toBe(false)
+            expect(isS3FileKey('docs/nested/')).toBe(false)
+        })
+
+        it('keeps regular file keys, including empty file keys with extensions', () => {
+            expect(isS3FileKey('docs/readme.txt')).toBe(true)
+            expect(isS3FileKey('empty-file.txt')).toBe(true)
+        })
+
+        it('skips missing keys', () => {
+            expect(isS3FileKey()).toBe(false)
+            expect(isS3FileKey('')).toBe(false)
+        })
+    })
+})

--- a/packages/components/nodes/documentloaders/S3Directory/S3Directory.ts
+++ b/packages/components/nodes/documentloaders/S3Directory/S3Directory.ts
@@ -17,6 +17,9 @@ import { TextSplitter } from '@langchain/textsplitters'
 import { CSVLoader } from '../Csv/CsvLoader'
 import { LoadOfSheet } from '../MicrosoftExcel/ExcelLoader'
 import { PowerpointLoader } from '../MicrosoftPowerpoint/PowerpointLoader'
+
+const isS3FileKey = (key?: string): key is string => Boolean(key && !key.endsWith('/'))
+
 class S3_DocumentLoaders implements INode {
     label: string
     name: string
@@ -184,7 +187,7 @@ class S3_DocumentLoaders implements INode {
                 })
             )
 
-            const keys: string[] = (listObjectsOutput?.Contents ?? []).filter((item) => item.Key && item.ETag).map((item) => item.Key!)
+            const keys: string[] = (listObjectsOutput?.Contents ?? []).filter((item) => isS3FileKey(item.Key) && item.ETag).map((item) => item.Key!)
 
             await Promise.all(
                 keys.map(async (key) => {
@@ -290,4 +293,4 @@ class S3_DocumentLoaders implements INode {
         }
     }
 }
-module.exports = { nodeClass: S3_DocumentLoaders }
+module.exports = { nodeClass: S3_DocumentLoaders, isS3FileKey }


### PR DESCRIPTION
Summary
- Ignore S3 keys ending in `/` when loading a directory prefix.
- Add coverage for folder marker objects so they are not downloaded as files.

Tests
- `git diff --check`
- Focused Jest blocked locally by repository engine gate: Node ^24 and pnpm ^10.26.0 required; current shell reported Node v26.0.0 and pnpm 10.6.5.

Notes
- Fixes #4688.