### PR TITLE
fix: add timeout to prompt list fetch

### DIFF
--- a/packages/server/src/services/prompts-lists/index.test.ts
+++ b/packages/server/src/services/prompts-lists/index.test.ts
@@ -1,0 +1,37 @@
+import axios from 'axios'
+import promptsListsService from '.'
+
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+describe('promptsListsService.createPromptsList', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('fetches LangChain Hub prompts with a bounded timeout', async () => {
+        const repos = [{ id: 'owner/prompt', num_likes: 42 }]
+        mockedAxios.get.mockResolvedValue({ data: { repos } })
+
+        const result = await promptsListsService.createPromptsList({})
+
+        expect(mockedAxios.get).toHaveBeenCalledWith(
+            'https://api.hub.langchain.com/repos/?limit=100&has_commits=true&sort_field=num_likes&sort_direction=desc&is_archived=false',
+            { timeout: 10000 }
+        )
+        expect(result).toEqual({
+            status: 'OK',
+            repos
+        })
+    })
+
+    it('returns the existing fallback when LangChain Hub request fails', async () => {
+        mockedAxios.get.mockRejectedValue(new Error('timeout'))
+
+        await expect(promptsListsService.createPromptsList({})).resolves.toEqual({
+            status: 'ERROR',
+            repos: []
+        })
+    })
+})

--- a/packages/server/src/services/prompts-lists/index.ts
+++ b/packages/server/src/services/prompts-lists/index.ts
@@ -1,11 +1,13 @@
 import axios from 'axios'
 
+const LANGCHAIN_HUB_PROMPTS_TIMEOUT_MS = 10000
+
 const createPromptsList = async (requestBody: any) => {
     try {
         const tags = requestBody.tags ? `tags=${requestBody.tags}` : ''
         // Default to 100, TODO: add pagination and use offset & limit
         const url = `https://api.hub.langchain.com/repos/?limit=100&${tags}has_commits=true&sort_field=num_likes&sort_direction=desc&is_archived=false`
-        const resp = await axios.get(url)
+        const resp = await axios.get(url, { timeout: LANGCHAIN_HUB_PROMPTS_TIMEOUT_MS })
         if (resp.data.repos) {
             return {
                 status: 'OK',


### PR DESCRIPTION
## Summary
- Add a 10s timeout to the LangChain Hub prompt list request so unavailable upstream calls fail into the existing fallback path.
- Add a service test covering the timeout option and error fallback.

Closes #6514

## Tests
- pnpm exec jest src/services/prompts-lists/index.test.ts --runInBand
- pnpm exec prettier --check packages/server/src/services/prompts-lists/index.ts packages/server/src/services/prompts-lists/index.test.ts
- pnpm exec eslint packages/server/src/services/prompts-lists/index.ts packages/server/src/services/prompts-lists/index.test.ts