### PR TITLE
fix: allow custom Azure OpenAI model names

### DIFF
--- a/packages/components/nodes/llms/Azure OpenAI/AzureOpenAI.ts
+++ b/packages/components/nodes/llms/Azure OpenAI/AzureOpenAI.ts
@@ -55,7 +55,8 @@ class AzureOpenAI_LLMs implements INode {
                 name: 'modelName',
                 type: 'asyncOptions',
                 loadMethod: 'listModels',
-                default: 'text-davinci-003'
+                default: 'text-davinci-003',
+                freeSolo: true
             },
             {
                 label: 'Temperature',

--- a/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
+++ b/packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx
@@ -92,6 +92,12 @@ export const AsyncDropdown = ({
         }
         return options.find((option) => option.name === value)
     }
+    const getSelectionValue = (selection) => (typeof selection === 'string' ? selection : selection?.name ?? '')
+    const getAutocompleteValue = (options = [], value) => {
+        const matchingOption = findMatchingOptions(options, value)
+        if (matchingOption) return matchingOption
+        return !multiple && freeSolo && value && value !== 'choose an option' ? value : getDefaultOptionValue()
+    }
     const getDefaultOptionValue = () => (multiple ? [] : '')
     const addNewOption = [{ label: '- Create New -', name: '-create-' }]
     let [internalValue, setInternalValue] = useState(value ?? 'choose an option')
@@ -194,7 +200,9 @@ export const AsyncDropdown = ({
                     setOpen(false)
                 }}
                 options={options}
-                value={findMatchingOptions(options, internalValue) || getDefaultOptionValue()}
+                value={getAutocompleteValue(options, internalValue)}
+                getOptionLabel={(option) => (typeof option === 'string' ? option : option?.label ?? option?.name ?? '')}
+                isOptionEqualToValue={(option, value) => option?.name === (typeof value === 'string' ? value : value?.name)}
                 onChange={(e, selection) => {
                     if (multiple) {
                         let value = ''
@@ -205,7 +213,7 @@ export const AsyncDropdown = ({
                         setInternalValue(value)
                         onSelect(value)
                     } else {
-                        const value = selection ? selection.name : ''
+                        const value = getSelectionValue(selection)
                         if (isCreateNewOption && value === '-create-') {
                             onCreateNew()
                         } else {

--- a/packages/ui/src/ui-component/dropdown/Dropdown.jsx
+++ b/packages/ui/src/ui-component/dropdown/Dropdown.jsx
@@ -21,6 +21,12 @@ const StyledPopper = styled(Popper)({
 export const Dropdown = ({ name, value, loading, options, onSelect, disabled = false, freeSolo = false, disableClearable = false }) => {
     const customization = useSelector((state) => state.customization)
     const findMatchingOptions = (options = [], value) => options.find((option) => option.name === value)
+    const getSelectionValue = (selection) => (typeof selection === 'string' ? selection : selection?.name ?? '')
+    const getAutocompleteValue = (options = [], value) => {
+        const matchingOption = findMatchingOptions(options, value)
+        if (matchingOption) return matchingOption
+        return freeSolo && value && value !== 'choose an option' ? value : getDefaultOptionValue()
+    }
     const getDefaultOptionValue = () => ''
     let [internalValue, setInternalValue] = useState(value ?? 'choose an option')
     const theme = useTheme()
@@ -35,9 +41,11 @@ export const Dropdown = ({ name, value, loading, options, onSelect, disabled = f
                 size='small'
                 loading={loading}
                 options={options || []}
-                value={findMatchingOptions(options, internalValue) || getDefaultOptionValue()}
+                value={getAutocompleteValue(options, internalValue)}
+                getOptionLabel={(option) => (typeof option === 'string' ? option : option?.label ?? option?.name ?? '')}
+                isOptionEqualToValue={(option, value) => option?.name === (typeof value === 'string' ? value : value?.name)}
                 onChange={(e, selection) => {
-                    const value = selection ? selection.name : ''
+                    const value = getSelectionValue(selection)
                     setInternalValue(value)
                     onSelect(value)
                 }}


### PR DESCRIPTION
## Summary
- Preserve freeSolo string values from MUI Autocomplete in shared dropdown components.
- Keep custom async dropdown values visible when they do not match a predefined option.
- Allow the deprecated Azure OpenAI LLM node model selector to accept custom deployment/model names.

## Validation
- corepack pnpm exec eslint packages/ui/src/ui-component/dropdown/AsyncDropdown.jsx packages/ui/src/ui-component/dropdown/Dropdown.jsx "packages/components/nodes/llms/Azure OpenAI/AzureOpenAI.ts"
- corepack pnpm --filter flowise-ui build
- corepack pnpm --filter flowise-components build

Closes #6590