### PR TITLE
feat(canvas): auto-switch workspace when opening a flow URL from another member workspace

### DIFF
--- a/packages/server/src/controllers/chatflows/index.ts
+++ b/packages/server/src/controllers/chatflows/index.ts
@@ -143,6 +143,25 @@ const getChatflowById = async (req: Request, res: Response, next: NextFunction) 
     }
 }
 
+// Resolve the owning workspace of a flow for the requesting user IFF they are a member of it (else an
+// identical 404 — no cross-workspace disclosure). Used by the UI to auto-switch the active workspace when a
+// user opens a flow URL that lives in a workspace they belong to but isn't active. UI-only: API-key callers
+// have no req.user.id, so the service treats them as non-members (404).
+const getChatflowWorkspace = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        if (typeof req.params === 'undefined' || !req.params.id) {
+            throw new InternalFlowiseError(
+                StatusCodes.PRECONDITION_FAILED,
+                `Error: chatflowsController.getChatflowWorkspace - id not provided!`
+            )
+        }
+        const apiResponse = await chatflowsService.resolveChatflowWorkspace(req.params.id, req.user?.id)
+        return res.json(apiResponse)
+    } catch (error) {
+        next(error)
+    }
+}
+
 const saveChatflow = async (req: Request, res: Response, next: NextFunction) => {
     try {
         if (!req.body) {
@@ -444,6 +463,7 @@ export default {
     getAllChatflows,
     getChatflowByApiKey,
     getChatflowById,
+    getChatflowWorkspace,
     saveChatflow,
     updateChatflow,
     getSinglePublicChatflow,

--- a/packages/server/src/routes/chatflows/index.ts
+++ b/packages/server/src/routes/chatflows/index.ts
@@ -21,6 +21,14 @@ router.get(
     checkAnyPermission('chatflows:view,chatflows:update,chatflows:delete,agentflows:view,agentflows:update,agentflows:delete'),
     chatflowsController.getChatflowById
 )
+// Resolve the owning workspace of a flow for the current user (membership-gated; identical 404 otherwise).
+// Lets the UI auto-switch the active workspace when opening a flow URL from another (member) workspace.
+// Two-segment path so it never collides with the single-segment '/:id' matcher above.
+router.get(
+    '/resolve-workspace/:id',
+    checkAnyPermission('chatflows:view,chatflows:update,chatflows:delete,agentflows:view,agentflows:update,agentflows:delete'),
+    chatflowsController.getChatflowWorkspace
+)
 router.get(['/apikey/', '/apikey/:apikey'], chatflowsController.getChatflowByApiKey)
 
 // UPDATE

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -12,7 +12,7 @@ import { ChatMessageFeedback } from '../../database/entities/ChatMessageFeedback
 import { ScheduleTriggerType } from '../../database/entities/ScheduleRecord'
 import { UpsertHistory } from '../../database/entities/UpsertHistory'
 import { Workspace } from '../../enterprise/database/entities/workspace.entity'
-import { WorkspaceUser } from '../../enterprise/database/entities/workspace-user.entity'
+import { WorkspaceUser, WorkspaceUserStatus } from '../../enterprise/database/entities/workspace-user.entity'
 import { getWorkspaceSearchOptions } from '../../enterprise/utils/ControllerServiceUtils'
 import { InternalFlowiseError } from '../../errors/internalFlowiseError'
 import { getErrorMessage } from '../../errors/utils'
@@ -329,10 +329,12 @@ const resolveChatflowWorkspace = async (chatflowId: string, userId?: string): Pr
             throw notFound()
         }
         // Direct membership check so the no-leak guarantee holds: identical response whether the flow is
-        // missing or the user simply isn't a member of its workspace.
+        // missing or the user simply isn't an active member of its workspace. Require ACTIVE status so a
+        // user who is only INVITED (not yet accepted) or DISABLEd cannot resolve or switch into it.
         const membership = await appServer.AppDataSource.getRepository(WorkspaceUser).findOneBy({
             workspaceId: chatflow.workspaceId,
-            userId
+            userId,
+            status: WorkspaceUserStatus.ACTIVE
         })
         if (!membership) {
             throw notFound()

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -12,6 +12,7 @@ import { ChatMessageFeedback } from '../../database/entities/ChatMessageFeedback
 import { ScheduleTriggerType } from '../../database/entities/ScheduleRecord'
 import { UpsertHistory } from '../../database/entities/UpsertHistory'
 import { Workspace } from '../../enterprise/database/entities/workspace.entity'
+import { WorkspaceUser } from '../../enterprise/database/entities/workspace-user.entity'
 import { getWorkspaceSearchOptions } from '../../enterprise/utils/ControllerServiceUtils'
 import { InternalFlowiseError } from '../../errors/internalFlowiseError'
 import { getErrorMessage } from '../../errors/utils'
@@ -300,6 +301,50 @@ const getChatflowById = async (chatflowId: string, workspaceId?: string): Promis
         throw new InternalFlowiseError(
             StatusCodes.INTERNAL_SERVER_ERROR,
             `Error: chatflowsService.getChatflowById - ${getErrorMessage(error)}`
+        )
+    }
+}
+
+// Resolve which workspace owns a flow, but ONLY for a caller who is a member of that workspace. A chatflow
+// id is a globally-unique UUID, so it maps to exactly one owning workspace; the UI uses this to auto-switch
+// the active workspace when a user opens a flow URL that lives in a workspace they belong to but isn't
+// currently active. SECURITY: every failure mode returns the IDENTICAL 404 as getChatflowById, so this never
+// discloses that a flow exists in a workspace the caller cannot access. API-key callers (no userId) -> 404.
+const resolveChatflowWorkspace = async (chatflowId: string, userId?: string): Promise<{ workspaceId: string }> => {
+    const notFound = () => new InternalFlowiseError(StatusCodes.NOT_FOUND, `Chatflow ${chatflowId} not found in the database!`)
+    try {
+        if (!isValidUUID(chatflowId)) {
+            throw new InternalFlowiseError(StatusCodes.BAD_REQUEST, ChatflowErrorMessage.INVALID_CHATFLOW_ID)
+        }
+        if (!userId) {
+            throw notFound()
+        }
+        const appServer = getRunningExpressApp()
+        // Look up the flow across ALL workspaces (no workspace filter), then gate strictly on membership.
+        const chatflow = await appServer.AppDataSource.getRepository(ChatFlow).findOne({
+            where: { id: chatflowId },
+            select: ['id', 'workspaceId']
+        })
+        if (!chatflow) {
+            throw notFound()
+        }
+        // Direct membership check so the no-leak guarantee holds: identical response whether the flow is
+        // missing or the user simply isn't a member of its workspace.
+        const membership = await appServer.AppDataSource.getRepository(WorkspaceUser).findOneBy({
+            workspaceId: chatflow.workspaceId,
+            userId
+        })
+        if (!membership) {
+            throw notFound()
+        }
+        return { workspaceId: chatflow.workspaceId }
+    } catch (error) {
+        if (error instanceof InternalFlowiseError) {
+            throw error
+        }
+        throw new InternalFlowiseError(
+            StatusCodes.INTERNAL_SERVER_ERROR,
+            `Error: chatflowsService.resolveChatflowWorkspace - ${getErrorMessage(error)}`
         )
     }
 }
@@ -702,6 +747,7 @@ export default {
     getChatflowByApiKey,
     getChatflowById,
     getChatflowByIdForWorkspace,
+    resolveChatflowWorkspace,
     saveChatflow,
     updateChatflow,
     getSinglePublicChatbotConfig,

--- a/packages/server/src/services/chatflows/index.ts
+++ b/packages/server/src/services/chatflows/index.ts
@@ -325,7 +325,7 @@ const resolveChatflowWorkspace = async (chatflowId: string, userId?: string): Pr
             where: { id: chatflowId },
             select: ['id', 'workspaceId']
         })
-        if (!chatflow) {
+        if (!chatflow || !chatflow.workspaceId) {
             throw notFound()
         }
         // Direct membership check so the no-leak guarantee holds: identical response whether the flow is

--- a/packages/ui/src/api/chatflows.js
+++ b/packages/ui/src/api/chatflows.js
@@ -8,6 +8,10 @@ const getSpecificChatflow = (id) => client.get(`/chatflows/${id}`)
 
 const getSpecificChatflowFromPublicEndpoint = (id) => client.get(`/public-chatflows/${id}`)
 
+// Resolve which workspace owns a flow, but only if the current user is a member (404 otherwise). Used to
+// auto-switch the active workspace when opening a flow URL that lives in another (member) workspace.
+const getChatflowWorkspace = (id) => client.get(`/chatflows/resolve-workspace/${id}`)
+
 const createNewChatflow = (body) => client.post(`/chatflows`, body)
 
 const updateChatflow = (id, body) => client.put(`/chatflows/${id}`, body)
@@ -39,6 +43,7 @@ export default {
     getAllAgentflows,
     getSpecificChatflow,
     getSpecificChatflowFromPublicEndpoint,
+    getChatflowWorkspace,
     createNewChatflow,
     updateChatflow,
     deleteChatflow,

--- a/packages/ui/src/hooks/useFlowWorkspaceAutoSwitch.jsx
+++ b/packages/ui/src/hooks/useFlowWorkspaceAutoSwitch.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import chatflowsApi from '@/api/chatflows'
@@ -18,12 +18,25 @@ import { workspaceSwitchSuccess } from '@/store/reducers/authSlice'
 export const useFlowWorkspaceAutoSwitch = () => {
     const dispatch = useDispatch()
     const currentUser = useSelector((state) => state.auth.user)
+    // Keep the latest user in a ref so tryAutoSwitch can read it without being listed as a useCallback dep.
+    // This keeps the callback identity stable (callers omit it from their useEffect deps) while still reading
+    // the freshest user — avoiding a stale closure if the user loads/changes after the callback was created.
+    const currentUserRef = useRef(currentUser)
+    useEffect(() => {
+        currentUserRef.current = currentUser
+    }, [currentUser])
+
     const attemptedRef = useRef(new Set())
 
     const tryAutoSwitch = useCallback(
         async (chatflowId, error, onSwitched) => {
             const status = error?.response?.status
             if (status !== 404 || !chatflowId) return false
+
+            // Bail before marking attempted if the user isn't loaded yet, so a later (loaded) call can retry.
+            const user = currentUserRef.current
+            if (!user) return false
+
             // Only attempt once per flow id to avoid any retry loop if something goes sideways.
             if (attemptedRef.current.has(chatflowId)) return false
             attemptedRef.current.add(chatflowId)
@@ -32,8 +45,8 @@ export const useFlowWorkspaceAutoSwitch = () => {
                 const res = await chatflowsApi.getChatflowWorkspace(chatflowId)
                 const workspaceId = res?.data?.workspaceId
                 if (!workspaceId) return false
-                if (workspaceId === currentUser?.activeWorkspaceId) return false
-                const assigned = currentUser?.assignedWorkspaces || []
+                if (workspaceId === user.activeWorkspaceId) return false
+                const assigned = user.assignedWorkspaces || []
                 if (!assigned.some((w) => w?.id === workspaceId)) return false
 
                 const switchRes = await workspaceApi.switchWorkspace(workspaceId)
@@ -45,7 +58,7 @@ export const useFlowWorkspaceAutoSwitch = () => {
                 return false
             }
         },
-        [currentUser, dispatch]
+        [dispatch]
     )
 
     return tryAutoSwitch

--- a/packages/ui/src/hooks/useFlowWorkspaceAutoSwitch.jsx
+++ b/packages/ui/src/hooks/useFlowWorkspaceAutoSwitch.jsx
@@ -54,7 +54,12 @@ export const useFlowWorkspaceAutoSwitch = () => {
                 if (typeof onSwitched === 'function') onSwitched()
                 return true
             } catch (e) {
-                // Resolver 404 (not a member / missing flow) or any failure → fall back to the normal error.
+                // A 404 is definitive (not a member / missing flow) — leave it marked so we don't retry.
+                // For transient failures (network error, 5xx, etc.) clear the mark so a later re-fetch can retry.
+                if (e?.response?.status !== 404) {
+                    attemptedRef.current.delete(chatflowId)
+                }
+                // Fall back to the caller's normal error handling.
                 return false
             }
         },

--- a/packages/ui/src/hooks/useFlowWorkspaceAutoSwitch.jsx
+++ b/packages/ui/src/hooks/useFlowWorkspaceAutoSwitch.jsx
@@ -1,0 +1,49 @@
+import { useRef } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import chatflowsApi from '@/api/chatflows'
+import workspaceApi from '@/api/workspace'
+import { workspaceSwitchSuccess } from '@/store/reducers/authSlice'
+
+// When a flow canvas fails to load with a 404 because the flow lives in a workspace the user belongs to but
+// isn't their ACTIVE workspace, resolve the flow's owning workspace (membership-gated server-side) and switch
+// to it, then let the caller re-fetch — instead of dead-ending on "Chatflow <id> not found in the database!".
+//
+// Returns an async `tryAutoSwitch(chatflowId, error, onSwitched)`:
+//   - returns true  => it switched workspaces and invoked onSwitched() (caller should suppress its error)
+//   - returns false => not applicable / not a member; caller should fall back to its normal error handling
+//
+// Security: the resolver only returns a workspaceId when the user is a member, and we additionally verify the
+// id is in the user's assignedWorkspaces before switching — so we never switch into an unauthorized workspace.
+export const useFlowWorkspaceAutoSwitch = () => {
+    const dispatch = useDispatch()
+    const currentUser = useSelector((state) => state.auth.user)
+    const attemptedRef = useRef(new Set())
+
+    const tryAutoSwitch = async (chatflowId, error, onSwitched) => {
+        const status = error?.response?.status
+        if (status !== 404 || !chatflowId) return false
+        // Only attempt once per flow id to avoid any retry loop if something goes sideways.
+        if (attemptedRef.current.has(chatflowId)) return false
+        attemptedRef.current.add(chatflowId)
+
+        try {
+            const res = await chatflowsApi.getChatflowWorkspace(chatflowId)
+            const workspaceId = res?.data?.workspaceId
+            if (!workspaceId) return false
+            if (workspaceId === currentUser?.activeWorkspaceId) return false
+            const assigned = currentUser?.assignedWorkspaces || []
+            if (!assigned.some((w) => w.id === workspaceId)) return false
+
+            const switchRes = await workspaceApi.switchWorkspace(workspaceId)
+            dispatch(workspaceSwitchSuccess(switchRes.data))
+            if (typeof onSwitched === 'function') onSwitched()
+            return true
+        } catch (e) {
+            // Resolver 404 (not a member / missing flow) or any failure → fall back to the normal error.
+            return false
+        }
+    }
+
+    return tryAutoSwitch
+}

--- a/packages/ui/src/hooks/useFlowWorkspaceAutoSwitch.jsx
+++ b/packages/ui/src/hooks/useFlowWorkspaceAutoSwitch.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import chatflowsApi from '@/api/chatflows'
@@ -20,30 +20,33 @@ export const useFlowWorkspaceAutoSwitch = () => {
     const currentUser = useSelector((state) => state.auth.user)
     const attemptedRef = useRef(new Set())
 
-    const tryAutoSwitch = async (chatflowId, error, onSwitched) => {
-        const status = error?.response?.status
-        if (status !== 404 || !chatflowId) return false
-        // Only attempt once per flow id to avoid any retry loop if something goes sideways.
-        if (attemptedRef.current.has(chatflowId)) return false
-        attemptedRef.current.add(chatflowId)
+    const tryAutoSwitch = useCallback(
+        async (chatflowId, error, onSwitched) => {
+            const status = error?.response?.status
+            if (status !== 404 || !chatflowId) return false
+            // Only attempt once per flow id to avoid any retry loop if something goes sideways.
+            if (attemptedRef.current.has(chatflowId)) return false
+            attemptedRef.current.add(chatflowId)
 
-        try {
-            const res = await chatflowsApi.getChatflowWorkspace(chatflowId)
-            const workspaceId = res?.data?.workspaceId
-            if (!workspaceId) return false
-            if (workspaceId === currentUser?.activeWorkspaceId) return false
-            const assigned = currentUser?.assignedWorkspaces || []
-            if (!assigned.some((w) => w.id === workspaceId)) return false
+            try {
+                const res = await chatflowsApi.getChatflowWorkspace(chatflowId)
+                const workspaceId = res?.data?.workspaceId
+                if (!workspaceId) return false
+                if (workspaceId === currentUser?.activeWorkspaceId) return false
+                const assigned = currentUser?.assignedWorkspaces || []
+                if (!assigned.some((w) => w?.id === workspaceId)) return false
 
-            const switchRes = await workspaceApi.switchWorkspace(workspaceId)
-            dispatch(workspaceSwitchSuccess(switchRes.data))
-            if (typeof onSwitched === 'function') onSwitched()
-            return true
-        } catch (e) {
-            // Resolver 404 (not a member / missing flow) or any failure → fall back to the normal error.
-            return false
-        }
-    }
+                const switchRes = await workspaceApi.switchWorkspace(workspaceId)
+                dispatch(workspaceSwitchSuccess(switchRes?.data))
+                if (typeof onSwitched === 'function') onSwitched()
+                return true
+            } catch (e) {
+                // Resolver 404 (not a member / missing flow) or any failure → fall back to the normal error.
+                return false
+            }
+        },
+        [currentUser, dispatch]
+    )
 
     return tryAutoSwitch
 }

--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -552,7 +552,10 @@ const AgentflowCanvas = () => {
             // If the flow lives in another workspace the user is a member of, auto-switch + re-fetch instead
             // of dead-ending on "not found". Falls back to the normal error if it's a genuine 404 / non-member.
             tryWorkspaceAutoSwitch(chatflowId, error, () => getSpecificChatflowApi.request(chatflowId)).then((handled) => {
-                if (!handled) errorFailed(`Failed to retrieve ${canvasTitle}: ${error.response.data.message}`)
+                if (!handled) {
+                    const errorMsg = error?.response?.data?.message || error?.message || 'Unknown error'
+                    errorFailed(`Failed to retrieve ${canvasTitle}: ${errorMsg}`)
+                }
             })
         }
 

--- a/packages/ui/src/views/agentflowsv2/Canvas.jsx
+++ b/packages/ui/src/views/agentflowsv2/Canvas.jsx
@@ -41,6 +41,7 @@ import chatflowsApi from '@/api/chatflows'
 
 // Hooks
 import useApi from '@/hooks/useApi'
+import { useFlowWorkspaceAutoSwitch } from '@/hooks/useFlowWorkspaceAutoSwitch'
 import useConfirm from '@/hooks/useConfirm'
 
 // icons
@@ -125,6 +126,7 @@ const AgentflowCanvas = () => {
     const createNewChatflowApi = useApi(chatflowsApi.createNewChatflow)
     const updateChatflowApi = useApi(chatflowsApi.updateChatflow)
     const getSpecificChatflowApi = useApi(chatflowsApi.getSpecificChatflow)
+    const tryWorkspaceAutoSwitch = useFlowWorkspaceAutoSwitch()
 
     // ==============================|| Events & Actions ||============================== //
 
@@ -546,7 +548,12 @@ const AgentflowCanvas = () => {
             setEdges(initialFlow.edges || [])
             dispatch({ type: SET_CHATFLOW, chatflow })
         } else if (getSpecificChatflowApi.error) {
-            errorFailed(`Failed to retrieve ${canvasTitle}: ${getSpecificChatflowApi.error.response.data.message}`)
+            const error = getSpecificChatflowApi.error
+            // If the flow lives in another workspace the user is a member of, auto-switch + re-fetch instead
+            // of dead-ending on "not found". Falls back to the normal error if it's a genuine 404 / non-member.
+            tryWorkspaceAutoSwitch(chatflowId, error, () => getSpecificChatflowApi.request(chatflowId)).then((handled) => {
+                if (!handled) errorFailed(`Failed to retrieve ${canvasTitle}: ${error.response.data.message}`)
+            })
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -34,6 +34,7 @@ import chatflowsApi from '@/api/chatflows'
 
 // Hooks
 import useApi from '@/hooks/useApi'
+import { useFlowWorkspaceAutoSwitch } from '@/hooks/useFlowWorkspaceAutoSwitch'
 import useConfirm from '@/hooks/useConfirm'
 import { useAuth } from '@/hooks/useAuth'
 
@@ -112,6 +113,7 @@ const Canvas = () => {
     const createNewChatflowApi = useApi(chatflowsApi.createNewChatflow)
     const updateChatflowApi = useApi(chatflowsApi.updateChatflow)
     const getSpecificChatflowApi = useApi(chatflowsApi.getSpecificChatflow)
+    const tryWorkspaceAutoSwitch = useFlowWorkspaceAutoSwitch()
     const getHasChatflowChangedApi = useApi(chatflowsApi.getHasChatflowChanged)
 
     // ==============================|| Events & Actions ||============================== //
@@ -420,7 +422,12 @@ const Canvas = () => {
             setEdges(initialFlow.edges || [])
             dispatch({ type: SET_CHATFLOW, chatflow })
         } else if (getSpecificChatflowApi.error) {
-            errorFailed(`Failed to retrieve ${canvasTitle}: ${getSpecificChatflowApi.error.response.data.message}`)
+            const error = getSpecificChatflowApi.error
+            // If the flow lives in another workspace the user is a member of, auto-switch + re-fetch instead
+            // of dead-ending on "not found". Falls back to the normal error if it's a genuine 404 / non-member.
+            tryWorkspaceAutoSwitch(chatflowId, error, () => getSpecificChatflowApi.request(chatflowId)).then((handled) => {
+                if (!handled) errorFailed(`Failed to retrieve ${canvasTitle}: ${error.response.data.message}`)
+            })
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -426,7 +426,10 @@ const Canvas = () => {
             // If the flow lives in another workspace the user is a member of, auto-switch + re-fetch instead
             // of dead-ending on "not found". Falls back to the normal error if it's a genuine 404 / non-member.
             tryWorkspaceAutoSwitch(chatflowId, error, () => getSpecificChatflowApi.request(chatflowId)).then((handled) => {
-                if (!handled) errorFailed(`Failed to retrieve ${canvasTitle}: ${error.response.data.message}`)
+                if (!handled) {
+                    const errorMsg = error?.response?.data?.message || error?.message || 'Unknown error'
+                    errorFailed(`Failed to retrieve ${canvasTitle}: ${errorMsg}`)
+                }
             })
         }
 


### PR DESCRIPTION
Closes #6581

### What this does

In multi-user / enterprise mode, chatflows/agentflows are scoped to the user's **active** workspace, and the canvas load is scoped to that active workspace. So when a user opens a flow URL (`/canvas/:id`, `/agentcanvas/:id`, `/v2/agentcanvas/:id`) whose flow lives in a workspace they are a **member of** but which isn't active, the canvas dead-ends on:

> `Chatflow <id> not found in the database!`

and they have to manually find and switch workspaces. Since `chat_flow.id` is a globally-unique UUID it maps to exactly one owning workspace, so the UI can resolve it and switch automatically — **only when the user is a member**.

### Changes

**Backend**
- `services/chatflows/index.ts`: new `resolveChatflowWorkspace(chatflowId, userId)` — looks the flow up by id (no workspace filter), then gates strictly on a direct `workspace_user` membership check, returning `{ workspaceId }`. Every failure mode (bad UUID aside) returns the **identical** `404 "Chatflow <id> not found in the database!"` as `getChatflowById`.
- `controllers/chatflows/index.ts`: new `getChatflowWorkspace` controller (uses `req.user?.id`; API-key callers have no user → 404).
- `routes/chatflows/index.ts`: new `GET /chatflows/resolve-workspace/:id` (two-segment path so it never collides with the `['/', '/:id']` matcher; same `checkAnyPermission` as the read route).

**Frontend**
- `api/chatflows.js`: `getChatflowWorkspace(id)`.
- `hooks/useFlowWorkspaceAutoSwitch.jsx` (new): shared hook used by both canvases. On a 404, resolves the owning workspace and — only if it's in the user's `assignedWorkspaces` and isn't already active — calls the existing `workspaceApi.switchWorkspace`, dispatches `workspaceSwitchSuccess`, and re-fetches the flow. Attempts at most once per flow id; falls back to the normal error otherwise. Stays on the same canvas URL (no `navigate('/'); navigate(0)`).
- `views/canvas/index.jsx` and `views/agentflowsv2/Canvas.jsx`: wire the hook into the existing `getSpecificChatflow` error branch.

### Security

This preserves the existing **"Protect Against Cross-Workspace Chatflow Disclosure"** behavior:
- All non-member / missing / no-user branches return the **identical 404**, so the endpoint never reveals that a flow exists in a workspace the caller can't access.
- Membership is the only thing that reveals a workspace id; API-key callers are excluded.
- The client additionally verifies the resolved workspace is in `assignedWorkspaces` before switching, so it can never switch into an unauthorized workspace.

### How it was tested

Manually against a local multi-user instance:
1. **Member-but-inactive:** flow in WS-A, user member of A, active in B → opening the flow URL auto-switches to A and the canvas loads, URL preserved. ✅
2. **Non-member:** user not in A opens A's flow → identical 404, no switch, no leak. ✅
3. **Same-workspace:** normal open unaffected. ✅
4. Verified for both v1 (`/canvas`, `/agentcanvas`) and v2 (`/v2/agentcanvas`).

The backend resolver was also exercised directly: 404 repro, 200 member-resolve, identical-404 for non-member (no leak), 400 for a malformed UUID.
