### PR TITLE
fix(postgres): honor user-supplied ssl config in vector store connection

### DIFF
--- a/packages/components/nodes/vectorstores/Postgres/driver/TypeORM.ts
+++ b/packages/components/nodes/vectorstores/Postgres/driver/TypeORM.ts
@@ -1,5 +1,6 @@
 import { DataSourceOptions } from 'typeorm'
 import { VectorStoreDriver } from './Base'
+import { resolvePostgresSSL } from '../sslConfig'
 import { FLOWISE_CHATID, ICommonObject } from '../../../../src'
 import { sanitizeDataSourceOptions } from '../../../../src/sanitizeDataSourceOptions'
 import { TypeORMVectorStore, TypeORMVectorStoreArgs, TypeORMVectorStoreDocument } from '@langchain/community/vectorstores/typeorm'
@@ -36,7 +37,10 @@ export class TypeORMDriver extends VectorStoreDriver {
                 type: 'postgres',
                 host: this.getHost(),
                 port: this.getPort(),
-                ssl: this.getSSL(),
+                // A user-supplied `ssl` in Additional Configuration (e.g. a custom CA or
+                // rejectUnauthorized flag for AWS RDS / corporate CAs) takes precedence over
+                // the boolean SSL toggle; see resolvePostgresSSL. Falls back to the toggle.
+                ssl: resolvePostgresSSL(additionalConfiguration, this.getSSL()),
                 username: user, // Required by TypeORMVectorStore
                 user: user, // Required by Pool in similaritySearchVectorWithScore
                 password: password,

--- a/packages/components/nodes/vectorstores/Postgres/sslConfig.test.ts
+++ b/packages/components/nodes/vectorstores/Postgres/sslConfig.test.ts
@@ -1,0 +1,30 @@
+import { resolvePostgresSSL } from './sslConfig'
+
+describe('resolvePostgresSSL', () => {
+    it('falls back to the boolean toggle when Additional Configuration has no ssl', () => {
+        expect(resolvePostgresSSL({}, true)).toBe(true)
+        expect(resolvePostgresSSL({}, false)).toBe(false)
+        expect(resolvePostgresSSL({ connectTimeout: 5000 }, true)).toBe(true)
+    })
+
+    it('falls back to the boolean toggle when Additional Configuration is undefined', () => {
+        expect(resolvePostgresSSL(undefined, true)).toBe(true)
+        expect(resolvePostgresSSL(undefined, false)).toBe(false)
+    })
+
+    it('prefers a user-supplied ssl object over the boolean toggle', () => {
+        const ssl = { rejectUnauthorized: true, ca: 'CERT' }
+        // custom CA must win even when the toggle is off (AWS RDS / corporate CA case)
+        expect(resolvePostgresSSL({ ssl }, false)).toBe(ssl)
+        expect(resolvePostgresSSL({ ssl }, true)).toBe(ssl)
+    })
+
+    it('respects an explicit ssl:false in Additional Configuration', () => {
+        expect(resolvePostgresSSL({ ssl: false }, true)).toBe(false)
+    })
+
+    it('respects rejectUnauthorized:false for self-signed certificates', () => {
+        const ssl = { rejectUnauthorized: false }
+        expect(resolvePostgresSSL({ ssl }, false)).toBe(ssl)
+    })
+})

--- a/packages/components/nodes/vectorstores/Postgres/sslConfig.ts
+++ b/packages/components/nodes/vectorstores/Postgres/sslConfig.ts
@@ -1,0 +1,27 @@
+/**
+ * SSL configuration resolution for the Postgres vector store connection.
+ *
+ * Kept as a dependency-free leaf module (no barrel import) so it can be unit
+ * tested in isolation, mirroring `src/sanitizeDataSourceOptions.ts`.
+ */
+
+/**
+ * Resolves the SSL option used to open the Postgres connection.
+ *
+ * The node exposes a boolean "SSL" toggle, but the "Additional Configuration"
+ * field also documents `ssl` as a supported TypeORM connection option. When an
+ * operator needs a custom CA (AWS RDS, an internal corporate CA) or has to relax
+ * verification for a self-signed certificate, they supply a richer value there,
+ * e.g. `{ "ssl": { "ca": "<pem>" } }` or `{ "ssl": { "rejectUnauthorized": false } }`.
+ * That value must take precedence over the boolean toggle instead of being
+ * clobbered by it, otherwise operators are pushed onto the global
+ * `NODE_TLS_REJECT_UNAUTHORIZED=0` escape hatch, which disables TLS verification
+ * process-wide. Falls back to the boolean toggle when Additional Configuration
+ * does not specify `ssl`, preserving the existing default behaviour.
+ */
+export function resolvePostgresSSL(additionalConfig: Record<string, any> | undefined, sslToggle: boolean): boolean | Record<string, any> {
+    if (additionalConfig != null && Object.prototype.hasOwnProperty.call(additionalConfig, 'ssl')) {
+        return additionalConfig.ssl
+    }
+    return sslToggle
+}


### PR DESCRIPTION
## Summary

The Postgres vector store cannot connect to databases that present a custom or self-signed CA chain (AWS RDS, an internal corporate CA). Upserts fail with:

```
Error: self-signed certificate in certificate chain
Error: unable to verify the first certificate
```

Root cause: `getDriverFromConfig` always selects the **TypeORM** driver, and `TypeORMDriver.getPostgresConnectionOptions` set the connection `ssl` field from the boolean **SSL** toggle *after* spreading the user's **Additional Configuration**:

```ts
this._postgresConnectionOptions = {
    ...additionalConfiguration, // may contain ssl: { ca, rejectUnauthorized }
    ...
    ssl: this.getSSL(),         // boolean — clobbers the object above
    ...
}
```

So any richer `ssl` object a user supplies is silently discarded — even though the Additional Configuration field description explicitly documents `ssl` as a supported TypeORM option ("Optional TypeORM connection options (e.g. ssl, connectTimeout)"). The only remaining workaround is the global `NODE_TLS_REJECT_UNAUTHORIZED=0` env var, which disables TLS verification process-wide and is called out as unsafe by users in the linked issue.

This PR resolves `ssl` so that a value supplied via Additional Configuration takes precedence over the boolean toggle, and falls back to the toggle when it is absent. The resolution lives in a small dependency-free helper (`sslConfig.ts`) so it can be unit tested in isolation, mirroring the existing `sanitizeDataSourceOptions.ts` pattern.

Operators can now point Flowise at an RDS / corporate-CA Postgres with a scoped, per-connection SSL config, for example in **Additional Configuration**:

```json
{ "ssl": { "rejectUnauthorized": true, "ca": "-----BEGIN CERTIFICATE-----\n..." } }
```

or, for a self-signed cert:

```json
{ "ssl": { "rejectUnauthorized": false } }
```

**No behaviour changes for existing users:** when Additional Configuration does not contain `ssl`, the boolean toggle drives the connection exactly as before.

Closes #5292
Closes #5351

## Verification

- `resolvePostgresSSL` returns the user-supplied `ssl` object/boolean when present, else the toggle — covered by a new unit test (`sslConfig.test.ts`, 5 cases: toggle passthrough, undefined config, object-wins-over-toggle for both toggle states, explicit `ssl:false`, `rejectUnauthorized:false`).
- `tsc --noEmit` on `flowise-components`: 0 errors.
- `eslint` on the changed files: 0 errors/warnings.
- `prettier --check` on the changed files: clean.
- `jest` (`sslConfig.test.ts`): 5/5 passing.
- Scope is confined to the Postgres vector store TypeORM connection path; no defaults changed, and the PGVector driver (currently unreachable) is untouched.
