### PR TITLE
fix: add explicit TypeScript rootDir settings

### DIFF
--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -4,6 +4,7 @@
         "experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
         "emitDecoratorMetadata": true /* Emit design-type metadata for decorated declarations in source files. */,
         "target": "ES2020", // or higher
+        "rootDir": "./",
         "outDir": "./dist/",
         "resolveJsonModule": true,
         "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,6 +5,7 @@
         "experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
         "emitDecoratorMetadata": true /* Emit design-type metadata for decorated declarations in source files. */,
         "module": "commonjs" /* Specify what module code is generated. */,
+        "rootDir": "./src",
         "outDir": "dist",
         "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
         "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,


### PR DESCRIPTION
## Summary

This PR adds explicit `rootDir` settings to the TypeScript configs for the server and components packages.

## Why

Newer TypeScript versions can report a rootDir-related issue when `outDir` is configured and the compiler cannot infer the common source directory reliably. Setting `rootDir` explicitly makes the build output layout more predictable and avoids this configuration warning/error.

## Changes

- Added `rootDir: "./src"` to packages/server/tsconfig.json
- Added `rootDir: "./"` to packages/components/tsconfig.json

## Verification

- Editor diagnostics report no errors for the updated tsconfig files.