### PR TITLE
fix(ui): sync sidebar active state when navigating via logo

### DIFF
--- a/packages/ui/src/layout/MainLayout/LogoSection/index.jsx
+++ b/packages/ui/src/layout/MainLayout/LogoSection/index.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { useDispatch } from 'react-redux'
 
 // material-ui
 import { ButtonBase } from '@mui/material'
@@ -6,13 +7,22 @@ import { ButtonBase } from '@mui/material'
 // project imports
 import config from '@/config'
 import Logo from '@/ui-component/extended/Logo'
+import { MENU_OPEN } from '@/store/actions'
 
 // ==============================|| MAIN LOGO ||============================== //
 
-const LogoSection = () => (
-    <ButtonBase disableRipple component={Link} to={config.defaultPath}>
-        <Logo />
-    </ButtonBase>
-)
+const LogoSection = () => {
+    const dispatch = useDispatch()
+
+    const handleLogoClick = (e) => {
+        dispatch({ type: MENU_OPEN, id: 'chatflows' })
+    }
+
+    return (
+        <ButtonBase disableRipple component={Link} to={config.defaultPath} onClick={handleLogoClick}>
+            <Logo />
+        </ButtonBase>
+    )
+}
 
 export default LogoSection


### PR DESCRIPTION
## What

Sidebar active menu item remains highlighted after navigating via the Flowise logo back to Chatflows.

## Root cause

The logo uses a `<Link to={config.defaultPath}>` which navigates to `/chatflows` but does not dispatch `MENU_OPEN` to sync the sidebar active state. The active state (`customization.isOpen`) still holds the previously clicked item id.

## Fix

Add a click handler on the logo button that dispatches `MENU_OPEN` with `id: "chatflows"`, so the Chatflows nav item becomes active when navigating via the logo.

## References

Closes #6510