### PR TITLE
Add Scavio tool node

### DIFF
--- a/packages/components/credentials/ScavioApi.credential.ts
+++ b/packages/components/credentials/ScavioApi.credential.ts
@@ -1,0 +1,26 @@
+import { INodeParams, INodeCredential } from '../src/Interface'
+
+class ScavioApi implements INodeCredential {
+    label: string
+    name: string
+    version: number
+    description: string
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'Scavio API'
+        this.name = 'scavioApi'
+        this.version = 1.0
+        this.description =
+            'Scavio is a real-time search API for AI agents. Get an API key at https://dashboard.scavio.dev'
+        this.inputs = [
+            {
+                label: 'Scavio API Key',
+                name: 'scavioApiKey',
+                type: 'password'
+            }
+        ]
+    }
+}
+
+module.exports = { credClass: ScavioApi }

--- a/packages/components/nodes/tools/Scavio/Scavio.ts
+++ b/packages/components/nodes/tools/Scavio/Scavio.ts
@@ -1,7 +1,7 @@
-import axios from 'axios'
 import { Tool } from '@langchain/core/tools'
 import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { secureAxiosRequest } from '../../../src/httpSecurity'
 
 interface ScavioSearchParams {
     apiKey: string
@@ -47,12 +47,19 @@ class ScavioSearchTool extends Tool {
         if (this.page) body.page = this.page
 
         try {
-            const { data } = await axios.post('https://api.scavio.dev/api/v2/google', body, {
+            const response = await secureAxiosRequest({
+                method: 'POST',
+                url: 'https://api.scavio.dev/api/v2/google',
+                data: body,
                 headers: {
                     'Content-Type': 'application/json',
                     Authorization: `Bearer ${this.apiKey}`
                 }
             })
+            if (response.status >= 400) {
+                return `Scavio API error (${response.status}): ${JSON.stringify(response.data).slice(0, 2000)}`
+            }
+            const data = response.data
             const results = Array.isArray(data?.organic_results) ? data.organic_results : []
             if (!results.length) return JSON.stringify(data).slice(0, 4000)
             return JSON.stringify(
@@ -165,6 +172,9 @@ class Scavio_Tools implements INode {
     async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
         const credentialData = await getCredentialData(nodeData.credential ?? '', options)
         const scavioApiKey = getCredentialParam('scavioApiKey', credentialData, nodeData)
+        if (!scavioApiKey) {
+            throw new Error('Scavio API Key is missing. Please connect your Scavio API credential.')
+        }
 
         const searchType = nodeData.inputs?.searchType as string
         const countryCode = nodeData.inputs?.countryCode as string

--- a/packages/components/nodes/tools/Scavio/Scavio.ts
+++ b/packages/components/nodes/tools/Scavio/Scavio.ts
@@ -1,0 +1,188 @@
+import axios from 'axios'
+import { Tool } from '@langchain/core/tools'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
+import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+
+interface ScavioSearchParams {
+    apiKey: string
+    searchType?: string
+    countryCode?: string
+    language?: string
+    device?: string
+    lightRequest?: boolean
+    page?: number
+}
+
+class ScavioSearchTool extends Tool {
+    name = 'scavio_search'
+    description =
+        'Real-time web search via Scavio. Input should be a plain search query string. Returns Google results (title, url, description) as JSON.'
+
+    apiKey: string
+    searchType?: string
+    countryCode?: string
+    language?: string
+    device?: string
+    lightRequest?: boolean
+    page?: number
+
+    constructor(fields: ScavioSearchParams) {
+        super()
+        this.apiKey = fields.apiKey
+        this.searchType = fields.searchType
+        this.countryCode = fields.countryCode
+        this.language = fields.language
+        this.device = fields.device
+        this.lightRequest = fields.lightRequest
+        this.page = fields.page
+    }
+
+    async _call(input: string): Promise<string> {
+        const body: Record<string, any> = { query: input }
+        if (this.searchType) body.search_type = this.searchType
+        if (this.countryCode) body.country_code = this.countryCode
+        if (this.language) body.language = this.language
+        if (this.device) body.device = this.device
+        if (this.lightRequest !== undefined) body.light_request = this.lightRequest
+        if (this.page) body.page = this.page
+
+        try {
+            const { data } = await axios.post('https://api.scavio.dev/api/v2/google', body, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${this.apiKey}`
+                }
+            })
+            const results = Array.isArray(data?.organic_results) ? data.organic_results : []
+            if (!results.length) return JSON.stringify(data).slice(0, 4000)
+            return JSON.stringify(
+                results.map((r: any) => ({ title: r.title, url: r.link, description: r.snippet })),
+                null,
+                2
+            )
+        } catch (error: any) {
+            const status = error?.response?.status
+            const detail = error?.response?.data ? JSON.stringify(error.response.data) : error?.message
+            return `Scavio API error${status ? ` (${status})` : ''}: ${detail}`
+        }
+    }
+}
+
+class Scavio_Tools implements INode {
+    label: string
+    name: string
+    version: number
+    description: string
+    type: string
+    icon: string
+    category: string
+    baseClasses: string[]
+    credential: INodeParams
+    inputs: INodeParams[]
+
+    constructor() {
+        this.label = 'Scavio'
+        this.name = 'scavioAPI'
+        this.version = 1.0
+        this.type = 'Scavio'
+        this.icon = 'scavio.svg'
+        this.category = 'Tools'
+        this.description =
+            'Real-time search API for AI agents - Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram as clean JSON'
+        this.inputs = [
+            {
+                label: 'Search Type',
+                name: 'searchType',
+                type: 'options',
+                options: [
+                    { label: 'Classic', name: 'classic' },
+                    { label: 'News', name: 'news' },
+                    { label: 'Images', name: 'images' }
+                ],
+                default: 'classic',
+                description: 'Google search vertical',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Country Code',
+                name: 'countryCode',
+                type: 'string',
+                placeholder: 'us',
+                description: 'Two-letter country code, e.g. us',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Language',
+                name: 'language',
+                type: 'string',
+                placeholder: 'en',
+                description: 'Two-letter language code, e.g. en',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Device',
+                name: 'device',
+                type: 'options',
+                options: [
+                    { label: 'Desktop', name: 'desktop' },
+                    { label: 'Mobile', name: 'mobile' }
+                ],
+                default: 'desktop',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Light Request',
+                name: 'lightRequest',
+                type: 'boolean',
+                default: true,
+                description: 'Cheaper, lighter response (1 credit instead of 2)',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Page',
+                name: 'page',
+                type: 'number',
+                default: 1,
+                description: 'Result page number (1-based)',
+                additionalParams: true,
+                optional: true
+            }
+        ]
+        this.credential = {
+            label: 'Connect Credential',
+            name: 'credential',
+            type: 'credential',
+            credentialNames: ['scavioApi']
+        }
+        this.baseClasses = [this.type, ...getBaseClasses(Tool)]
+    }
+
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
+        const credentialData = await getCredentialData(nodeData.credential ?? '', options)
+        const scavioApiKey = getCredentialParam('scavioApiKey', credentialData, nodeData)
+
+        const searchType = nodeData.inputs?.searchType as string
+        const countryCode = nodeData.inputs?.countryCode as string
+        const language = nodeData.inputs?.language as string
+        const device = nodeData.inputs?.device as string
+        const lightRequest = nodeData.inputs?.lightRequest as boolean
+        const page = nodeData.inputs?.page as number
+
+        return new ScavioSearchTool({
+            apiKey: scavioApiKey,
+            searchType,
+            countryCode,
+            language,
+            device,
+            lightRequest,
+            page
+        })
+    }
+}
+
+module.exports = { nodeClass: Scavio_Tools }

--- a/packages/components/nodes/tools/Scavio/Scavio.ts
+++ b/packages/components/nodes/tools/Scavio/Scavio.ts
@@ -5,11 +5,11 @@ import { secureAxiosRequest } from '../../../src/httpSecurity'
 
 interface ScavioSearchParams {
     apiKey: string
-    searchType?: string
-    countryCode?: string
-    language?: string
+    gl?: string
+    hl?: string
+    googleDomain?: string
+    location?: string
     device?: string
-    lightRequest?: boolean
     page?: number
 }
 
@@ -19,32 +19,32 @@ class ScavioSearchTool extends Tool {
         'Real-time web search via Scavio. Input should be a plain search query string. Returns Google results (title, url, description) as JSON.'
 
     apiKey: string
-    searchType?: string
-    countryCode?: string
-    language?: string
+    gl?: string
+    hl?: string
+    googleDomain?: string
+    location?: string
     device?: string
-    lightRequest?: boolean
     page?: number
 
     constructor(fields: ScavioSearchParams) {
         super()
         this.apiKey = fields.apiKey
-        this.searchType = fields.searchType
-        this.countryCode = fields.countryCode
-        this.language = fields.language
+        this.gl = fields.gl
+        this.hl = fields.hl
+        this.googleDomain = fields.googleDomain
+        this.location = fields.location
         this.device = fields.device
-        this.lightRequest = fields.lightRequest
         this.page = fields.page
     }
 
     async _call(input: string): Promise<string> {
         const body: Record<string, any> = { query: input }
-        if (this.searchType) body.search_type = this.searchType
-        if (this.countryCode) body.country_code = this.countryCode
-        if (this.language) body.language = this.language
+        if (this.gl) body.gl = this.gl
+        if (this.hl) body.hl = this.hl
+        if (this.googleDomain) body.google_domain = this.googleDomain
+        if (this.location) body.location = this.location
         if (this.device) body.device = this.device
-        if (this.lightRequest !== undefined) body.light_request = this.lightRequest
-        if (this.page) body.page = this.page
+        if (this.page && this.page > 1) body.start = (this.page - 1) * 10
 
         try {
             const response = await secureAxiosRequest({
@@ -98,34 +98,38 @@ class Scavio_Tools implements INode {
             'Real-time search API for AI agents - Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram as clean JSON'
         this.inputs = [
             {
-                label: 'Search Type',
-                name: 'searchType',
-                type: 'options',
-                options: [
-                    { label: 'Classic', name: 'classic' },
-                    { label: 'News', name: 'news' },
-                    { label: 'Images', name: 'images' }
-                ],
-                default: 'classic',
-                description: 'Google search vertical',
-                additionalParams: true,
-                optional: true
-            },
-            {
                 label: 'Country Code',
-                name: 'countryCode',
+                name: 'gl',
                 type: 'string',
                 placeholder: 'us',
-                description: 'Two-letter country code, e.g. us',
+                description: 'Two-letter country code (ISO 3166-1 alpha-2), e.g. us',
                 additionalParams: true,
                 optional: true
             },
             {
                 label: 'Language',
-                name: 'language',
+                name: 'hl',
                 type: 'string',
                 placeholder: 'en',
                 description: 'Two-letter language code, e.g. en',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Google Domain',
+                name: 'googleDomain',
+                type: 'string',
+                placeholder: 'google.com',
+                description: 'Google domain to use, e.g. google.com',
+                additionalParams: true,
+                optional: true
+            },
+            {
+                label: 'Location',
+                name: 'location',
+                type: 'string',
+                placeholder: 'Austin, Texas, United States',
+                description: 'Canonical location string to originate the search from',
                 additionalParams: true,
                 optional: true
             },
@@ -138,15 +142,6 @@ class Scavio_Tools implements INode {
                     { label: 'Mobile', name: 'mobile' }
                 ],
                 default: 'desktop',
-                additionalParams: true,
-                optional: true
-            },
-            {
-                label: 'Light Request',
-                name: 'lightRequest',
-                type: 'boolean',
-                default: true,
-                description: 'Cheaper, lighter response (1 credit instead of 2)',
                 additionalParams: true,
                 optional: true
             },
@@ -176,20 +171,20 @@ class Scavio_Tools implements INode {
             throw new Error('Scavio API Key is missing. Please connect your Scavio API credential.')
         }
 
-        const searchType = nodeData.inputs?.searchType as string
-        const countryCode = nodeData.inputs?.countryCode as string
-        const language = nodeData.inputs?.language as string
+        const gl = nodeData.inputs?.gl as string
+        const hl = nodeData.inputs?.hl as string
+        const googleDomain = nodeData.inputs?.googleDomain as string
+        const location = nodeData.inputs?.location as string
         const device = nodeData.inputs?.device as string
-        const lightRequest = nodeData.inputs?.lightRequest as boolean
         const page = nodeData.inputs?.page as number
 
         return new ScavioSearchTool({
             apiKey: scavioApiKey,
-            searchType,
-            countryCode,
-            language,
+            gl,
+            hl,
+            googleDomain,
+            location,
             device,
-            lightRequest,
             page
         })
     }

--- a/packages/components/nodes/tools/Scavio/scavio.svg
+++ b/packages/components/nodes/tools/Scavio/scavio.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#1D4ED8"/>
+  <!-- Magnifying glass with data nodes - search API concept -->
+  <circle cx="14" cy="14" r="5.5" stroke="white" stroke-width="2"/>
+  <line x1="18" y1="18" x2="23" y2="23" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <!-- Data flow dots -->
+  <circle cx="14" cy="11.5" r="1" fill="white"/>
+  <circle cx="12" cy="14.5" r="1" fill="white"/>
+  <circle cx="16" cy="14.5" r="1" fill="white"/>
+</svg>


### PR DESCRIPTION
### Description

Adds a **Scavio** tool node under `Tools`, alongside the existing search nodes (Tavily, SerpAPI, Brave, Exa). Scavio is a real-time search API for AI agents (a unified API over Google, YouTube, Amazon, Walmart, Reddit, TikTok, and Instagram) that returns clean JSON.

The node returns a LangChain `Tool` that searches Google in real time and returns results (title, url, description) as JSON, so it plugs into any agent/chain that accepts a Tool. It follows the same structure as the existing `TavilyAPI` node.

### Files
- `packages/components/nodes/tools/Scavio/Scavio.ts` — the tool node
- `packages/components/nodes/tools/Scavio/scavio.svg` — icon
- `packages/components/credentials/ScavioApi.credential.ts` — API-key credential

### How it works
- User creates a **Scavio API** credential (API key from https://dashboard.scavio.dev).
- The node calls the Scavio API with the key and returns structured results.

Docs: https://scavio.dev/docs
