### PR TITLE
fix: pin Docker image package version

### DIFF
--- a/.github/workflows/docker-image-dockerhub.yml
+++ b/.github/workflows/docker-image-dockerhub.yml
@@ -85,6 +85,7 @@ jobs:
                   platforms: ${{ matrix.platform }}
                   build-args: |
                       NODE_VERSION=${{ needs.prepare.outputs.node_version }}
+                      FLOWISE_VERSION=${{ needs.prepare.outputs.tag_version }}
                   outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
 
             - name: Export digest
@@ -142,3 +143,16 @@ jobs:
             - name: Inspect image
               run: |
                   docker buildx imagetools inspect ${{ matrix.image }}:${{ needs.prepare.outputs.tag_version }}
+
+            - name: Verify Flowise package version
+              if: matrix.image == 'flowiseai/flowise' && needs.prepare.outputs.tag_version != 'latest'
+              run: |
+                  expected="${{ needs.prepare.outputs.tag_version }}"
+                  expected="${expected#v}"
+                  actual=$(docker run --rm --entrypoint flowise "${{ matrix.image }}:${{ needs.prepare.outputs.tag_version }}" --version)
+                  echo "Expected Flowise version: ${expected}"
+                  echo "Image reports: ${actual}"
+                  if [[ "${actual}" != "flowise/${expected} "* ]]; then
+                      echo "::error::Image package version does not match tag ${{ needs.prepare.outputs.tag_version }}"
+                      exit 1
+                  fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,11 @@
 # Node.js version (overridable via build-arg from CI)
 ARG NODE_VERSION=24
+ARG FLOWISE_VERSION=latest
 
 # Stage 1: Build stage
 FROM node:${NODE_VERSION}-alpine AS build
+
+ARG FLOWISE_VERSION
 
 USER root
 
@@ -12,8 +15,8 @@ RUN apk add --no-cache git python3 py3-pip make g++ build-base cairo-dev pango-d
 # Skip downloading Chrome for Puppeteer (saves build time)
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 
-# Install latest Flowise globally (specific version can be set: flowise@1.0.0)
-RUN npm install -g flowise
+# Install the package version that the image will be tagged with.
+RUN npm install -g "flowise@${FLOWISE_VERSION}"
 
 # Stage 2: Runtime stage
 FROM node:${NODE_VERSION}-alpine


### PR DESCRIPTION
## Summary

- install the Flowise npm package version requested by the Docker Hub image tag instead of unpinned `latest`
- keep `latest` as the Dockerfile default for existing manual builds
- verify versioned images report a CLI version matching their published tag

Fixes #6623

## Testing

- `python -X utf8 -c "import yaml; ..."` (workflow YAML parse)
- `npx --yes prettier@2.7.1 --check .github/workflows/docker-image-dockerhub.yml`
- `git diff --cached --check`
- `npm view flowise@3.1.2 version`
- `npm view flowise@v3.1.3 version`

The local Docker Desktop Linux engine did not become responsive, so I could not complete a local image build. The workflow now performs the end-to-end CLI version assertion after publishing the manifest.
