### PR TITLE
fix: ignore Enter during IME composition in remaining text inputs

### DIFF
--- a/packages/ui/src/ui-component/dialog/ExportAsTemplateDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/ExportAsTemplateDialog.jsx
@@ -82,7 +82,9 @@ const ExportAsTemplateDialog = ({ show, dialogProps, onCancel }) => {
     }
 
     const handleUsecaseInputKeyDown = (event) => {
-        if (event.key === 'Enter' && usecaseInput.trim()) {
+        // Check if IME composition is in progress
+        const isIMEComposition = event.isComposing || event.keyCode === 229
+        if (event.key === 'Enter' && !isIMEComposition && usecaseInput.trim()) {
             event.preventDefault()
             if (!usecases.includes(usecaseInput)) {
                 setUsecases([...usecases, usecaseInput])

--- a/packages/ui/src/ui-component/dialog/SaveChatflowDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/SaveChatflowDialog.jsx
@@ -41,7 +41,9 @@ const SaveChatflowDialog = ({ show, dialogProps, onCancel, onConfirm }) => {
                     value={chatflowName}
                     onChange={(e) => setChatflowName(e.target.value)}
                     onKeyDown={(e) => {
-                        if (isReadyToSave && e.key === 'Enter') onConfirm(e.target.value)
+                        // Check if IME composition is in progress
+                        const isIMEComposition = e.isComposing || e.keyCode === 229
+                        if (isReadyToSave && e.key === 'Enter' && !isIMEComposition) onConfirm(e.target.value)
                     }}
                 />
             </DialogContent>

--- a/packages/ui/src/ui-component/dialog/TagDialog.jsx
+++ b/packages/ui/src/ui-component/dialog/TagDialog.jsx
@@ -16,7 +16,9 @@ const TagDialog = ({ isOpen, dialogProps, onClose, onSubmit }) => {
     }
 
     const handleInputKeyDown = (event) => {
-        if (event.key === 'Enter' && inputValue.trim()) {
+        // Check if IME composition is in progress
+        const isIMEComposition = event.isComposing || event.keyCode === 229
+        if (event.key === 'Enter' && !isIMEComposition && inputValue.trim()) {
             event.preventDefault()
             if (!categoryValues.includes(inputValue)) {
                 setCategoryValues([...categoryValues, inputValue])

--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -482,7 +482,9 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                                     }}
                                     defaultValue={flowName}
                                     onKeyDown={(e) => {
-                                        if (e.key === 'Enter') {
+                                        // Check if IME composition is in progress
+                                        const isIMEComposition = e.isComposing || e.keyCode === 229
+                                        if (e.key === 'Enter' && !isIMEComposition) {
                                             submitFlowName()
                                         } else if (e.key === 'Escape') {
                                             setEditingFlowName(false)


### PR DESCRIPTION
### What

`ChatMessage` and `VectorStoreQuery` already skip their Enter handler while an IME is composing:

```js
const isIMEComposition = e.isComposing || e.keyCode === 229
if (e.key === 'Enter' && ... && !isIMEComposition) { ... }
```

A few other single-line text inputs handle Enter on keydown but don't have that check, so they act while the user is still composing.

### Why

When typing with an IME (Japanese, Chinese, Korean, and macOS dead keys), the Enter that confirms a candidate fires a `keydown` with `key === 'Enter'` (and `keyCode === 229` / `isComposing === true`) before `compositionend`. Without a guard, that first confirmation Enter is treated as a submit, so:

- Canvas header: the flow name is saved and edit mode closes on the first IME confirmation, before the user has finished the name.
- Save chatflow dialog: the dialog confirms on the confirmation key.
- Tag dialog and Export-as-template dialog: a half-composed string gets added as a tag / usecase.

The result is that a CJK user cannot reliably type a multi-character word in these fields.

### Change

Apply the same guard the repo already uses in `ChatMessage` and `VectorStoreQuery` to the inputs that were missing it:

- `views/canvas/CanvasHeader.jsx` (flow name rename)
- `ui-component/dialog/SaveChatflowDialog.jsx` (save name)
- `ui-component/dialog/TagDialog.jsx` (add tag)
- `ui-component/dialog/ExportAsTemplateDialog.jsx` (add usecase)

For a normal keystroke `isComposing` is `false` and `keyCode` is `13`, so the guard is a no-op and existing behavior is unchanged. Escape handling is left as-is.

### Testing

I didn't have an IME set up to reproduce this directly. I confirmed the changed files build and that the guard expression is identical to the one already shipping in `ChatMessage` / `VectorStoreQuery`. A manual check with a Japanese or Chinese IME in these four fields would be welcome to confirm.
