### PR TITLE
fix: honor telemetry opt-out

### DIFF
--- a/packages/server/src/utils/telemetry.test.ts
+++ b/packages/server/src/utils/telemetry.test.ts
@@ -43,6 +43,8 @@ const ORIGINAL_ENV = process.env
 describe('utils/telemetry.ts', () => {
     beforeEach(() => {
         process.env = { ...ORIGINAL_ENV }
+        delete process.env.POSTHOG_PUBLIC_API_KEY
+        delete process.env.DISABLE_FLOWISE_TELEMETRY
         jest.clearAllMocks()
 
         jest.useFakeTimers()
@@ -66,6 +68,16 @@ describe('utils/telemetry.ts', () => {
         it('does not create PostHog when POSTHOG_PUBLIC_API_KEY is unset', async () => {
             delete process.env.POSTHOG_PUBLIC_API_KEY
             const t = new Telemetry()
+            expect(t.postHog).toBeUndefined()
+            expect(posthogNode.PostHog).not.toHaveBeenCalled()
+        })
+
+        it('does not create PostHog when telemetry is disabled', async () => {
+            process.env.POSTHOG_PUBLIC_API_KEY = 'ph-key'
+            process.env.DISABLE_FLOWISE_TELEMETRY = 'true'
+
+            const t = new Telemetry()
+
             expect(t.postHog).toBeUndefined()
             expect(posthogNode.PostHog).not.toHaveBeenCalled()
         })

--- a/packages/server/src/utils/telemetry.ts
+++ b/packages/server/src/utils/telemetry.ts
@@ -15,7 +15,9 @@ export class Telemetry {
     postHog?: PostHog
 
     constructor() {
-        if (process.env.POSTHOG_PUBLIC_API_KEY) {
+        const telemetryDisabled = process.env.DISABLE_FLOWISE_TELEMETRY?.toLowerCase() === 'true'
+
+        if (process.env.POSTHOG_PUBLIC_API_KEY && !telemetryDisabled) {
             this.postHog = new PostHog(process.env.POSTHOG_PUBLIC_API_KEY)
         } else {
             this.postHog = undefined


### PR DESCRIPTION
## Summary

- honor `DISABLE_FLOWISE_TELEMETRY=true` before creating the PostHog client
- add a regression test covering the opt-out when a PostHog key is configured

## Root cause

`DISABLE_FLOWISE_TELEMETRY` was passed through the CLI and deployment configuration but was never read by the telemetry initializer. As a result, setting the documented opt-out did not prevent PostHog telemetry from being enabled when `POSTHOG_PUBLIC_API_KEY` was present.

## Validation

- `pnpm --dir packages/server exec jest src/utils/telemetry.test.ts --runInBand`
- `pnpm exec prettier --check packages/server/src/utils/telemetry.ts packages/server/src/utils/telemetry.test.ts`

Fixes #6618