### PR TITLE
docs: add local providers, caching, and RAG template guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ Flowise supports different environment variables to configure your instance. You
 
 You can view the Flowise Docs [here](https://docs.flowiseai.com/)
 
+### In-Repository Guides
+
+Self-hosted and local-development guides shipped with this repo:
+
+-   [Local LLM Providers (Ollama, LM Studio, LocalAI)](./docs/local-providers.md)
+-   [LLM & Embedding Caching](./docs/llm-caching.md)
+-   [RAG & Agent Templates](./docs/rag-and-agent-templates.md)
+-   [Local Development Setup](./docs/local-development-setup.md)
+-   [All guides](./docs/README.md)
+
 ## 🌐 Self Host
 
 Deploy Flowise self-hosted in your existing infrastructure, we support various [deployments](https://docs.flowiseai.com/configuration/deployment)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# Flowise In-Repository Guides
+
+These guides complement the official [Flowise documentation](https://docs.flowiseai.com/). They focus on common self-hosted and local-development workflows that are not always easy to discover from the UI alone.
+
+## Guides
+
+| Guide | Description |
+| ----- | ----------- |
+| [Local LLM Providers](./local-providers.md) | Run Ollama, LocalAI, and LM Studio with Flowise — including Docker networking and embeddings |
+| [LLM & Embedding Caching](./llm-caching.md) | Reduce latency and cost with response and embedding caches |
+| [RAG & Agent Templates](./rag-and-agent-templates.md) | Start from built-in marketplace templates for document Q&A and AgentFlow v2 |
+| [Local Development Setup](./local-development-setup.md) | Developer setup checklist, env files, and common troubleshooting |
+
+## Contributing to documentation
+
+Official docs live in the [FlowiseDocs](https://github.com/FlowiseAI/FlowiseDocs) repository. In-repo guides here cover setup patterns tied directly to nodes and marketplace templates shipped with this codebase.
+
+When adding a new guide:
+
+1. Keep examples aligned with current node names in `packages/components/nodes/`.
+2. Link to [docs.flowiseai.com](https://docs.flowiseai.com/) for node-specific API details where they already exist.
+3. Avoid private URLs, internal credentials, or environment-specific references.

--- a/docs/llm-caching.md
+++ b/docs/llm-caching.md
@@ -1,0 +1,172 @@
+# LLM & Embedding Caching
+
+Flowise integrates LangChain cache nodes to avoid redundant LLM calls and embedding computations. Caching is especially useful for:
+
+- Repeated identical prompts in development
+- High-traffic chatflows with common questions
+- RAG pipelines that re-embed the same document chunks
+
+## Cache types in Flowise
+
+| Node | Category | What it caches | Persistence |
+| ---- | -------- | -------------- | ----------- |
+| InMemory Cache | Cache | LLM responses | Per chatflow; cleared on restart |
+| Redis Cache | Cache | LLM responses | Shared across processes/servers |
+| Momento Cache | Cache | LLM responses | Distributed serverless cache |
+| Upstash Redis Cache | Cache | LLM responses | Managed Redis (Upstash) |
+| InMemory Embedding Cache | Cache | Embedding vectors | Per chatflow; cleared on restart |
+| Redis Embeddings Cache | Cache | Embedding vectors | Shared across processes/servers |
+
+Cache nodes output a `BaseCache` (LLM) or wrapped `Embeddings` (embedding cache) that downstream nodes consume.
+
+---
+
+## LLM response caching
+
+Many chat model and LLM nodes expose an optional **Cache** input. Connect a cache node to that input before connecting the model to your chain or agent.
+
+### Supported models (partial list)
+
+Cache input is available on nodes including:
+
+- ChatOllama, ChatLocalAI, ChatOpenAI, ChatOpenAI Custom
+- Groq, Mistral, Anthropic, Cohere, TogetherAI
+- Ollama (LLM), OpenAI (LLM), Azure OpenAI
+
+Check the node's **Cache** field in the UI — if present, any `BaseCache` output can be wired in.
+
+### InMemory Cache (development)
+
+Best for local testing. Cache is scoped to the chatflow and stored in Flowise's cache pool.
+
+```
+[InMemory Cache] ──► [ChatOllama / ChatOpenAI / ...] ──► [Chain or Agent]
+```
+
+**Behavior:**
+
+- Identical prompts with the same model configuration return cached text.
+- Cache is lost when the Flowise process restarts.
+- LangChain skips `handleLLMStart` / token streaming callbacks on cache hits.
+
+### Redis Cache (production)
+
+Use when running multiple Flowise workers or queue mode.
+
+**Setup:**
+
+1. Add **Cache → Redis Cache**.
+2. Attach **Redis Cache API** or **Redis Cache URL API** credentials.
+3. Optionally set **Time to Live (ms)** — cached entries expire after TTL.
+4. Connect the Redis Cache output to your chat model's **Cache** input.
+
+**Credential options:**
+
+| Credential | Fields |
+| ---------- | ------ |
+| Redis Cache API | Host, port, username, password, SSL |
+| Redis Cache URL API | `redis://` or `rediss://` connection URL |
+
+Redis Cache reconnects automatically if the connection drops during lookup/update.
+
+### Momento & Upstash
+
+For managed infrastructure without self-hosting Redis:
+
+- **Momento Cache** — requires Momento API credentials and cache name.
+- **Upstash Redis Cache** — requires Upstash REST URL and token.
+
+Both follow the same wiring pattern as Redis Cache.
+
+---
+
+## Embedding caching
+
+Embedding caches wrap an underlying embeddings node so repeated text is not re-vectorized.
+
+### InMemory Embedding Cache
+
+```
+[Ollama Embedding] ──► [InMemory Embedding Cache] ──► [Faiss / Chroma / ...]
+```
+
+**Fields:**
+
+- **Embeddings** — connect your embeddings node output here.
+- **Namespace** (optional) — isolate cache keys when sharing a Flowise instance.
+
+### Redis Embeddings Cache
+
+Same pattern as InMemory, but vectors persist in Redis.
+
+**Additional fields:**
+
+- **Time to Live (ms)** — default `3600000` (1 hour).
+- **Namespace** — prefix for cache keys.
+
+Use Redis Embeddings Cache when:
+
+- Multiple workers upsert the same document store
+- You re-run ingestion flows against unchanged files
+
+---
+
+## Example: cached local Ollama chat
+
+```
+┌─────────────────┐     ┌────────────┐     ┌──────────────────┐
+│ InMemory Cache  │────►│ ChatOllama │────►│ Conversation     │
+│                 │     │ llama3.2   │     │ Chain            │
+└─────────────────┘     └────────────┘     └──────────────────┘
+```
+
+1. Add **InMemory Cache** to the canvas.
+2. Add **ChatOllama** and connect the cache output to the model's **Cache** input.
+3. Connect ChatOllama to your chain.
+4. Ask the same question twice — the second response should return without a full model inference (no token stream on cache hit).
+
+---
+
+## Example: cached RAG ingestion
+
+```
+┌──────────────┐   ┌─────────────────────────┐   ┌────────┐
+│ Ollama       │──►│ InMemory Embedding Cache│──►│ Faiss  │
+│ Embedding    │   │                         │   │        │
+└──────────────┘   └─────────────────────────┘   └────────┘
+```
+
+Re-upserting the same PDF chunks reuses stored vectors instead of calling the embedding model again.
+
+---
+
+## Cache key behavior
+
+LLM caches key on the **prompt text** and an **LLM configuration hash** (model name, temperature, and related parameters). Changing any model parameter misses the cache.
+
+Embedding caches key on the **document text** (with optional namespace prefix).
+
+---
+
+## When caching does not help
+
+- **Streaming UX testing** — cached responses bypass token streaming.
+- **Identical prompts, different session context** — chains that inject memory/history change the effective prompt; cache hits decrease.
+- **Tool-calling agents** — multi-step tool loops rarely repeat identical full prompts.
+- **Provider-side prompt caching** — Anthropic/OpenAI prompt caching is separate from these LangChain cache nodes. Flowise cache nodes store full prior responses, not provider token-cache discounts.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| No cache hit on repeat question | Memory/history alters prompt | Test with a chain that has no memory, or identical full prompt |
+| Redis connection errors | Wrong credentials or network | Verify `PING` from Flowise host; check `REDIS_KEEP_ALIVE` env |
+| Stale answers after prompt change | Old cache entry | Restart Flowise (InMemory) or flush Redis keys |
+| Embeddings still slow | Cache not in path | Ensure embeddings flow _through_ the cache node, not around it |
+
+## Related documentation
+
+- [Local LLM Providers](./local-providers.md) — Ollama and LocalAI setup
+- [RAG & Agent Templates](./rag-and-agent-templates.md) — templates that benefit from embedding caches

--- a/docs/local-development-setup.md
+++ b/docs/local-development-setup.md
@@ -1,0 +1,139 @@
+# Local Development Setup
+
+A concise checklist for running Flowise from source. For npm/Docker quick start, see the [main README](../README.md).
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+| ----------- | ------- | ----- |
+| Node.js | >= 20 | Required for build and runtime |
+| pnpm | v10 | Monorepo package manager (`npm i -g pnpm`) |
+| Git | any | Clone and branch for contributions |
+
+Optional for local LLM testing:
+
+- [Ollama](https://ollama.com) on port 11434
+- [LM Studio](https://lmstudio.ai) on port 1234
+- [LocalAI](https://localai.io) on port 8080
+
+## First-time setup
+
+```bash
+git clone https://github.com/FlowiseAI/Flowise.git
+cd Flowise
+pnpm install
+pnpm build
+pnpm start
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+### Environment files (development mode)
+
+For hot reload during UI/server development:
+
+**`packages/server/.env`** (copy from `.env.example`):
+
+```env
+PORT=3000
+# DATABASE_PATH=~/.flowise   # optional; defaults to ~/.flowise
+```
+
+**`packages/ui/.env`** (copy from `.env.example`):
+
+```env
+VITE_PORT=8080
+```
+
+Then run:
+
+```bash
+pnpm dev
+```
+
+The UI dev server runs at [http://localhost:8080](http://localhost:8080) with API proxy to the server.
+
+> Changes in `packages/components` require `pnpm build` to appear in the running app.
+
+## Build memory issues
+
+If `pnpm build` fails with exit code 134 (heap out of memory):
+
+```powershell
+# Windows PowerShell
+$env:NODE_OPTIONS="--max-old-space-size=4096"
+pnpm build
+```
+
+```bash
+# macOS / Linux / Git Bash
+export NODE_OPTIONS="--max-old-space-size=4096"
+pnpm build
+```
+
+## Project layout
+
+| Package | Path | Role |
+| ------- | ---- | ---- |
+| Server | `packages/server` | Express API, marketplace templates, persistence |
+| UI | `packages/ui` | React frontend |
+| Components | `packages/components` | LangChain nodes and credentials |
+| AgentFlow | `packages/agentflow` | AgentFlow v2 canvas SDK |
+| API Docs | `packages/api-documentation` | Swagger UI |
+
+## Running tests
+
+Tests are co-located with source files (`Foo.test.ts` next to `Foo.ts`).
+
+```bash
+# All packages
+pnpm test
+
+# Individual packages
+pnpm --filter flowise-components test
+pnpm --filter "./packages/server" test
+pnpm --filter @flowiseai/agentflow test
+```
+
+## Docker development
+
+See [`docker/README.md`](../docker/README.md) for Compose setup.
+
+Persist data across restarts by setting in `docker/.env`:
+
+```env
+DATABASE_PATH=/root/.flowise
+LOG_PATH=/root/.flowise/logs
+SECRETKEY_PATH=/root/.flowise
+BLOB_STORAGE_PATH=/root/.flowise/storage
+```
+
+When combining Docker Flowise with local LLM services on the host, use `host.docker.internal` in model base URLs. See [Local LLM Providers](./local-providers.md).
+
+## Useful environment variables
+
+| Variable | Purpose |
+| -------- | ------- |
+| `DEBUG` | Verbose component logging |
+| `DISABLED_NODES` | Comma-separated node names to hide from UI |
+| `MODEL_LIST_CONFIG_JSON` | Path or URL to custom model list JSON |
+| `FLOWISE_FILE_SIZE_LIMIT` | Upload size cap (default `50mb`) |
+| `DATABASE_TYPE` | `sqlite` (default), `postgres`, or `mysql` |
+
+Full list: [CONTRIBUTING.md — Env Variables](../CONTRIBUTING.md#-env-variables) or [docs.flowiseai.com](https://docs.flowiseai.com/configuration/environment-variables).
+
+## Common issues
+
+| Issue | Fix |
+| ----- | --- |
+| Port 3000 in use | Set `PORT=3001` in `packages/server/.env` |
+| Blank UI after component change | Run `pnpm build` from repo root |
+| `pnpm install` peer dependency warnings | Expected in monorepo; use pnpm v10 |
+| SQLite locked | Only one server instance per `DATABASE_PATH` |
+| Cannot reach Ollama from Docker | Use `http://host.docker.internal:11434` |
+
+## Next steps
+
+- [Local LLM Providers](./local-providers.md) — connect Ollama, LM Studio, or LocalAI
+- [RAG & Agent Templates](./rag-and-agent-templates.md) — start from marketplace flows
+- [Contributing Guide](../CONTRIBUTING.md) — PR process and code standards

--- a/docs/local-providers.md
+++ b/docs/local-providers.md
@@ -1,0 +1,212 @@
+# Local LLM Providers
+
+Flowise supports several ways to run models locally without cloud API keys. This guide covers the three most common setups: **Ollama**, **LocalAI**, and **LM Studio**.
+
+For node-level API reference, see the official docs:
+
+- [ChatOllama](https://docs.flowiseai.com/integrations/langchain/chat-models/chatollama)
+- [ChatLocalAI](https://docs.flowiseai.com/integrations/langchain/chat-models/chatlocalai)
+
+## Quick comparison
+
+| Provider | Flowise node(s) | Default base URL | Best for |
+| -------- | --------------- | ---------------- | -------- |
+| Ollama | ChatOllama, Ollama, Ollama Embedding | `http://localhost:11434` | Easiest local setup; native Ollama models |
+| LocalAI | ChatLocalAI, LocalAI Embedding | `http://localhost:8080/v1` | OpenAI-compatible local server; ggml models |
+| LM Studio | ChatOpenAI Custom | `http://localhost:1234/v1` | GUI model loader; OpenAI-compatible API |
+
+---
+
+## Ollama
+
+### 1. Install and pull a model
+
+```bash
+# Install from https://ollama.com/download
+ollama pull llama3.2
+
+# Or run in Docker
+docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
+docker exec -it ollama ollama pull llama3.2
+```
+
+Verify the server is running:
+
+```bash
+curl http://localhost:11434/api/tags
+```
+
+### 2. Configure ChatOllama in Flowise
+
+1. Open the canvas and add **Chat Models → Ollama**.
+2. Set **Model Name** to the tag you pulled (e.g. `llama3.2`).
+3. Leave **Base URL** as `http://localhost:11434` when Flowise runs on the same machine.
+
+Optional fields worth tuning for RAG workloads:
+
+- **Context Window Size** (`numCtx`) — increase when documents are long (e.g. `8192`).
+- **Keep Alive** — keep the model loaded between requests (e.g. `10m`).
+- **Number of GPU** (`numGpu`) — set layers to offload; on macOS defaults to Metal.
+
+### 3. Embeddings with Ollama
+
+For local RAG, pair **ChatOllama** with **Embeddings → Ollama Embedding**:
+
+| Field | Example |
+| ----- | ------- |
+| Base URL | `http://localhost:11434` |
+| Model Name | `nomic-embed-text` |
+
+Pull the embedding model first:
+
+```bash
+ollama pull nomic-embed-text
+```
+
+### 4. Ollama Cloud (optional)
+
+If you use [Ollama Cloud](https://ollama.com) instead of a local daemon:
+
+1. Create an API key at [ollama.com/settings/keys](https://ollama.com/settings/keys).
+2. In Flowise, create an **Ollama API** credential with that key.
+3. Set **Base URL** to `https://ollama.com`.
+4. Use a cloud-available model name.
+
+### 5. Docker networking (Flowise + Ollama both in containers)
+
+When Flowise and Ollama run in separate Docker containers, `localhost` inside the Flowise container does not reach Ollama.
+
+| Host OS | Base URL for ChatOllama |
+| ------- | ----------------------- |
+| Windows / macOS | `http://host.docker.internal:11434` |
+| Linux | `http://172.17.0.1:11434` (default Docker bridge gateway) |
+
+> **Note:** Ollama listens on port **11434**, not 8000.
+
+---
+
+## LocalAI
+
+LocalAI exposes an OpenAI-compatible REST API for ggml-compatible models.
+
+### 1. Start LocalAI
+
+```bash
+git clone https://github.com/mudler/LocalAI
+cd LocalAI
+# Place model files in models/
+docker compose up -d --pull always
+```
+
+Verify:
+
+```bash
+curl http://localhost:8080/v1/models
+```
+
+### 2. Configure ChatLocalAI in Flowise
+
+1. Add **Chat Models → LocalAI**.
+2. Set **Base Path** to `http://localhost:8080/v1`.
+3. Set **Model Name** to the filename in your `models/` directory (e.g. `ggml-gpt4all-j.bin`).
+
+For embeddings, use **Embeddings → LocalAI Embedding** with the same base path and an embedding-capable model name.
+
+### 3. Docker networking
+
+| Host OS | Base Path |
+| ------- | --------- |
+| Windows / macOS | `http://host.docker.internal:8080/v1` |
+| Linux | `http://172.17.0.1:8080/v1` |
+
+LocalAI accepts a placeholder API key. Flowise sends `sk-` by default when no credential is attached.
+
+---
+
+## LM Studio
+
+LM Studio is not a dedicated Flowise node. It works through the **OpenAI-compatible local server** that LM Studio exposes.
+
+### 1. Start the local server in LM Studio
+
+1. Load a model in LM Studio.
+2. Open the **Local Server** tab.
+3. Start the server (default port **1234**).
+4. Note the model identifier shown in the server panel.
+
+### 2. Configure ChatOpenAI Custom in Flowise
+
+1. Add **Chat Models → OpenAI Custom Model**.
+2. Set **Model Name** to the identifier from LM Studio (e.g. `meta-llama-3.1-8b-instruct`).
+3. Expand **Additional Parameters** and set **Base Path** to:
+
+   ```
+   http://localhost:1234/v1
+   ```
+
+4. Credentials are optional — LM Studio does not validate the API key. You can create an OpenAI credential with any placeholder value, or leave credentials unset if your Flowise version allows it.
+
+### 3. Embeddings in LM Studio workflows
+
+LM Studio's local server is primarily for chat completions. For RAG with LM Studio chat + local embeddings, use one of:
+
+- **Ollama Embedding** or **LocalAI Embedding** for the vector store pipeline
+- **In-memory** or **HuggingFace Inference** embeddings if you already run those services
+
+A typical local stack: **ChatOpenAI Custom (LM Studio)** + **Ollama Embedding** + **Faiss** or **Chroma** vector store.
+
+### 4. Docker networking
+
+If Flowise runs in Docker but LM Studio runs on the host:
+
+| Host OS | Base Path |
+| ------- | --------- |
+| Windows / macOS | `http://host.docker.internal:1234/v1` |
+| Linux | `http://172.17.0.1:1234/v1` |
+
+Ensure LM Studio binds to `0.0.0.0` (not only `127.0.0.1`) when accessed from a container.
+
+---
+
+## End-to-end local RAG stack
+
+The built-in marketplace template **Local QnA** (`packages/server/marketplaces/chatflows/Local QnA.json`) wires:
+
+```
+PDF Loader → Text Splitter → Ollama Embedding → Faiss
+                                    ↓
+              Conversational Retrieval QA Chain ← ChatOllama
+```
+
+To use it:
+
+1. Go to **Marketplace → Chatflows → Local QnA**.
+2. Click **Use Template**.
+3. Replace placeholder model names with models you have pulled locally.
+4. Upload a PDF and run the flow.
+
+See [RAG & Agent Templates](./rag-and-agent-templates.md) for more template options.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| `ECONNREFUSED` on chat | Wrong base URL or server not running | Confirm `curl` to the base URL; fix Docker host URL |
+| Model not found | Name mismatch | Use exact tag from `ollama list` or LocalAI `/v1/models` |
+| Slow first response | Model cold start | Set Ollama **Keep Alive**; preload model in LM Studio |
+| Empty RAG answers | Embedding/chat model mismatch | Use the same provider family or verify dimensions match |
+| Works locally, fails in Docker | `localhost` scope | Switch to `host.docker.internal` or bridge IP |
+
+## Related nodes
+
+| Category | Node | Purpose |
+| -------- | ---- | ------- |
+| Chat Models | `chatOllama` | Ollama chat |
+| Chat Models | `chatLocalAI` | LocalAI chat |
+| Chat Models | `chatOpenAICustom` | LM Studio and other OpenAI-compatible servers |
+| LLMs | `ollama` | Non-chat Ollama completion |
+| Embeddings | `ollamaEmbedding` | Ollama embeddings |
+| Embeddings | `localAIEmbeddings` | LocalAI embeddings |
+| Vector Stores | `faiss`, `chroma`, `inMemory` | Local vector storage |

--- a/docs/rag-and-agent-templates.md
+++ b/docs/rag-and-agent-templates.md
@@ -1,0 +1,166 @@
+# RAG & Agent Templates
+
+Flowise ships ready-made flows in `packages/server/marketplaces/`. Use them from **Marketplace** in the UI to avoid building common patterns from scratch.
+
+This guide maps templates to use cases and shows how to adapt them for local LLM providers.
+
+## Accessing templates
+
+1. Open Flowise at `http://localhost:3000`.
+2. Navigate to **Marketplace** in the sidebar.
+3. Browse **Chatflows**, **Agentflows v2**, or **Tools**.
+4. Click a template → **Use Template** to open it in the canvas.
+
+Templates are JSON files loaded at server startup from:
+
+```
+packages/server/marketplaces/
+├── chatflows/        # LangChain chatflow templates
+├── agentflowsv2/     # AgentFlow v2 templates
+├── agentflows/       # Legacy agentflow templates
+└── tools/            # Reusable tool templates
+```
+
+---
+
+## Chatflow templates for RAG
+
+| Template | File | Use case |
+| -------- | ---- | -------- |
+| **Local QnA** | `chatflows/Local QnA.json` | Fully local RAG: Ollama + LocalAI embeddings + Faiss |
+| **Conversational Retrieval QA Chain** | `chatflows/Conversational Retrieval QA Chain.json` | Classic RAG with conversational memory |
+| **Multiple Documents QnA** | `chatflows/Multiple Documents QnA.json` | Q&A across several uploaded files |
+| **Github Docs QnA** | `chatflows/Github Docs QnA.json` | Ingest GitHub repository documentation |
+| **Query Engine** | `chatflows/Query Engine.json` | LlamaIndex-style query engine |
+| **SubQuestion Query Engine** | `chatflows/SubQuestion Query Engine.json` | Decompose complex questions into sub-queries |
+
+### Local QnA — recommended starting point
+
+Description: _"QnA chain using Ollama local LLM, LocalAI embedding model, and Faiss local vector store"_
+
+**Before running:**
+
+1. Start Ollama and pull a chat model (`ollama pull llama3.2`).
+2. Start LocalAI with an embedding model, or swap the embedding node to **Ollama Embedding**.
+3. Open the template and update model name fields to match your local models.
+4. Upload a PDF via the **PDF Loader** node or replace it with your preferred document loader.
+
+**Core flow:**
+
+```
+Document Loader → Text Splitter → Embeddings → Faiss (upsert)
+                                                    ↓
+User question → Conversational Retrieval QA Chain ← Chat Model
+```
+
+See [Local LLM Providers](./local-providers.md) for provider-specific base URLs.
+
+### Conversational Retrieval QA Chain
+
+Best when you already have a cloud or local chat model configured. Provides:
+
+- Follow-up question handling with chat history
+- Source document return (enable in chain settings)
+
+Swap the default chat model node for **ChatOllama** or **ChatOpenAI Custom (LM Studio)** to run locally.
+
+---
+
+## AgentFlow v2 templates
+
+AgentFlow v2 templates live under `agentflowsv2/` and use the visual agent editor.
+
+| Template | File | Use case |
+| -------- | ---- | -------- |
+| **Simple RAG** | `agentflowsv2/Simple RAG.json` | Basic retrieve-then-answer agent |
+| **Agentic RAG** | `agentflowsv2/Agentic RAG.json` | Agent decides when/how to retrieve |
+| **Supervisor Worker** | `agentflowsv2/Supervisor Worker.json` | Multi-agent task delegation |
+| **Deep Research With Subagents** | `agentflowsv2/Deep Research With Subagents.json` | Research workflow with sub-agents |
+| **SQL Agent** | `agentflowsv2/SQL Agent.json` | Natural language to SQL |
+| **Human In The Loop** | `agentflowsv2/Human In The Loop.json` | Pause for human approval |
+| **Structured Output** | `agentflowsv2/Structured Output.json` | JSON/schema-constrained responses |
+| **Agents Handoff** | `agentflowsv2/Agents Handoff.json` | Transfer between specialized agents |
+
+### Simple RAG
+
+Description: _"A basic RAG agent that can retrieve documents from document store and answer questions"_
+
+**Adaptation checklist:**
+
+1. Open template from Marketplace.
+2. Select the **LLM** node → replace with ChatOllama or your preferred local model.
+3. Open the **Retriever** node → point to your vector store (Document Store or in-flow Faiss/Chroma).
+4. If using a Document Store, create one under **Document Stores** and upsert files first.
+5. Test with a question whose answer exists in your indexed content.
+
+### Agentic RAG
+
+Use when simple retrieval is insufficient — the agent can reformulate queries or choose whether to retrieve. Requires a capable local model (larger context helps).
+
+---
+
+## Tool templates
+
+Reusable tools under `marketplaces/tools/` include:
+
+| Template | Purpose |
+| -------- | ------- |
+| Perplexity AI Search | Web search via Perplexity |
+| Spider Web Scraper | Scrape and search web content |
+| Send Slack/Discord/Teams Message | Notification integrations |
+| Get Current DateTime | Utility for agent date awareness |
+
+Import tools into Agent or Tool Agent nodes from the Marketplace **Tools** tab.
+
+---
+
+## Swapping cloud models for local providers
+
+When adapting any template:
+
+| Template default | Local replacement | Key settings |
+| ---------------- | ----------------- | ------------ |
+| ChatOpenAI | ChatOllama | Base URL `http://localhost:11434`, model tag |
+| ChatOpenAI | ChatOpenAI Custom (LM Studio) | Base Path `http://localhost:1234/v1` |
+| OpenAI Embeddings | Ollama Embedding | `nomic-embed-text` or similar |
+| OpenAI Embeddings | LocalAI Embedding | Base Path `http://localhost:8080/v1` |
+| Pinecone / cloud VS | Faiss / Chroma / In-Memory | Local path or Chroma URL |
+
+After swapping nodes, re-run **Upsert** on vector store nodes before querying.
+
+---
+
+## Performance tips for RAG templates
+
+1. **Add embedding cache** — wire [InMemory Embedding Cache](./llm-caching.md) between embeddings and vector store during development.
+2. **Tune chunk size** — start with 1000 tokens chunk / 200 overlap; reduce if answers miss fine details.
+3. **Set Top K** — retriever default is often 4; increase for broader context, decrease for precision.
+4. **Enable return source documents** — helps debug retrieval quality.
+
+---
+
+## Exporting and sharing your own templates
+
+To contribute a flow back to the community:
+
+1. Open your chatflow → **Settings** → **Export**.
+2. Share JSON + screenshot in [GitHub Discussions → Show and Tell](https://github.com/FlowiseAI/Flowise/discussions/categories/show-and-tell).
+
+Enterprise users can save **Custom Templates** from the Marketplace tab (requires `templates:custom` permission).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| Template opens empty | Version mismatch | Update Flowise; check server logs for missing nodes |
+| No documents retrieved | Vector store not upserted | Run upsert/load flow before Q&A |
+| Agent ignores retriever | Wrong tool/retriever wiring | Compare connections to original template JSON |
+| Local model timeout | Model too large for hardware | Use a smaller quant; increase timeout in model settings |
+
+## Related documentation
+
+- [Local LLM Providers](./local-providers.md)
+- [LLM & Embedding Caching](./llm-caching.md)
+- [Official Flowise Docs — Agentflows](https://docs.flowiseai.com/using-flowise/agentflowv2)


### PR DESCRIPTION
## Summary

Adds in-repo documentation for local providers, caching, and RAG templates.

## Changes

* Add docs/local-providers.md (Ollama, LocalAI, LM Studio via ChatOpenAI Custom)
* Add docs/llm-caching.md covering cache nodes
* Add docs/rag-and-agent-templates.md for marketplace templates
* Add docs/local-development-setup.md checklist
* Link guides from README.md

## Validation

* Node names cross-checked against packages/components/nodes/
* Documentation-only changes

## Notes

Kept intentionally small and aligned with existing project patterns.