### PR TITLE
fix: honor telemetry disable flag

### DIFF
--- a/packages/server/src/utils/telemetry.test.ts
+++ b/packages/server/src/utils/telemetry.test.ts
@@ -70,6 +70,16 @@ describe('utils/telemetry.ts', () => {
             expect(posthogNode.PostHog).not.toHaveBeenCalled()
         })
 
+        it('does not create PostHog when telemetry is explicitly disabled', () => {
+            process.env.POSTHOG_PUBLIC_API_KEY = 'ph-key'
+            process.env.DISABLE_FLOWISE_TELEMETRY = 'true'
+
+            const t = new Telemetry()
+
+            expect(t.postHog).toBeUndefined()
+            expect(posthogNode.PostHog).not.toHaveBeenCalled()
+        })
+
         it('creates PostHog when POSTHOG_PUBLIC_API_KEY is set and captures', async () => {
             process.env.POSTHOG_PUBLIC_API_KEY = 'ph-key'
 

--- a/packages/server/src/utils/telemetry.ts
+++ b/packages/server/src/utils/telemetry.ts
@@ -15,7 +15,7 @@ export class Telemetry {
     postHog?: PostHog
 
     constructor() {
-        if (process.env.POSTHOG_PUBLIC_API_KEY) {
+        if (process.env.POSTHOG_PUBLIC_API_KEY && process.env.DISABLE_FLOWISE_TELEMETRY !== 'true') {
             this.postHog = new PostHog(process.env.POSTHOG_PUBLIC_API_KEY)
         } else {
             this.postHog = undefined


### PR DESCRIPTION
## Summary

Honors `DISABLE_FLOWISE_TELEMETRY=true` when initializing PostHog telemetry.

## Root cause

The variable was exposed through the CLI and deployment configuration, but the telemetry constructor only checked `POSTHOG_PUBLIC_API_KEY`. As a result, an explicitly configured opt-out did not prevent telemetry initialization.

## Changes

- skip PostHog initialization when `DISABLE_FLOWISE_TELEMETRY` is `true`
- add a regression test covering an enabled PostHog key with telemetry explicitly disabled

## Validation

- `pnpm --filter ./packages/server test -- --runInBand src/utils/telemetry.test.ts`
- `pnpm exec prettier --check packages/server/src/utils/telemetry.ts packages/server/src/utils/telemetry.test.ts`
- `pnpm exec eslint packages/server/src/utils/telemetry.ts packages/server/src/utils/telemetry.test.ts`

Fixes #6618