### PR TITLE
fix: add gpt-5.4 model series to Azure ChatOpenAI model list

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -701,6 +701,30 @@
             "name": "azureChatOpenAI",
             "models": [
                 {
+                    "label": "gpt-5.4",
+                    "name": "gpt-5.4",
+                    "input_cost": 0.0000025,
+                    "output_cost": 0.000015
+                },
+                {
+                    "label": "gpt-5.4-pro",
+                    "name": "gpt-5.4-pro",
+                    "input_cost": 0.00003,
+                    "output_cost": 0.00018
+                },
+                {
+                    "label": "gpt-5.4-mini",
+                    "name": "gpt-5.4-mini",
+                    "input_cost": 0.00000075,
+                    "output_cost": 0.0000045
+                },
+                {
+                    "label": "gpt-5.4-nano",
+                    "name": "gpt-5.4-nano",
+                    "input_cost": 0.0000002,
+                    "output_cost": 0.00000125
+                },
+                {
                     "label": "gpt-5.2",
                     "name": "gpt-5.2",
                     "input_cost": 0.00000175,


### PR DESCRIPTION
## Summary
- Adds `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-mini`, and `gpt-5.4-nano` to the `azureChatOpenAI` entry in `packages/components/models.json`
- Pricing mirrors the values already used for the same models in the regular `chatOpenAI` entry

## Problem
PR #6028 added `gpt-5.4-mini`/`gpt-5.4-nano` (and the rest of the gpt-5.4 series) to the regular `chatOpenAI` model list, but `models.json` keeps a **separate** model array for `azureChatOpenAI`, which was never updated. As a result, Azure OpenAI users have no way to select these models in the node dropdown, and given Azure's upcoming retirement of older models, this blocks users who need to migrate (see #6411).

## Change
Minimal, additive change — 4 new entries inserted into the existing `azureChatOpenAI` models array, in the same position/order used by the `chatOpenAI` list:
```json
{ "label": "gpt-5.4-mini", "name": "gpt-5.4-mini", "input_cost": 0.00000075, "output_cost": 0.0000045 }
```
No other files needed changes — `isReasoningModelOpenAI()` in `packages/components/src/utils.ts` already classifies `gpt-5.4-*` correctly via its generic `gpt-5` substring rule, so no logic changes were required, only the missing model-list entries.

## Test plan
- [x] `packages/components/models.json` validated as well-formed JSON
- [x] Diffed against the original file to confirm only the 4 intended entries were added, no reformatting/reordering elsewhere

Fixes #6411
