### PR TITLE
fix(redis): escape all RediSearch special chars in metadata, not just -

### DIFF
--- a/packages/components/nodes/vectorstores/Redis/utils.ts
+++ b/packages/components/nodes/vectorstores/Redis/utils.ts
@@ -1,12 +1,37 @@
 import { isNil } from 'lodash'
 
 /*
- * Escapes all '-' characters.
- * Redis Search considers '-' as a negative operator, hence we need
- * to escape it
+ * Escapes all RediSearch special characters.
+ * Redis Search considers these characters as operators or special syntax,
+ * so they must be escaped to be treated as literals.
  */
 export const escapeSpecialChars = (str: string) => {
     return str.replaceAll('-', '\\-')
+        .replaceAll(',', '\\,')
+        .replaceAll('.', '\\.')
+        .replaceAll('<', '\\<')
+        .replaceAll('>', '\\>')
+        .replaceAll('{', '\\{')
+        .replaceAll('}', '\\}')
+        .replaceAll('[', '\\[')
+        .replaceAll(']', '\\]')
+        .replaceAll('"', '\\"')
+        .replaceAll("'", "\\'")
+        .replaceAll(':', '\\:')
+        .replaceAll(';', '\\;')
+        .replaceAll('!', '\\!')
+        .replaceAll('@', '\\@')
+        .replaceAll('#', '\\#')
+        .replaceAll('$', '\\$')
+        .replaceAll('%', '\\%')
+        .replaceAll('^', '\\^')
+        .replaceAll('&', '\\&')
+        .replaceAll('*', '\\*')
+        .replaceAll('(', '\\(')
+        .replaceAll(')', '\\)')
+        .replaceAll('+', '\\+')
+        .replaceAll('=', '\\=')
+        .replaceAll('~', '\\~')
 }
 
 export const escapeAllStrings = (obj: object) => {
@@ -27,5 +52,5 @@ export const escapeAllStrings = (obj: object) => {
 }
 
 export const unEscapeSpecialChars = (str: string) => {
-    return str.replaceAll('\\-', '-')
+    return str.replace(/\\([-,.<>{}[\]"':;!@#$%^&*()\-+=~])/g, '$1')
 }


### PR DESCRIPTION
## What

Redis vector store `escapeSpecialChars` only escapes the `-` character, but Redis Search reserves many more characters as operators/syntax: `,.<>{}[]"':;!@#$%^&*()-+=~`

When document metadata contains any of these unescaped characters (e.g. `:`, `"`), JSON.parse fails on retrieval.

## Fix

- `escapeSpecialChars`: now escapes all 26 RediSearch reserved characters
- `unEscapeSpecialChars`: now reverses all 26 escaped characters (single regex)

## Reproduction

1. Setup Redis vector store node
2. Upsert document with metadata containing colon or double quote
3. Run similarity search in Playground → JSON error
4. After fix: works

## References

Closes #6598